### PR TITLE
Add offline LLM application codebase

### DIFF
--- a/android/app/src/main/cpp/llama_jni.cpp
+++ b/android/app/src/main/cpp/llama_jni.cpp
@@ -1,0 +1,386 @@
+#include <jni.h>
+#include <string>
+#include <vector>
+#include <cmath>
+#include <algorithm>
+#include <thread>
+#include <mutex>
+#include <chrono>
+#include "llama.h"
+#include "mobile_quant.h"
+
+class LlamaContext {
+public:
+    LlamaContext(const std::string& model_path, int n_ctx, int n_threads, bool is_quantized) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        
+        llama_model_params model_params = llama_model_default_params();
+        
+        if (is_quantized) {
+            model_params = apply_mobile_quant_optimizations(model_params);
+            model_params.n_gpu_layers = 99;
+        } else {
+            model_params.n_gpu_layers = 35;
+        }
+        
+#ifdef GGML_USE_FLASH_ATTN
+        model_params.use_flash_attn = true;
+#endif
+        
+        model_ = llama_load_model_from_file(model_path.c_str(), model_params);
+        if (!model_) {
+            throw std::runtime_error("Failed to load model");
+        }
+        
+        llama_context_params ctx_params = llama_context_default_params();
+        ctx_params.n_ctx = n_ctx;
+        ctx_params.n_threads = n_threads;
+        ctx_params.n_threads_batch = n_threads;
+        
+        if (is_quantized && n_ctx > 4096) {
+            ctx_params.use_sparse_attention = true;
+        }
+        
+        ctx_ = llama_new_context_with_model(model_, ctx_params);
+        if (!ctx_) {
+            llama_free_model(model_);
+            throw std::runtime_error("Failed to create context");
+        }
+        
+        kv_cache_.reserve(max_cache_size_);
+        is_quantized_ = is_quantized;
+        performance_stats_ = {0, 0, 0};
+    }
+    
+    ~LlamaContext() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (ctx_) llama_free(ctx_);
+        if (model_) llama_free_model(model_);
+    }
+    
+    std::vector<llama_token> tokenize(const std::string& text) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return llama_tokenize(ctx_, text, true);
+    }
+    
+    std::string detokenize(const std::vector<llama_token>& tokens) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        std::string result;
+        for (auto token : tokens) {
+            result += llama_token_to_piece(ctx_, token);
+        }
+        return result;
+    }
+    
+    std::vector<llama_token> generate(const std::vector<llama_token>& input_tokens, 
+                                     int max_tokens, float temperature, bool use_sparse_attention) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        
+        auto start_time = std::chrono::high_resolution_clock::now();
+        
+        message_boundaries_.push_back(kv_cache_.size());
+        
+        kv_cache_.insert(kv_cache_.end(), input_tokens.begin(), input_tokens.end());
+        
+        trimCache();
+        
+        std::vector<llama_token> generated_tokens;
+        generated_tokens.reserve(max_tokens);
+        
+        if (!kv_cache_.empty()) {
+            llama_eval(ctx_, kv_cache_.data(), kv_cache_.size(), 0, 4);
+        }
+        
+        for (int i = 0; i < max_tokens; i++) {
+            llama_token next_token;
+            
+            if (use_sparse_attention) {
+                next_token = llama_sample_token_sparse(ctx_, temperature);
+            } else {
+                next_token = llama_sample_token(ctx_, temperature);
+            }
+            
+            if (next_token == llama_token_eos(ctx_)) {
+                break;
+            }
+            
+            generated_tokens.push(next_token);
+            kv_cache_.push_back(next_token);
+            
+            trimCache();
+            
+            llama_eval(ctx_, &next_token, 1, kv_cache_.size() - 1, 4);
+        }
+        
+        auto end_time = std::chrono::high_resolution_clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
+        
+        performance_stats_.total_inference_time += duration.count();
+        performance_stats_.inference_count++;
+        performance_stats_.last_inference_time = duration.count();
+        
+        return generated_tokens;
+    }
+    
+    std::vector<float> embed(const std::string& text) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        
+        auto tokens = tokenize(text);
+        if (tokens.empty()) {
+            return std::vector<float>(is_quantized_ ? 384 : 512, 0.0f);
+        }
+        
+        std::vector<float> embedding(llama_n_embd(ctx_), 0.0f);
+        llama_get_embeddings(ctx_, embedding.data());
+        
+        return embedding;
+    }
+    
+    void clear_kv_cache() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        kv_cache_.clear();
+        message_boundaries_.clear();
+    }
+    
+    void add_message_boundary() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        message_boundaries_.push_back(kv_cache_.size());
+    }
+    
+    size_t kv_cache_size() const {
+        return kv_cache_.size();
+    }
+    
+    size_t kv_cache_max_size() const {
+        return max_cache_size_;
+    }
+    
+    PerformanceStats get_performance_stats() const {
+        return performance_stats_;
+    }
+    
+    void adjust_cache_size(size_t new_size) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        max_cache_size_ = new_size;
+        trimCache();
+    }
+    
+    void enable_sparse_attention(bool enable) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        use_sparse_attention_ = enable;
+    }
+
+private:
+    llama_model* model_ = nullptr;
+    llama_context* ctx_ = nullptr;
+    std::vector<llama_token> kv_cache_;
+    std::vector<size_t> message_boundaries_;
+    size_t max_cache_size_ = 512;
+    bool is_quantized_ = false;
+    bool use_sparse_attention_ = false;
+    mutable std::mutex mutex_;
+    PerformanceStats performance_stats_;
+    
+    void trimCache() {
+        if (kv_cache_.size() <= max_cache_size_) return;
+        
+        if (message_boundaries_.size() > 1) {
+            size_t trim_index = 0;
+            for (size_t i = 0; i < message_boundaries_.size() - 1; i++) {
+                if (kv_cache_.size() - message_boundaries_[i] <= max_cache_size_) {
+                    trim_index = message_boundaries_[i];
+                    break;
+                }
+            }
+            
+            if (trim_index > 0) {
+                kv_cache_.erase(kv_cache_.begin(), kv_cache_.begin() + trim_index);
+                
+                std::vector<size_t> new_boundaries;
+                for (auto boundary : message_boundaries_) {
+                    if (boundary > trim_index) {
+                        new_boundaries.push_back(boundary - trim_index);
+                    }
+                }
+                message_boundaries_ = new_boundaries;
+                return;
+            }
+        }
+        
+        size_t excess = kv_cache_.size() - max_cache_size_;
+        kv_cache_.erase(kv_cache_.begin(), kv_cache_.begin() + excess);
+    }
+};
+
+std::unique_ptr<LlamaContext> g_ctx;
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_com_myofflinellmapp_LlamaTurboModule_loadModel(JNIEnv *env, jobject thiz, jstring model_path) {
+    const char *path = env->GetStringUTFChars(model_path, 0);
+    
+    try {
+        std::string model_path_str(path);
+        bool is_quantized = false;
+        std::vector<std::string> quant_patterns = {
+            "Q4_0", "Q5_0", "Q2_K", "Q3_K_S", "Q3_K_M", "Q3_K_L", 
+            "Q4_K_S", "Q4_K_M", "Q5_K_S", "Q5_K_M", "Q6_K", "MobileQuant"
+        };
+        
+        for (const auto& pattern : quant_patterns) {
+            if (model_path_str.find(pattern) != std::string::npos) {
+                is_quantized = true;
+                break;
+            }
+        }
+        
+        int n_ctx = is_quantized ? 8192 : 4096;
+        int n_threads = std::max(1, static_cast<int>(std::thread::hardware_concurrency() * 0.75));
+        
+        g_ctx = std::make_unique<LlamaContext>(path, n_ctx, n_threads, is_quantized);
+        env->ReleaseStringUTFChars(model_path, path);
+        return reinterpret_cast<jlong>(g_ctx.get());
+    } catch (const std::exception& e) {
+        env->ReleaseStringUTFChars(model_path, path);
+        return 0;
+    }
+}
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_myofflinellmapp_LlamaTurboModule_generate(JNIEnv *env, jobject thiz, jlong ctx_ptr,
+                                                  jstring prompt, jint max_tokens, jfloat temperature,
+                                                  jboolean use_sparse_attention) {
+    if (!g_ctx) {
+        return env->NewStringUTF("Error: Model not loaded");
+    }
+    
+    const char *prompt_str = env->GetStringUTFChars(prompt, 0);
+    std::string prompt_text(prompt_str);
+    env->ReleaseStringUTFChars(prompt, prompt_str);
+    
+    try {
+        g_ctx->add_message_boundary();
+        auto input_tokens = g_ctx->tokenize(prompt_text);
+        auto generated_tokens = g_ctx->generate(input_tokens, max_tokens, temperature, use_sparse_attention);
+        
+        input_tokens.insert(input_tokens.end(), generated_tokens.begin(), generated_tokens.end());
+        std::string response = g_ctx->detokenize(input_tokens);
+        
+        return env->NewStringUTF(response.c_str());
+    } catch (const std::exception& e) {
+        return env->NewStringUTF("Error during generation");
+    }
+}
+
+extern "C" JNIEXPORT jfloatArray JNICALL
+Java_com_myofflinellmapp_LlamaTurboModule_embed(JNIEnv *env, jobject thiz, jlong ctx_ptr, jstring text) {
+    if (!g_ctx) {
+        return env->NewFloatArray(0);
+    }
+    
+    const char *text_str = env->GetStringUTFChars(text, 0);
+    std::string text_text(text_str);
+    env->ReleaseStringUTFChars(text, text_str);
+    
+    try {
+        auto embedding = g_ctx->embed(text_text);
+        
+        jfloatArray result = env->NewFloatArray(embedding.size());
+        env->SetFloatArrayRegion(result, 0, embedding.size(), embedding.data());
+        
+        return result;
+    } catch (const std::exception& e) {
+        return env->NewFloatArray(0);
+    }
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_myofflinellmapp_LlamaTurboModule_clearKVCache(JNIEnv *env, jobject thiz, jlong ctx_ptr) {
+    if (g_ctx) {
+        g_ctx->clear_kv_cache();
+    }
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_myofflinellmapp_LlamaTurboModule_getKVCacheSize(JNIEnv *env, jobject thiz, jlong ctx_ptr) {
+    if (g_ctx) {
+        return g_ctx->kv_cache_size();
+    }
+    return 0;
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_myofflinellmapp_LlamaTurboModule_getKVCacheMaxSize(JNIEnv *env, jobject thiz, jlong ctx_ptr) {
+    if (g_ctx) {
+        return g_ctx->kv_cache_max_size();
+    }
+    return 512;
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_myofflinellmapp_LlamaTurboModule_addMessageBoundary(JNIEnv *env, jobject thiz, jlong ctx_ptr) {
+    if (g_ctx) {
+        g_ctx->add_message_boundary();
+    }
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_myofflinellmapp_LlamaTurboModule_freeModel(JNIEnv *env, jobject thiz, jlong ctx_ptr) {
+    g_ctx.reset();
+}
+
+extern "C" JNIEXPORT jobject JNICALL
+Java_com_myofflinellmapp_LlamaTurboModule_getPerformanceMetrics(JNIEnv *env, jobject thiz, jlong ctx_ptr) {
+    if (!g_ctx) {
+        return nullptr;
+    }
+    
+    try {
+        auto stats = g_ctx->get_performance_stats();
+        
+        jclass hashMapClass = env->FindClass("java/util/HashMap");
+        jmethodID hashMapInit = env->GetMethodID(hashMapClass, "<init>", "()V");
+        jobject hashMap = env->NewObject(hashMapClass, hashMapInit);
+        jmethodID hashMapPut = env->GetMethodID(hashMapClass, "put", 
+            "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+        
+        env->CallObjectMethod(hashMap, hashMapPut, 
+            env->NewStringUTF("totalInferenceTime"), 
+            env->NewStringUTF(std::to_string(stats.total_inference_time).c_str()));
+        env->CallObjectMethod(hashMap, hashMapPut, 
+            env->NewStringUTF("inferenceCount"), 
+            env->NewStringUTF(std::to_string(stats.inference_count).c_str()));
+        env->CallObjectMethod(hashMap, hashMapPut, 
+            env->NewStringUTF("lastInferenceTime"), 
+            env->NewStringUTF(std::to_string(stats.last_inference_time).c_str()));
+        
+        return hashMap;
+    } catch (const std::exception& e) {
+        return nullptr;
+    }
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_myofflinellmapp_LlamaTurboModule_adjustPerformanceMode(JNIEnv *env, jobject thiz, jlong ctx_ptr, jstring mode) {
+    if (!g_ctx) {
+        return;
+    }
+    
+    const char *mode_str = env->GetStringUTFChars(mode, 0);
+    std::string mode_text(mode_str);
+    env->ReleaseStringUTFChars(mode, mode_str);
+    
+    try {
+        if (mode_text == "low-memory") {
+            g_ctx->adjust_cache_size(256);
+            g_ctx->enable_sparse_attention(true);
+        } else if (mode_text == "power-saving") {
+            g_ctx->adjust_cache_size(512);
+            g_ctx->enable_sparse_attention(false);
+        } else if (mode_text == "performance") {
+            g_ctx->adjust_cache_size(1024);
+            g_ctx->enable_sparse_attention(false);
+        }
+    } catch (const std::exception& e) {
+        // Ignore errors
+    }
+}

--- a/android/app/src/main/java/com/myofflinellmapp/LlamaRNModule.java
+++ b/android/app/src/main/java/com/myofflinellmapp/LlamaRNModule.java
@@ -1,0 +1,168 @@
+package com.myofflinellmapp;
+
+import androidx.annotation.NonNull;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.module.annotations.ReactModule;
+
+@ReactModule(name = LlamaRNModule.NAME)
+public class LlamaRNModule extends ReactContextBaseJavaModule {
+    public static final String NAME = "LlamaRN";
+    private native long nativeLoadModel(String modelPath, String quantizationType, int contextSize, int maxThreads);
+    private native String nativeGenerate(long ctxPtr, String prompt, int maxTokens, float temperature, boolean useSparseAttention);
+    private native float[] nativeEmbed(long ctxPtr, String text);
+    private native void nativeClearKVCache(long ctxPtr);
+    private native void nativeAddMessageBoundary(long ctxPtr);
+    private native int nativeGetKVCacheSize(long ctxPtr);
+    private native int nativeGetKVCacheMaxSize(long ctxPtr);
+    private native WritableMap nativeGetPerformanceMetrics(long ctxPtr);
+    private native void nativeAdjustPerformanceMode(long ctxPtr, String mode);
+    private native void nativeFreeModel(long ctxPtr);
+    
+    private long mCtxPtr = 0;
+
+    static {
+        System.loadLibrary("llama_rn");
+    }
+
+    public LlamaRNModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    @NonNull
+    public String getName() {
+        return NAME;
+    }
+
+    @ReactMethod
+    public void loadModel(String modelPath, ReadableMap options, Promise promise) {
+        try {
+            String quantizationType = options.hasKey("quantizationType") ? 
+                options.getString("quantizationType") : "none";
+            int contextSize = options.hasKey("contextSize") ? 
+                options.getInt("contextSize") : 4096;
+            int maxThreads = options.hasKey("maxThreads") ? 
+                options.getInt("maxThreads") : Math.max(1, Runtime.getRuntime().availableProcessors() - 1);
+            
+            mCtxPtr = nativeLoadModel(modelPath, quantizationType, contextSize, maxThreads);
+            
+            WritableMap result = new WritableNativeMap();
+            result.putString("status", "loaded");
+            result.putString("model", modelPath);
+            result.putString("quantizationType", quantizationType);
+            result.putInt("contextSize", contextSize);
+            promise.resolve(result);
+        } catch (Exception e) {
+            promise.reject("LOAD_ERROR", "Failed to load model: " + e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void generate(String prompt, ReadableMap options, Promise promise) {
+        if (mCtxPtr == 0) {
+            promise.reject("NO_MODEL", "Model not loaded");
+            return;
+        }
+
+        try {
+            int maxTokens = options.hasKey("maxTokens") ? options.getInt("maxTokens") : 256;
+            float temperature = options.hasKey("temperature") ? 
+                (float) options.getDouble("temperature") : 0.7f;
+            boolean useSparseAttention = options.hasKey("useSparseAttention") && 
+                options.getBoolean("useSparseAttention");
+            
+            String result = nativeGenerate(mCtxPtr, prompt, maxTokens, temperature, useSparseAttention);
+            promise.resolve(result);
+        } catch (Exception e) {
+            promise.reject("GENERATE_ERROR", "Generation failed: " + e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void embed(String text, Promise promise) {
+        if (mCtxPtr == 0) {
+            promise.reject("NO_MODEL", "Model not loaded");
+            return;
+        }
+
+        try {
+            float[] embedding = nativeEmbed(mCtxPtr, text);
+            promise.resolve(convertToWritableArray(embedding));
+        } catch (Exception e) {
+            promise.reject("EMBED_ERROR", "Embedding failed: " + e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void clearKVCache(Promise promise) {
+        if (mCtxPtr != 0) {
+            nativeClearKVCache(mCtxPtr);
+        }
+        promise.resolve(null);
+    }
+
+    @ReactMethod
+    public void addMessageBoundary(Promise promise) {
+        if (mCtxPtr != 0) {
+            nativeAddMessageBoundary(mCtxPtr);
+        }
+        promise.resolve(null);
+    }
+
+    @ReactMethod
+    public void getKVCacheSize(Promise promise) {
+        int size = mCtxPtr != 0 ? nativeGetKVCacheSize(mCtxPtr) : 0;
+        int maxSize = mCtxPtr != 0 ? nativeGetKVCacheMaxSize(mCtxPtr) : 512;
+        
+        WritableMap result = new WritableNativeMap();
+        result.putInt("size", size);
+        result.putInt("maxSize", maxSize);
+        promise.resolve(result);
+    }
+
+    @ReactMethod
+    public void getPerformanceMetrics(Promise promise) {
+        if (mCtxPtr == 0) {
+            promise.reject("NO_MODEL", "Model not loaded");
+            return;
+        }
+
+        try {
+            WritableMap metrics = nativeGetPerformanceMetrics(mCtxPtr);
+            promise.resolve(metrics);
+        } catch (Exception e) {
+            promise.reject("METRICS_ERROR", "Failed to get metrics: " + e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void adjustPerformanceMode(String mode, Promise promise) {
+        if (mCtxPtr != 0) {
+            nativeAdjustPerformanceMode(mCtxPtr, mode);
+        }
+        promise.resolve(null);
+    }
+
+    @ReactMethod
+    public void freeModel(Promise promise) {
+        if (mCtxPtr != 0) {
+            nativeFreeModel(mCtxPtr);
+            mCtxPtr = 0;
+        }
+        promise.resolve(null);
+    }
+
+    private WritableNativeArray convertToWritableArray(float[] array) {
+        WritableNativeArray result = new WritableNativeArray();
+        for (float value : array) {
+            result.pushDouble(value);
+        }
+        return result;
+    }
+}

--- a/app.json
+++ b/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "MyOfflineLLMApp",
+  "displayName": "MyOfflineLLMApp"
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+import { AppRegistry } from 'react-native';
+import App from './src/App';
+import { name as appName } from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/ios/MyOfflineLLMApp/MLXTurboModule.mm
+++ b/ios/MyOfflineLLMApp/MLXTurboModule.mm
@@ -1,0 +1,345 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTLog.h>
+#import <MLX/MLX.h>
+#import <MLXLLM/MLXLLM.h>
+#import "ANEOptimizer.h"
+#import "ThermalManager.h"
+
+@interface RCT_EXTERN_MODULE(MLXTurboModule, NSObject)
+
+RCT_EXTERN_METHOD(loadModel:(NSString *)modelPath
+                 resolver:(RCTPromiseResolveBlock)resolver
+                 rejecter:(RCTPromiseRejectBlock)rejecter)
+
+RCT_EXTERN_METHOD(generate:(NSString *)prompt
+                 maxTokens:(NSNumber *)maxTokens
+                 temperature:(float)temperature
+                 useSparseAttention:(BOOL)useSparseAttention
+                 resolver:(RCTPromiseResolveBlock)resolver
+                 rejecter:(RCTPromiseRejectBlock)rejecter)
+
+RCT_EXTERN_METHOD(embed:(NSString *)text
+                 resolver:(RCTPromiseResolveBlock)resolver
+                 rejecter:(RCTPromiseRejectBlock)rejecter)
+
+RCT_EXTERN_METHOD(clearKVCache:(RCTPromiseResolveBlock)resolver
+                 rejecter:(RCTPromiseRejectBlock)rejecter)
+
+RCT_EXTERN_METHOD(addMessageBoundary:(RCTPromiseResolveBlock)resolver
+                 rejecter:(RCTPromiseRejectBlock)rejecter)
+
+RCT_EXTERN_METHOD(getPerformanceMetrics:(RCTPromiseResolveBlock)resolver
+                 rejecter:(RCTPromiseRejectBlock)rejecter)
+
+RCT_EXTERN_METHOD(adjustPerformanceMode:(NSString *)mode
+                 resolver:(RCTPromiseResolveBlock)resolver
+                 rejecter:(RCTPromiseRejectBlock)rejecter)
+
+@end
+
+@implementation MLXTurboModule {
+  MLXLLMModel *_model;
+  MLXLLMTokenizer *_tokenizer;
+  NSMutableArray *_kvCache;
+  NSMutableArray *_messageBoundaries;
+  NSUInteger _maxCacheSize;
+  BOOL _isQuantized;
+  BOOL _useSparseAttention;
+  ANEOptimizer *_aneOptimizer;
+  ThermalManager *_thermalManager;
+  NSDate *_lastInferenceTime;
+  NSTimeInterval _totalInferenceTime;
+  NSUInteger _inferenceCount;
+  NSString *_quantizationType;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _maxCacheSize = 512;
+    _kvCache = [NSMutableArray arrayWithCapacity:_maxCacheSize];
+    _messageBoundaries = [NSMutableArray array];
+    _aneOptimizer = [[ANEOptimizer alloc] init];
+    _thermalManager = [[ThermalManager alloc] init];
+    _totalInferenceTime = 0;
+    _inferenceCount = 0;
+    _quantizationType = @"none";
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleThermalStateChange:)
+                                                 name:ThermalStateChangedNotification
+                                               object:nil];
+  }
+  return self;
+}
+
+- (void)handleThermalStateChange:(NSNotification *)notification {
+  ThermalState state = [notification.userInfo[@"state"] integerValue];
+  [self adjustPerformanceForThermalState:state];
+}
+
+- (void)adjustPerformanceForThermalState:(ThermalState)state {
+  switch (state) {
+    case ThermalStateNominal:
+      _maxCacheSize = _isQuantized ? 2048 : 1024;
+      _useSparseAttention = NO;
+      break;
+    case ThermalStateFair:
+      _maxCacheSize = _isQuantized ? 1024 : 512;
+      _useSparseAttention = NO;
+      break;
+    case ThermalStateSerious:
+      _maxCacheSize = _isQuantized ? 512 : 256;
+      _useSparseAttention = YES;
+      break;
+    case ThermalStateCritical:
+      _maxCacheSize = 256;
+      _useSparseAttention = YES;
+      break;
+  }
+}
+
+- (void)loadModel:(NSString *)modelPath
+         resolver:(RCTPromiseResolveBlock)resolver
+         rejecter:(RCTPromiseRejectBlock)rejecter {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    @try {
+      [MLX setup];
+      
+      NSArray *quantizationMarkers = @[@"Q4_0", @"Q5_0", @"Q2_K", @"Q3_K_S", @"Q3_K_M", @"Q3_K_L", 
+                                      @"Q4_K_S", @"Q4_K_M", @"Q5_K_S", @"Q5_K_M", @"Q6_K", @"MobileQuant"];
+      BOOL isQuantized = NO;
+      NSString *detectedQuantization = @"none";
+      
+      for (NSString *marker in quantizationMarkers) {
+        if ([modelPath rangeOfString:marker].location != NSNotFound) {
+          isQuantized = YES;
+          detectedQuantization = marker;
+          self->_quantizationType = marker;
+          break;
+        }
+      }
+      
+      MLXLLMModelOptions *options = [[MLXLLMModelOptions alloc] init];
+      options.quantize = isQuantized;
+      
+      if (isQuantized) {
+        options.contextLength = 8192;
+        options.useSparseAttention = YES;
+      }
+      
+      if ([_aneOptimizer isANEAvailable]) {
+        options = [_aneOptimizer optimizeModelOptions:options];
+      }
+      
+      NSURL *modelURL = [NSURL fileURLWithPath:modelPath];
+      self->_model = [MLXLLMModel modelWithContentsOfURL:modelURL options:options];
+      
+      if (!self->_model) {
+        @throw [NSException exceptionWithName:@"ModelLoadError"
+                                      reason:@"Failed to load MLX model"
+                                    userInfo:nil];
+      }
+      
+      self->_tokenizer = [MLXLLMTokenizer tokenizerWithModel:self->_model];
+      
+      if (!self->_tokenizer) {
+        @throw [NSException exceptionWithName:@"TokenizerError"
+                                      reason:@"Failed to initialize tokenizer"
+                                    userInfo:nil];
+      }
+      
+      [self configureDynamicCacheSize];
+      
+      [self->_kvCache removeAllObjects];
+      [self->_messageBoundaries removeAllObjects];
+      
+      RCTLogInfo(@"Model loaded successfully: %@ (quantized: %@)", modelPath, detectedQuantization);
+      resolver(@{
+        @"status": @"loaded", 
+        @"contextSize": @(isQuantized ? 8192 : 4096),
+        @"model": modelPath,
+        @"quantized": @(isQuantized),
+        @"quantizationType": detectedQuantization,
+        @"supportsSparseAttention": @(YES)
+      });
+    } @catch (NSException *exception) {
+      NSString *errorMsg = [NSString stringWithFormat:@"Failed to load model: %@", exception.reason];
+      rejecter(@"LOAD_ERROR", errorMsg, nil);
+    }
+  });
+}
+
+- (void)generate:(NSString *)prompt
+       maxTokens:(NSNumber *)maxTokens
+     temperature:(float)temperature
+useSparseAttention:(BOOL)useSparseAttention
+        resolver:(RCTPromiseResolveBlock)resolver
+        rejecter:(RCTPromiseRejectBlock)rejecter {
+  if (!_model || !_tokenizer) {
+    rejecter(@"NO_MODEL", @"Model not loaded", nil);
+    return;
+  }
+  
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    @try {
+      NSDate *startTime = [NSDate date];
+      
+      NSArray<NSNumber *> *inputTokens = [self->_tokenizer encode:prompt];
+      
+      [self addMessageBoundary];
+      
+      [self->_kvCache addObjectsFromArray:inputTokens];
+      [self trimCache];
+      
+      MLXLLMGenerateOptions *options = [[MLXLLMGenerateOptions alloc] init];
+      options.maxTokens = [maxTokens intValue];
+      options.temperature = temperature;
+      options.kvCache = self->_kvCache;
+      options.useSparseAttention = useSparseAttention || self->_useSparseAttention;
+      
+      NSArray<NSNumber *> *generatedTokens = [self->_model generateWithInputTokens:inputTokens options:options];
+      
+      [self->_kvCache addObjectsFromArray:generatedTokens];
+      [self trimCache];
+      
+      NSString *response = [self->_tokenizer decode:generatedTokens];
+      
+      NSTimeInterval inferenceTime = -[startTime timeIntervalSinceNow];
+      self->_totalInferenceTime += inferenceTime;
+      self->_inferenceCount++;
+      
+      resolver(@{
+        @"text": response,
+        @"tokensGenerated": @(generatedTokens.count),
+        @"kvCacheSize": @(self->_kvCache.count),
+        @"kvCacheMax": @(self->_maxCacheSize),
+        @"inferenceTime": @(inferenceTime),
+        @"usedSparseAttention": @(options.useSparseAttention),
+        @"quantizationType": self->_quantizationType
+      });
+    } @catch (NSException *exception) {
+      NSString *errorMsg = [NSString stringWithFormat:@"Generation failed: %@", exception.reason];
+      rejecter(@"GENERATE_ERROR", errorMsg, nil);
+    }
+  });
+}
+
+- (void)getPerformanceMetrics:(RCTPromiseResolveBlock)resolver
+                    rejecter:(RCTPromiseRejectBlock)rejecter {
+  NSTimeInterval avgInferenceTime = _inferenceCount > 0 ? _totalInferenceTime / _inferenceCount : 0;
+  
+  resolver(@{
+    @"totalInferenceTime": @(_totalInferenceTime),
+    @"inferenceCount": @(_inferenceCount),
+    @"averageInferenceTime": @(avgInferenceTime),
+    @"currentCacheSize": @(_kvCache.count),
+    @"maxCacheSize": @(_maxCacheSize),
+    @"thermalState": @([_thermalManager currentThermalState]),
+    @"usingSparseAttention": @(_useSparseAttention),
+    @"quantizationType": _quantizationType
+  });
+}
+
+- (void)embed:(NSString *)text
+     resolver:(RCTPromiseResolveBlock)resolver
+     rejecter:(RCTPromiseRejectBlock)rejecter {
+  if (!_model || !_tokenizer) {
+    rejecter(@"NO_MODEL", @"Model not loaded", nil);
+    return;
+  }
+  
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    @try {
+      NSArray<NSNumber *> *tokens = [self->_tokenizer encode:text];
+      MLXArray *embeddings = [self->_model embedTokens:tokens];
+      
+      NSMutableArray *embeddingArray = [NSMutableArray array];
+      float *data = (float *)[embeddings data];
+      NSUInteger count = [embeddings count];
+      
+      for (NSUInteger i = 0; i < count; i++) {
+        [embeddingArray addObject:@(data[i])];
+      }
+      
+      resolver(embeddingArray);
+    } @catch (NSException *exception) {
+      NSString *errorMsg = [NSString stringWithFormat:@"Embedding failed: %@", exception.reason];
+      rejecter(@"EMBED_ERROR", errorMsg, nil);
+    }
+  });
+}
+
+- (void)clearKVCache:(RCTPromiseResolveBlock)resolver
+            rejecter:(RCTPromiseRejectBlock)rejecter {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    @try {
+      [self->_kvCache removeAllObjects];
+      [self->_messageBoundaries removeAllObjects];
+      resolver(@{@"status": @"cleared", @"size": @(0)});
+    } @catch (NSException *exception) {
+      NSString *errorMsg = [NSString stringWithFormat:@"Failed to clear KV cache: %@", exception.reason];
+      rejecter(@"CACHE_ERROR", errorMsg, nil);
+    }
+  });
+}
+
+- (void)addMessageBoundary:(RCTPromiseResolveBlock)resolver
+                 rejecter:(RCTPromiseRejectBlock)rejecter {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    @try {
+      [self addMessageBoundary];
+      resolver(@{@"status": @"boundary added", @"count": @(self->_messageBoundaries.count)});
+    } @catch (NSException *exception) {
+      NSString *errorMsg = [NSString stringWithFormat:@"Failed to add boundary: %@", exception.reason];
+      rejecter(@"BOUNDARY_ERROR", errorMsg, nil);
+    }
+  });
+}
+
+- (void)addMessageBoundary {
+  [self->_messageBoundaries addObject:@(self->_kvCache.count)];
+}
+
+- (void)trimCache {
+  if (self->_kvCache.count <= self->_maxCacheSize) return;
+  
+  if (self->_messageBoundaries.count > 1) {
+    NSUInteger trimIndex = 0;
+    for (NSUInteger i = 0; i < self->_messageBoundaries.count - 1; i++) {
+      NSNumber *boundary = self->_messageBoundaries[i];
+      if (self->_kvCache.count - boundary.intValue <= self->_maxCacheSize) {
+        trimIndex = boundary.intValue;
+        break;
+      }
+    }
+    
+    if (trimIndex > 0) {
+      [self->_kvCache removeObjectsInRange:NSMakeRange(0, trimIndex)];
+      NSMutableArray *newBoundaries = [NSMutableArray array];
+      for (NSNumber *boundary in self->_messageBoundaries) {
+        if (boundary.intValue > trimIndex) {
+          [newBoundaries addObject:@(boundary.intValue - trimIndex)];
+        }
+      }
+      self->_messageBoundaries = newBoundaries;
+      return;
+    }
+  }
+  
+  NSUInteger excess = self->_kvCache.count - self->_maxCacheSize;
+  [self->_kvCache removeObjectsInRange:NSMakeRange(0, excess)];
+}
+
+- (void)configureDynamicCacheSize {
+  NSUInteger totalMemory = [[NSProcessInfo processInfo] physicalMemory] / (1024 * 1024);
+  if (totalMemory > 8000) {
+    _maxCacheSize = _isQuantized ? 4096 : 2048;
+  } else if (totalMemory > 4000) {
+    _maxCacheSize = _isQuantized ? 2048 : 1024;
+  } else {
+    _maxCacheSize = 512;
+  }
+}
+
+@end

--- a/package.json
+++ b/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "my-offline-llm-app",
+  "version": "2.0.0",
+  "description": "Offline LLM application with advanced optimizations",
+  "main": "index.js",
+  "scripts": {
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
+    "start": "react-native start",
+    "test": "jest",
+    "lint": "eslint .",
+    "build:android": "cd android && ./gradlew assembleRelease",
+    "build:ios": "cd ios && xcodebuild -workspace MyOfflineLLMApp.xcworkspace -scheme MyOfflineLLMApp -configuration Release",
+    "bundle:android": "react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res",
+    "bundle:ios": "react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ios/main.jsbundle --assets-dest ios"
+  },
+  "dependencies": {
+    "@react-native-async-storage/async-storage": "^2.0.0",
+    "@react-native-community/clipboard": "^1.5.11",
+    "@react-native-community/slider": "^4.4.2",
+    "@react-native-fs/fs": "^2.20.0",
+    "crypto-js": "^4.1.1",
+    "langchain": "^0.0.187",
+    "noble-post-quantum": "^1.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.4",
+    "react-native-sqlite-storage": "^6.1.0",
+    "react-native-voice": "^0.10.0",
+    "react-native-tts": "^4.1.0",
+    "rxdb": "^15.0.0",
+    "transformers.js": "^2.4.0",
+    "jsdom": "^22.0.0",
+    "react-native-readability": "^0.2.0",
+    "react-native-render-html": "^6.3.4",
+    "tiktoken": "^1.0.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0",
+    "@babel/preset-env": "^7.20.0",
+    "@babel/runtime": "^7.20.0",
+    "@react-native/eslint-config": "^0.72.2",
+    "@react-native/metro-config": "^0.72.11",
+    "@tsconfig/react-native": "^3.0.0",
+    "@types/jest": "^29.2.3",
+    "@types/react": "^18.0.24",
+    "@types/react-test-renderer": "^18.0.0",
+    "babel-jest": "^29.2.3",
+    "eslint": "^8.19.0",
+    "jest": "^29.2.3",
+    "metro-react-native-babel-preset": "^0.76.8",
+    "prettier": "^2.8.3",
+    "react-test-renderer": "18.2.0",
+    "typescript": "4.8.4"
+  },
+  "engines": {
+    "node": ">=16"
+  }
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,102 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
+import LLMService from './services/llmService';
+import { ToolRegistry } from './architecture/toolSystem';
+import { builtInTools } from './architecture/toolSystem';
+import { PluginManager } from './architecture/pluginManager';
+import { DependencyInjector } from './architecture/dependencyInjector';
+
+function App() {
+  const [initialized, setInitialized] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    initializeApp();
+  }, []);
+
+  const initializeApp = async () => {
+    try {
+      // Initialize dependency injection
+      const dependencyInjector = new DependencyInjector();
+      
+      // Initialize tool registry
+      const toolRegistry = new ToolRegistry();
+      Object.entries(builtInTools).forEach(([name, tool]) => {
+        toolRegistry.registerTool(name, tool);
+      });
+      
+      // Initialize plugin manager
+      const pluginManager = new PluginManager();
+      
+      // Load default model
+      await LLMService.loadModel('path/to/default/model');
+      
+      // Register dependencies
+      dependencyInjector.register('toolRegistry', toolRegistry);
+      dependencyInjector.register('pluginManager', pluginManager);
+      dependencyInjector.register('llmService', LLMService);
+      
+      setInitialized(true);
+    } catch (error) {
+      console.error('App initialization failed:', error);
+      setError(error.message);
+    }
+  };
+
+  if (error) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.error}>Initialization Error: {error}</Text>
+      </View>
+    );
+  }
+
+  if (!initialized) {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator size="large" />
+        <Text style={styles.loading}>Initializing LLM Application...</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Offline LLM Application</Text>
+      <Text style={styles.subtitle}>Ready to use</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#f5f5f5',
+    padding: 20
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 10,
+    color: '#333'
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#666',
+    marginBottom: 20
+  },
+  loading: {
+    marginTop: 20,
+    fontSize: 16,
+    color: '#666'
+  },
+  error: {
+    fontSize: 16,
+    color: 'red',
+    textAlign: 'center'
+  }
+});
+
+export default App;

--- a/src/architecture/dependencyInjector.js
+++ b/src/architecture/dependencyInjector.js
@@ -1,0 +1,29 @@
+const dependencies = new Map();
+
+export class DependencyInjector {
+    constructor() {
+        this.dependencies = new Map();
+    }
+
+    register(name, dependency) {
+        this.dependencies.set(name, dependency);
+    }
+
+    inject(name) {
+        const dep = this.dependencies.get(name);
+        if (!dep) {
+            throw new Error(`Dependency ${name} not provided`);
+        }
+        return dep;
+    }
+
+    has(name) {
+        return this.dependencies.has(name);
+    }
+
+    clear() {
+        this.dependencies.clear();
+    }
+}
+
+export const dependencyInjector = new DependencyInjector();

--- a/src/architecture/diSetup.js
+++ b/src/architecture/diSetup.js
@@ -1,0 +1,5 @@
+export function setupLLMDI(di, { deviceProfile, performanceMetrics, kvCache }) {
+  di.register('deviceProfile', deviceProfile);
+  di.register('performanceMetrics', performanceMetrics);
+  di.register('kvCache', kvCache);
+}

--- a/src/architecture/pluginManager.js
+++ b/src/architecture/pluginManager.js
@@ -1,0 +1,222 @@
+const plugins = new Map();
+const hooks = new Map();
+const originals = new Map();
+
+export class PluginManager {
+    constructor() {
+        this.plugins = new Map();
+        this.activePlugins = new Set();
+        this.hooks = new Map();
+        this.originals = new Map();
+        this.overrides = new Map();
+    }
+
+    registerPlugin(name, plugin) {
+        this.plugins.set(name, {
+            ...plugin,
+            enabled: false
+        });
+        
+        if (plugin.hooks) {
+            for (const [hookName, hookFunction] of Object.entries(plugin.hooks)) {
+                this.registerHook(hookName, hookFunction);
+            }
+        }
+    }
+
+    async enablePlugin(name) {
+        if (!this.plugins.has(name)) {
+            throw new Error(`Plugin ${name} not registered`);
+        }
+        
+        const plugin = this.plugins.get(name);
+        
+        try {
+            if (plugin.initialize) {
+                await plugin.initialize();
+            }
+            
+            if (plugin.replace) {
+                for (const [target, implementation] of Object.entries(plugin.replace)) {
+                    this._replaceModuleFunction(target, implementation);
+                }
+            }
+            
+            if (plugin.extend) {
+                for (const [target, extensions] of Object.entries(plugin.extend)) {
+                    this._extendModule(target, extensions);
+                }
+            }
+            
+            plugin.enabled = true;
+            this.activePlugins.add(name);
+            
+            console.log(`Plugin ${name} enabled successfully`);
+        } catch (error) {
+            console.error(`Failed to enable plugin ${name}:`, error);
+            throw error;
+        }
+    }
+
+    async disablePlugin(name) {
+        if (!this.plugins.has(name) || !this.plugins.get(name).enabled) {
+            return;
+        }
+        
+        const plugin = this.plugins.get(name);
+        
+        try {
+            if (plugin.cleanup) {
+                await plugin.cleanup();
+            }
+            
+            if (plugin.replace) {
+                for (const [target] of Object.entries(plugin.replace)) {
+                    this._restoreModuleFunction(target);
+                }
+            }
+            
+            if (plugin.extend) {
+                for (const [target, extensions] of Object.entries(plugin.extend)) {
+                    this._removeModuleExtensions(target, Object.keys(extensions));
+                }
+            }
+            
+            plugin.enabled = false;
+            this.activePlugins.delete(name);
+            
+            console.log(`Plugin ${name} disabled successfully`);
+        } catch (error) {
+            console.error(`Failed to disable plugin ${name}:`, error);
+        }
+    }
+
+    registerHook(hookName, hookFunction) {
+        if (!this.hooks.has(hookName)) {
+            this.hooks.set(hookName, []);
+        }
+        
+        this.hooks.get(hookName).push(hookFunction);
+    }
+
+    async executeHook(hookName, ...args) {
+        if (!this.hooks.has(hookName)) {
+            return;
+        }
+        
+        const results = [];
+        for (const hookFunction of this.hooks.get(hookName)) {
+            try {
+                results.push(await hookFunction(...args));
+            } catch (error) {
+                console.error(`Error executing hook ${hookName}:`, error);
+            }
+        }
+        
+        return results;
+    }
+
+    async execute(methodName, args, context) {
+        const results = await this.executeHook(`before_${methodName}`, ...args);
+        
+        let result;
+        if (this.hasOverride(methodName)) {
+            result = await this._executeOverride(methodName, args, context);
+        } else {
+            if (context[methodName]) {
+                result = await context[methodName](...args);
+            } else {
+                throw new Error(`Method ${methodName} not found`);
+            }
+        }
+        
+        await this.executeHook(`after_${methodName}`, result, ...args);
+        
+        return result;
+    }
+
+    hasOverride(methodName) {
+        for (const plugin of this.plugins.values()) {
+            if (plugin.replace && plugin.replace[methodName]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    isPluginEnabled(name) {
+        return this.plugins.has(name) && this.plugins.get(name).enabled;
+    }
+
+    _replaceModuleFunction(modulePath, implementation) {
+        const parts = modulePath.split('.');
+        const moduleName = parts[0];
+        const functionName = parts[1];
+        
+        if (!this.overrides.has(modulePath)) {
+            if (!this.originals.has(modulePath) && global[moduleName] && global[moduleName][functionName] !== undefined) {
+                this.originals.set(modulePath, global[moduleName][functionName]);
+            }
+        }
+        this.overrides.set(modulePath, implementation);
+    }
+
+    _restoreModuleFunction(modulePath) {
+        if (this.overrides.has(modulePath)) {
+            this.overrides.delete(modulePath);
+        }
+        if (this.originals.has(modulePath)) {
+            this.originals.delete(modulePath);
+        }
+    }
+
+    getModuleFunction(modulePath) {
+        if (this.overrides.has(modulePath)) {
+            return this.overrides.get(modulePath);
+        }
+        if (this.originals.has(modulePath)) {
+            return this.originals.get(modulePath);
+        }
+        const parts = modulePath.split('.');
+        const moduleName = parts[0];
+        const functionName = parts[1];
+        return global[moduleName]?.[functionName];
+    }
+
+    _extendModule(moduleName, extensions) {
+        if (!global[moduleName]) {
+            global[moduleName] = {};
+        }
+        
+        for (const [key, value] of Object.entries(extensions)) {
+            const fullPath = `${moduleName}.${key}`;
+            if (!this.originals.has(fullPath) && global[moduleName][key] !== undefined) {
+                this.originals.set(fullPath, global[moduleName][key]);
+            }
+            
+            global[moduleName][key] = value;
+        }
+    }
+
+    _removeModuleExtensions(moduleName, keys) {
+        for (const key of keys) {
+            const fullPath = `${moduleName}.${key}`;
+            if (this.originals.has(fullPath)) {
+                global[moduleName][key] = this.originals.get(fullPath);
+                this.originals.delete(fullPath);
+            } else {
+                delete global[moduleName][key];
+            }
+        }
+    }
+
+    _executeOverride(methodName, args, context) {
+        for (const plugin of this.plugins.values()) {
+            if (plugin.replace && plugin.replace[methodName]) {
+                return plugin.replace[methodName].apply(context, args);
+            }
+        }
+        
+        throw new Error(`Override for ${methodName} not found`);
+    }
+}

--- a/src/architecture/pluginSetup.js
+++ b/src/architecture/pluginSetup.js
@@ -1,0 +1,42 @@
+export function registerLLMPlugins(pluginManager, context) {
+  pluginManager.registerPlugin('sparseAttention', {
+    initialize: async () => {
+      console.log('Sparse attention plugin initialized');
+    },
+    replace: {
+      generate: async function (prompt, maxTokens, temperature, options = {}) {
+        const useSparse = options.useSparseAttention ||
+          context.deviceProfile.tier === 'low' ||
+          context.kvCache.size > context.kvCache.maxSize * 0.8;
+        if (context.isWeb) {
+          return context._generateWeb(prompt, maxTokens, temperature);
+        }
+        return await context.nativeModule.generate(
+          prompt,
+          maxTokens,
+          temperature,
+          useSparse
+        );
+      }
+    }
+  });
+
+  pluginManager.registerPlugin('adaptiveQuantization', {
+    initialize: async () => {
+      console.log('Adaptive quantization plugin initialized');
+    },
+    extend: {
+      LLMService: {
+        adjustQuantization: async function () {
+          const metrics = await this.getPerformanceMetrics();
+          const { averageInferenceTime, memoryUsage } = metrics;
+          if (averageInferenceTime > 1000 || memoryUsage > 0.8) {
+            await this._switchQuantization('Q4_0');
+          } else if (averageInferenceTime < 300 && memoryUsage < 0.6) {
+            await this._switchQuantization('Q8_0');
+          }
+        }
+      }
+    }
+  });
+}

--- a/src/architecture/toolSystem.js
+++ b/src/architecture/toolSystem.js
@@ -1,0 +1,434 @@
+import SQLite from 'react-native-sqlite-storage';
+import { cosineSimilarity, quantizeVector } from '../utils/vectorUtils';
+import { Platform } from 'react-native';
+
+const HNSW_DEFAULTS = {
+    m: 16,
+    efConstruction: 100,
+    efSearch: 50,
+    maxLayer: null,
+    quantization: 'scalar'
+};
+
+export class ToolRegistry {
+    constructor() {
+        this.tools = new Map();
+        this.toolCategories = new Map();
+        this.executionHistory = [];
+    }
+
+    registerTool(toolName, toolDefinition, category = 'general') {
+        if (!this.toolCategories.has(category)) {
+            this.toolCategories.set(category, new Set());
+        }
+        
+        this.tools.set(toolName, {
+            ...toolDefinition,
+            category,
+            lastUsed: null,
+            usageCount: 0
+        });
+        
+        this.toolCategories.get(category).add(toolName);
+    }
+
+    async executeTool(toolName, parameters, context = {}) {
+        const tool = this.tools.get(toolName);
+        if (!tool) {
+            throw new Error(`Tool ${toolName} not found`);
+        }
+
+        try {
+            // Validate parameters
+            this.validateParameters(tool, parameters);
+            
+            // Execute the tool
+            const result = await tool.execute(parameters, context);
+            
+            // Update tool usage statistics
+            tool.lastUsed = new Date();
+            tool.usageCount = (tool.usageCount || 0) + 1;
+            
+            // Log execution
+            this.executionHistory.push({
+                tool: toolName,
+                parameters,
+                result,
+                timestamp: new Date(),
+                success: true
+            });
+            
+            return result;
+        } catch (error) {
+            this.executionHistory.push({
+                tool: toolName,
+                parameters,
+                error: error.message,
+                timestamp: new Date(),
+                success: false
+            });
+            
+            throw error;
+        }
+    }
+
+    validateParameters(tool, parameters) {
+        if (tool.parameters) {
+            for (const [paramName, paramConfig] of Object.entries(tool.parameters)) {
+                if (paramConfig.required && !(paramName in parameters)) {
+                    throw new Error(`Missing required parameter: ${paramName}`);
+                }
+                
+                if (parameters[paramName] !== undefined && paramConfig.validate) {
+                    if (!paramConfig.validate(parameters[paramName])) {
+                        throw new Error(`Invalid value for parameter: ${paramName}`);
+                    }
+                }
+            }
+        }
+    }
+
+    getToolsByCategory(category) {
+        return Array.from(this.toolCategories.get(category) || [])
+            .map(toolName => this.tools.get(toolName));
+    }
+
+    getMostUsedTools(limit = 10) {
+        return Array.from(this.tools.values())
+            .sort((a, b) => (b.usageCount || 0) - (a.usageCount || 0))
+            .slice(0, limit);
+    }
+
+    suggestTools(query, context) {
+        // Simple tool suggestion based on name and description matching
+        const queryLower = query.toLowerCase();
+        
+        return Array.from(this.tools.entries())
+            .map(([name, tool]) => {
+                let score = 0;
+                
+                // Name match
+                if (name.toLowerCase().includes(queryLower)) {
+                    score += 3;
+                }
+                
+                // Description match
+                if (tool.description && tool.description.toLowerCase().includes(queryLower)) {
+                    score += 2;
+                }
+                
+                // Category match
+                if (tool.category && tool.category.toLowerCase().includes(queryLower)) {
+                    score += 1;
+                }
+                
+                // Recent usage bonus
+                if (tool.lastUsed && (Date.now() - tool.lastUsed) < 24 * 60 * 60 * 1000) {
+                    score += 0.5;
+                }
+                
+                return { name, tool, score };
+            })
+            .filter(item => item.score > 0)
+            .sort((a, b) => b.score - a.score)
+            .map(item => item.name);
+    }
+}
+
+export class MCPClient {
+    constructor(serverUrl, options = {}) {
+        this.serverUrl = serverUrl;
+        this.options = {
+            timeout: 30000,
+            autoReconnect: true,
+            reconnectDelay: 2000,
+            maxReconnectAttempts: 5,
+            ...options
+        };
+        this.connected = false;
+        this.reconnectAttempts = 0;
+        this.messageId = 0;
+        this.pendingRequests = new Map();
+        this.ws = null;
+        this.messageQueue = [];
+    }
+
+    async connect() {
+        return new Promise((resolve, reject) => {
+            if (this.connected) {
+                resolve();
+                return;
+            }
+
+            try {
+                this.ws = new WebSocket(this.serverUrl);
+                
+                this.ws.onopen = () => {
+                    this.connected = true;
+                    this.reconnectAttempts = 0;
+                    console.log('MCP client connected to:', this.serverUrl);
+                    
+                    // Process any queued messages
+                    this.processMessageQueue();
+                    
+                    resolve();
+                };
+                
+                this.ws.onmessage = (event) => {
+                    try {
+                        const response = JSON.parse(event.data);
+                        this.handleResponse(response);
+                    } catch (error) {
+                        console.error('Failed to parse MCP response:', error);
+                    }
+                };
+                
+                this.ws.onclose = (event) => {
+                    this.connected = false;
+                    console.log('MCP connection closed:', event.code, event.reason);
+                    
+                    if (this.options.autoReconnect && 
+                        this.reconnectAttempts < this.options.maxReconnectAttempts) {
+                        setTimeout(() => {
+                            this.reconnectAttempts++;
+                            console.log(`Reconnecting attempt ${this.reconnectAttempts}...`);
+                            this.connect().catch(console.error);
+                        }, this.options.reconnectDelay);
+                    }
+                };
+                
+                this.ws.onerror = (error) => {
+                    console.error('MCP WebSocket error:', error);
+                    reject(error);
+                };
+                
+            } catch (error) {
+                console.error('MCP connection failed:', error);
+                reject(error);
+            }
+        });
+    }
+
+    async callTool(toolName, parameters) {
+        if (!this.connected) {
+            await this.connect();
+        }
+
+        const messageId = this.messageId++;
+        const request = {
+            jsonrpc: '2.0',
+            id: messageId,
+            method: 'tools/call',
+            params: {
+                name: toolName,
+                arguments: parameters
+            }
+        };
+
+        return new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                this.pendingRequests.delete(messageId);
+                reject(new Error('MCP request timeout'));
+            }, this.options.timeout);
+
+            this.pendingRequests.set(messageId, { resolve, reject, timeout });
+            
+            this.sendRequest(request);
+        });
+    }
+
+    async listTools() {
+        if (!this.connected) {
+            await this.connect();
+        }
+
+        const messageId = this.messageId++;
+        const request = {
+            jsonrpc: '2.0',
+            id: messageId,
+            method: 'tools/list'
+        };
+
+        return new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                this.pendingRequests.delete(messageId);
+                reject(new Error('MCP request timeout'));
+            }, this.options.timeout);
+
+            this.pendingRequests.set(messageId, { resolve, reject, timeout });
+            this.sendRequest(request);
+        });
+    }
+
+    sendRequest(request) {
+        if (this.connected && this.ws && this.ws.readyState === WebSocket.OPEN) {
+            this.ws.send(JSON.stringify(request));
+        } else {
+            // Queue the message if not connected
+            this.messageQueue.push(request);
+            if (!this.connected) {
+                this.connect().catch(console.error);
+            }
+        }
+    }
+
+    processMessageQueue() {
+        while (this.messageQueue.length > 0 && this.connected) {
+            const request = this.messageQueue.shift();
+            this.ws.send(JSON.stringify(request));
+        }
+    }
+
+    handleResponse(response) {
+        const pending = this.pendingRequests.get(response.id);
+        if (!pending) return;
+
+        clearTimeout(pending.timeout);
+        this.pendingRequests.delete(response.id);
+
+        if (response.error) {
+            pending.reject(new Error(response.error.message || 'MCP error'));
+        } else {
+            pending.resolve(response.result);
+        }
+    }
+
+    disconnect() {
+        this.options.autoReconnect = false;
+        if (this.ws) {
+            this.ws.close();
+            this.ws = null;
+        }
+        this.connected = false;
+        
+        // Reject all pending requests
+        for (const [id, pending] of this.pendingRequests) {
+            clearTimeout(pending.timeout);
+            pending.reject(new Error('MCP connection closed'));
+        }
+        this.pendingRequests.clear();
+    }
+}
+
+// Example tool implementations
+
+function evaluateExpression(expression) {
+    const sanitized = expression.replace(/[^0-9+\-*/(). ]/g, '');
+    const tokens = sanitized.match(/[+\-*/()]|[0-9]+(?:\.[0-9]+)?/g);
+    if (!tokens) throw new Error('Invalid expression');
+    const output = [];
+    const ops = [];
+    const precedence = { '+':1, '-':1, '*':2, '/':2 };
+    for (const token of tokens) {
+        if (/\d/.test(token)) {
+            output.push(parseFloat(token));
+        } else if (token in precedence) {
+            while (ops.length && precedence[ops[ops.length-1]] >= precedence[token]) {
+                output.push(ops.pop());
+            }
+            ops.push(token);
+        } else if (token === '(') {
+            ops.push(token);
+        } else if (token === ')') {
+            while (ops.length && ops[ops.length-1] !== '(') output.push(ops.pop());
+            if (ops.pop() !== '(') throw new Error('Mismatched parentheses');
+        }
+    }
+    while (ops.length) {
+        const op = ops.pop();
+        if (op === '(') throw new Error('Mismatched parentheses');
+        output.push(op);
+    }
+    const stack = [];
+    for (const token of output) {
+        if (typeof token === 'number') stack.push(token);
+        else {
+            const b = stack.pop();
+            const a = stack.pop();
+            switch (token) {
+                case '+': stack.push(a + b); break;
+                case '-': stack.push(a - b); break;
+                case '*': stack.push(a * b); break;
+                case '/': stack.push(a / b); break;
+            }
+        }
+    }
+    if (stack.length !== 1) throw new Error('Invalid expression');
+    return stack[0];
+}
+
+export const builtInTools = {
+    calculator: {
+        description: 'Perform mathematical calculations',
+        parameters: {
+            expression: {
+                type: 'string',
+                required: true,
+                description: 'Mathematical expression to evaluate'
+            }
+        },
+        execute: async (parameters) => {
+            try {
+                const result = evaluateExpression(parameters.expression);
+                return { result, success: true };
+            } catch (error) {
+                return { error: error.message, success: false };
+            }
+        }
+    },
+
+    webSearch: {
+        description: 'Search the web for information',
+        parameters: {
+            query: {
+                type: 'string',
+                required: true,
+                description: 'Search query'
+            },
+            maxResults: {
+                type: 'number',
+                required: false,
+                description: 'Maximum number of results to return',
+                default: 5
+            }
+        },
+        execute: async (parameters, context) => {
+            // Implementation would depend on the search API
+            // This is a placeholder implementation
+            return {
+                results: [
+                    { title: 'Result 1', url: 'https://example.com/1', snippet: 'Snippet 1' },
+                    { title: 'Result 2', url: 'https://example.com/2', snippet: 'Snippet 2' }
+                ],
+                success: true
+            };
+        }
+    },
+
+    fileSystem: {
+        description: 'Read from and write to the file system',
+        parameters: {
+            operation: {
+                type: 'string',
+                required: true,
+                enum: ['read', 'write', 'list'],
+                description: 'File system operation to perform'
+            },
+            path: {
+                type: 'string',
+                required: true,
+                description: 'File or directory path'
+            },
+            content: {
+                type: 'string',
+                required: false,
+                description: 'Content to write (for write operations )'
+            }
+        },
+        execute: async (parameters) => {
+            // Implementation would use react-native-fs or similar
+            // This is a placeholder implementation
+            return { success: true, message: 'File operation completed' };
+        }
+    }
+};

--- a/src/components/ExtractedContent.js
+++ b/src/components/ExtractedContent.js
@@ -1,0 +1,177 @@
+import React from 'react';
+import { View, Text, ScrollView, StyleSheet, Linking } from 'react-native';
+import HTML from 'react-native-render-html';
+
+const ExtractedContent = ({ content, onLinkPress }) => {
+  if (!content) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.error}>No content available</Text>
+      </View>
+    );
+  }
+
+  const handleLinkPress = (event, href) => {
+    if (typeof href !== 'string' || !href.trim()) {
+      console.error('Invalid URL: href is empty or not a string');
+      return;
+    }
+    try {
+      // Basic URL validation
+      // eslint-disable-next-line no-new
+      new URL(href);
+      if (onLinkPress) {
+        onLinkPress(href);
+      } else {
+        Linking.openURL(href).catch(err =>
+          console.error('Failed to open URL:', err)
+        );
+      }
+    } catch (e) {
+      console.error('Invalid URL:', href, e);
+    }
+  };
+
+  return (
+    <ScrollView style={styles.container}>
+      <Text style={styles.title}>{content.title}</Text>
+      
+      {content.siteName && (
+        <Text style={styles.siteName}>From: {content.siteName}</Text>
+      )}
+      
+      {content.publishedTime && (
+        <Text style={styles.meta}>Published: {content.publishedTime}</Text>
+      )}
+      
+      {content.readingTime && (
+        <Text style={styles.meta}>Reading time: {content.readingTime} min</Text>
+      )}
+      
+      {content.excerpt && (
+        <View style={styles.excerptContainer}>
+          <Text style={styles.excerpt}>{content.excerpt}</Text>
+        </View>
+      )}
+      
+      {content.content ? (
+        <HTML
+          source={{ html: content.content }}
+          onLinkPress={handleLinkPress}
+          tagsStyles={htmlStyles}
+          baseStyle={styles.htmlBase}
+        />
+      ) : content.textContent ? (
+        <Text style={styles.textContent}>{content.textContent}</Text>
+      ) : (
+        <Text style={styles.error}>No content available</Text>
+      )}
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    backgroundColor: '#fff'
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 8,
+    color: '#333'
+  },
+  siteName: {
+    fontSize: 14,
+    color: '#666',
+    marginBottom: 4
+  },
+  meta: {
+    fontSize: 12,
+    color: '#888',
+    marginBottom: 8
+  },
+  excerptContainer: {
+    backgroundColor: '#f5f5f5',
+    padding: 12,
+    borderRadius: 6,
+    marginBottom: 16
+  },
+  excerpt: {
+    fontSize: 16,
+    fontStyle: 'italic',
+    color: '#555'
+  },
+  textContent: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: '#333'
+  },
+  htmlBase: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: '#333'
+  },
+  error: {
+    color: '#999',
+    fontStyle: 'italic',
+    textAlign: 'center',
+    marginVertical: 20
+  }
+});
+
+const htmlStyles = {
+  p: {
+    fontSize: 16,
+    lineHeight: 24,
+    marginBottom: 16,
+    color: '#333'
+  },
+  h1: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginTop: 24,
+    marginBottom: 16,
+    color: '#333'
+  },
+  h2: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginTop: 20,
+    marginBottom: 12,
+    color: '#333'
+  },
+  h3: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginTop: 18,
+    marginBottom: 10,
+    color: '#333'
+  },
+  a: {
+    color: '#0066cc',
+    textDecorationLine: 'underline'
+  },
+  ul: {
+    marginBottom: 16
+  },
+  ol: {
+    marginBottom: 16
+  },
+  li: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: '#333'
+  },
+  blockquote: {
+    backgroundColor: '#f5f5f5',
+    borderLeftWidth: 4,
+    borderLeftColor: '#ddd',
+    paddingLeft: 12,
+    marginBottom: 16,
+    fontStyle: 'italic'
+  }
+};
+
+export default ExtractedContent;

--- a/src/services/contextEngineer.js
+++ b/src/services/contextEngineer.js
@@ -1,0 +1,369 @@
+import { NativeModules, Platform } from 'react-native';
+import LLMService from './llmService';
+import { cosineSimilarity } from '../utils/vectorUtils';
+import { applySparseAttention } from '../utils/sparseAttention';
+import { encoding_for_model } from 'tiktoken';
+
+export class ContextEvaluator {
+  constructor() {
+    this.relevanceThreshold = 0.65;
+    this.qualityThreshold = 0.7;
+    this.useHierarchicalAttention = true;
+  }
+
+  async evaluateContext(query, contextItems) {
+    if (!contextItems || contextItems.length === 0) return [];
+    
+    if (this.useHierarchicalAttention && contextItems.length > 10) {
+      return this._evaluateWithHierarchicalAttention(query, contextItems);
+    }
+    
+    const relevantContext = contextItems.filter(item => 
+      item.similarity >= this.relevanceThreshold
+    );
+    
+    const topContext = relevantContext
+      .sort((a, b) => b.similarity - a.similarity)
+      .slice(0, 3);
+    
+    if (topContext.length === 0) return [];
+    
+    const deviceMemory = await this._getDeviceMemory();
+    if (deviceMemory < 3000) {
+      return topContext.map(item => ({
+        ...item,
+        qualityScore: item.similarity,
+        isHighQuality: item.similarity >= this.qualityThreshold
+      }));
+    }
+    
+    return await this._assessContextQuality(query, topContext);
+  }
+
+  async _evaluateWithHierarchicalAttention(query, contextItems) {
+    const queryEmbedding = await LLMService.embed(query);
+    
+    const clusteredContext = this._clusterContextItems(contextItems);
+    const selectedContext = await applySparseAttention(
+      queryEmbedding, 
+      clusteredContext,
+      { numClusters: 3, topK: 2 }
+    );
+    
+    return await this._assessContextQuality(query, selectedContext);
+  }
+
+  _clusterContextItems(contextItems) {
+    const clusters = [];
+    
+    for (const item of contextItems) {
+      let addedToCluster = false;
+      
+      for (const cluster of clusters) {
+        const clusterSimilarity = cosineSimilarity(
+          item.embedding, 
+          cluster.center
+        );
+        
+        if (clusterSimilarity > 0.7) {
+          cluster.items.push(item);
+          cluster.center = cluster.items.reduce((sum, i) => {
+            return sum.map((val, idx) => val + i.embedding[idx]);
+          }, new Array(item.embedding.length).fill(0))
+          .map(val => val / cluster.items.length);
+          addedToCluster = true;
+          break;
+        }
+      }
+      
+      if (!addedToCluster) {
+        clusters.push({
+          center: [...item.embedding],
+          items: [item]
+        });
+      }
+    }
+    
+    return clusters;
+  }
+
+  async _assessContextQuality(query, contextItems) {
+    const qualityResults = [];
+    
+    for (const item of contextItems) {
+      try {
+        let qualityScore = item.similarity;
+        
+        if (item.metadata.timestamp) {
+          const age = Date.now() - new Date(item.metadata.timestamp).getTime();
+          const ageFactor = Math.max(0.7, 1 - age / (30 * 24 * 60 * 60 * 1000));
+          qualityScore *= ageFactor;
+        }
+        
+        if (item.metadata.source === 'knowledge_base') {
+          qualityScore *= 1.1;
+        }
+        
+        qualityResults.push({
+          ...item,
+          qualityScore,
+          isHighQuality: qualityScore >= this.qualityThreshold
+        });
+      } catch (error) {
+        console.error('Context quality assessment failed:', error);
+        qualityResults.push({
+          ...item,
+          qualityScore: item.similarity,
+          isHighQuality: item.similarity >= this.qualityThreshold
+        });
+      }
+    }
+    
+    return qualityResults;
+  }
+
+  async _getDeviceMemory() {
+    try {
+      if (Platform.OS === 'ios') {
+        return NativeModules.DeviceInfo?.getTotalMemory?.() || 2000;
+      } else {
+        return NativeModules.DeviceInfo?.totalMemory?.() || 2000;
+      }
+    } catch (error) {
+      return 2000;
+    }
+  }
+
+  prioritizeContext(contextItems) {
+    if (!contextItems || contextItems.length === 0) return [];
+    
+    return contextItems
+      .sort((a, b) => {
+        const qualityDiff = (b.qualityScore || b.similarity) - (a.qualityScore || a.similarity);
+        if (Math.abs(qualityDiff) > 0.05) return qualityDiff;
+        
+        try {
+          const aTime = a.metadata?.timestamp ? new Date(a.metadata.timestamp).getTime() : 0;
+          const bTime = b.metadata?.timestamp ? new Date(b.metadata.timestamp).getTime() : 0;
+          return bTime - aTime;
+        } catch (e) {
+          return 0;
+        }
+      })
+      .filter(item => item.isHighQuality)
+      .slice(0, 2);
+  }
+}
+
+export class ContextEngineer {
+  constructor() {
+    this.contextEvaluator = new ContextEvaluator();
+    this.maxContextTokens = 768;
+    this.conversationSummaryLength = 128;
+    this.useDynamicTokenBudgeting = true;
+    try {
+      this.tokenizer = encoding_for_model('gpt-3.5-turbo');
+    } catch (e) {
+      this.tokenizer = null;
+    }
+  }
+
+  async engineerContext(query, conversationHistory) {
+    const { maxContextTokens, conversationSummaryLength } = await this._getDeviceConfig();
+    this.maxContextTokens = maxContextTokens;
+    this.conversationSummaryLength = conversationSummaryLength;
+    
+    const tokenBudget = this.useDynamicTokenBudgeting 
+      ? await this._calculateDynamicTokenBudget(query, conversationHistory)
+      : { maxContextTokens: this.maxContextTokens };
+    
+    if (this._requiresHierarchicalAttention(query, conversationHistory)) {
+      return this._hierarchicalContextProcessing(query, conversationHistory, tokenBudget);
+    }
+    
+    return this._standardContextProcessing(query, conversationHistory, tokenBudget);
+  }
+
+  async _calculateDynamicTokenBudget(query, conversationHistory) {
+    const deviceProfile = await this._getDeviceProfile();
+    const queryComplexity = this._assessQueryComplexity(query);
+    
+    let baseTokens = deviceProfile.tier === 'high' ? 1024 : 512;
+    
+    if (queryComplexity === 'high') {
+      baseTokens = Math.min(baseTokens, 768);
+    } else if (queryComplexity === 'low') {
+      baseTokens = Math.min(baseTokens, 1024);
+    }
+    
+    if (conversationHistory.length > 10) {
+      baseTokens = Math.max(256, baseTokens * 0.7);
+    }
+
+    baseTokens = Math.round(baseTokens);
+
+    return {
+      maxContextTokens: baseTokens,
+      queryTokens: Math.floor(baseTokens * 0.2),
+      contextTokens: Math.floor(baseTokens * 0.5),
+      historyTokens: Math.floor(baseTokens * 0.3)
+    };
+  }
+
+  _requiresHierarchicalAttention(query, conversationHistory) {
+    return query.length > 100 || 
+           conversationHistory.length > 10 ||
+           this._assessQueryComplexity(query) === 'high';
+  }
+
+  async _hierarchicalContextProcessing(query, conversationHistory, tokenBudget) {
+    const queryEmbedding = await LLMService.embed(query);
+    
+    const relevantChunks = await this._retrieveRelevantChunksSparse(
+      queryEmbedding, 
+      Math.floor(tokenBudget.contextTokens / 100)
+    );
+    
+    const conversationSummary = await this._summarizeConversationHierarchically(
+      conversationHistory, 
+      tokenBudget.historyTokens
+    );
+    
+    const availableContextTokens = tokenBudget.maxContextTokens - 
+                                  conversationSummary.tokenCount - 
+                                  tokenBudget.queryTokens;
+    
+    const selectedContext = await this._selectContextWithinBudgetSparse(
+      relevantChunks, 
+      availableContextTokens
+    );
+    
+    return {
+      contextPrompt: this._assembleHierarchicalContext(
+        query, 
+        selectedContext, 
+        conversationSummary
+      ),
+      tokenUsage: {
+        total: tokenBudget.maxContextTokens,
+        context: selectedContext.tokenCount,
+        conversation: conversationSummary.tokenCount,
+        query: tokenBudget.queryTokens
+      },
+      usedSparseAttention: true
+    };
+  }
+
+  async _retrieveRelevantChunksSparse(queryEmbedding, limit) {
+    try {
+      const results = await vectorStore.searchVectorsSparse(
+        queryEmbedding, 
+        limit,
+        { useHierarchical: true, numClusters: 3 }
+      );
+      return results;
+    } catch (error) {
+      console.error('Sparse retrieval failed, falling back to standard:', error);
+      return await vectorStore.searchVectors(queryEmbedding, limit);
+    }
+  }
+
+  async _summarizeConversationHierarchically(conversationHistory, maxTokens) {
+    const conversationText = conversationHistory
+      .map(m => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`)
+      .join('\n');
+      
+    try {
+      const summaryPrompt = `Summarize this conversation history concisely within ${maxTokens} tokens:\n\n${conversationText}\n\nSummary:`;
+      
+      const summaryResult = await LLMService.generate(
+        summaryPrompt, 
+        maxTokens, 
+        0.3
+      );
+      
+      return {
+        text: summaryResult.text,
+        tokenCount: this._estimateTokens(summaryResult.text)
+      };
+    } catch (error) {
+      console.error('Hierarchical summarization failed:', error);
+      return {
+        text: conversationHistory.slice(-2).map(m => m.content).join('\n'),
+        tokenCount: this._estimateTokens(conversationHistory.slice(-2).map(m => m.content).join('\n'))
+      };
+    }
+  }
+
+  _estimateTokens(text) {
+    if (this.tokenizer) {
+      return this.tokenizer.encode(text).length;
+    }
+    return Math.ceil(text.length / 4);
+  }
+
+  _assessQueryComplexity(query) {
+    let score = query.length / 100;
+    if (query.match(/\b(explain|analyze|reason|complex)\b/i)) score += 5;
+    return score > 5 ? 'high' : score > 2 ? 'medium' : 'low';
+  }
+
+  async _getDeviceConfig() {
+    const deviceMemory = await this._getDeviceMemory();
+    const isLowEnd = deviceMemory < 3000;
+    
+    if (isLowEnd) {
+      return {
+        maxContextTokens: 512,
+        conversationSummaryLength: 96
+      };
+    } else if (Platform.OS === 'ios') {
+      return {
+        maxContextTokens: 1024,
+        conversationSummaryLength: 160
+      };
+    } else {
+      return {
+        maxContextTokens: 768,
+        conversationSummaryLength: 128
+      };
+    }
+  }
+
+  async _getDeviceMemory() {
+    try {
+      if (Platform.OS === 'ios') {
+        return NativeModules.DeviceInfo?.getTotalMemory?.() || 2000;
+      } else {
+        return NativeModules.DeviceInfo?.totalMemory?.() || 2000;
+      }
+    } catch (error) {
+      return 2000;
+    }
+  }
+
+  async _getDeviceProfile() {
+    try {
+      const totalMemory = Platform.OS === 'ios' 
+        ? NativeModules.DeviceInfo?.getTotalMemory?.() 
+        : NativeModules.DeviceInfo?.totalMemory?.() || 2000;
+      
+      let tier = 'low';
+      if (totalMemory >= 6000) {
+        tier = 'high';
+      } else if (totalMemory >= 3000) {
+        tier = 'mid';
+      }
+      
+      return {
+        tier,
+        totalMemory
+      };
+    } catch (error) {
+      return {
+        tier: 'low',
+        totalMemory: 2000
+      };
+    }
+  }
+}

--- a/src/services/llmService.js
+++ b/src/services/llmService.js
@@ -1,0 +1,261 @@
+import { NativeModules, Platform } from 'react-native';
+import { getDeviceProfile } from '../utils/deviceUtils';
+import { PluginManager } from '../architecture/pluginManager';
+import { DependencyInjector } from '../architecture/dependencyInjector';
+import { registerLLMPlugins } from '../architecture/pluginSetup';
+import { setupLLMDI } from '../architecture/diSetup';
+
+class LLMService {
+  #quantizationAdjustmentPromise = Promise.resolve();
+
+  constructor() {
+    this.isWeb = Platform.OS === 'web';
+    this.isReady = false;
+    this.kvCache = {
+      tokens: [],
+      size: 0,
+      maxSize: 512
+    };
+    
+    this.pluginManager = new PluginManager();
+    this.dependencyInjector = new DependencyInjector();
+    
+    if (!this.isWeb) {
+      this.nativeModule = NativeModules[Platform.OS === 'ios' ? 'MLXTurboModule' : 'LlamaTurboModule'];
+    }
+    
+    this.deviceProfile = getDeviceProfile();
+    this.performanceMetrics = {
+      totalInferenceTime: 0,
+      inferenceCount: 0,
+      averageInferenceTime: 0
+    };
+    
+    registerLLMPlugins(this.pluginManager, this);
+    setupLLMDI(this.dependencyInjector, {
+      deviceProfile: this.deviceProfile,
+      performanceMetrics: this.performanceMetrics,
+      kvCache: this.kvCache
+    });
+  }
+
+  async #scheduleQuantizationAdjustment() {
+    this.#quantizationAdjustmentPromise = this.#quantizationAdjustmentPromise.then(() => {
+      return new Promise((resolve) => {
+        setTimeout(async () => {
+          try {
+            await this.adjustQuantization();
+          } catch (e) {
+            console.error('Quantization adjustment failed:', e);
+          }
+          resolve();
+        }, 0);
+      });
+    });
+    return this.#quantizationAdjustmentPromise;
+  }
+
+  async loadModel(modelPath) {
+    try {
+      let result;
+      
+      if (this.isWeb) {
+        result = { status: 'loaded', contextSize: 4096, model: modelPath };
+      } else {
+        result = await this.nativeModule.loadModel(modelPath);
+        
+        await this.pluginManager.enablePlugin('sparseAttention');
+        await this.pluginManager.enablePlugin('adaptiveQuantization');
+      }
+      
+      this.isReady = true;
+      this.clearKVCache();
+      return result;
+    } catch (error) {
+      console.error('Failed to load model:', error);
+      throw error;
+    }
+  }
+
+  async generate(prompt, maxTokens = 256, temperature = 0.7, options = {}) {
+    if (!this.isReady && !this.isWeb) {
+      throw new Error('Model not loaded');
+    }
+
+    try {
+      const startTime = Date.now();
+      
+      let response;
+      if (this.pluginManager.isPluginEnabled('sparseAttention')) {
+        response = await this.pluginManager.execute('generate', 
+          [prompt, maxTokens, temperature, options], this);
+      } else {
+        response = this.isWeb
+          ? await this._generateWeb(prompt, maxTokens, temperature)
+          : await this.nativeModule.generate(prompt, maxTokens, temperature, false);
+      }
+      
+      const inferenceTime = Date.now() - startTime;
+      this.performanceMetrics.totalInferenceTime += inferenceTime;
+      this.performanceMetrics.inferenceCount++;
+      this.performanceMetrics.averageInferenceTime = 
+        this.performanceMetrics.totalInferenceTime / this.performanceMetrics.inferenceCount;
+      
+      const newTokens = response.text.split(/\s+/);
+      this.kvCache.tokens.push(...newTokens);
+      this.kvCache.size = this.kvCache.tokens.length;
+      
+      if (response.kvCacheSize !== undefined) {
+        this.kvCache.size = response.kvCacheSize;
+        if (this.kvCache.tokens.length > this.kvCache.size) {
+          this.kvCache.tokens = this.kvCache.tokens.slice(-this.kvCache.size);
+        }
+      }
+      
+      if (this.kvCache.size > this.kvCache.maxSize) {
+        const excess = this.kvCache.size - this.kvCache.maxSize;
+        if (this.kvCache.tokens.length > excess) {
+          this.kvCache.tokens.splice(0, excess);
+        }
+        this.kvCache.size = this.kvCache.tokens.length;
+      }
+
+      if (this.pluginManager.isPluginEnabled('adaptiveQuantization')) {
+        await this.#scheduleQuantizationAdjustment();
+      }
+
+      return {
+        ...response,
+        kvCacheSize: this.kvCache.size,
+        kvCacheMax: response.kvCacheMax || this.kvCache.maxSize,
+        inferenceTime
+      };
+    } catch (error) {
+      console.error('Generation failed:', error);
+      throw error;
+    }
+  }
+
+  async getPerformanceMetrics() {
+    try {
+      if (!this.isWeb) {
+        const metrics = await this.nativeModule.getPerformanceMetrics();
+        
+        return {
+          ...this.performanceMetrics,
+          ...metrics
+        };
+      }
+      
+      return this.performanceMetrics;
+    } catch (error) {
+      console.error('Failed to get performance metrics:', error);
+      return this.performanceMetrics;
+    }
+  }
+
+  async adjustPerformanceMode(mode) {
+    try {
+      if (!this.isWeb) {
+        await this.nativeModule.adjustPerformanceMode(mode);
+        
+        switch (mode) {
+          case 'low-memory':
+            this.kvCache.maxSize = 256;
+            break;
+          case 'power-saving':
+            this.kvCache.maxSize = 512;
+            break;
+          case 'performance':
+            this.kvCache.maxSize = 1024;
+            break;
+        }
+      }
+      
+      return true;
+    } catch (error) {
+      console.error('Failed to adjust performance mode:', error);
+      return false;
+    }
+  }
+
+  async embed(text) {
+    if (!this.isReady && !this.isWeb) {
+      throw new Error('Model not loaded');
+    }
+
+    try {
+      return this.isWeb
+        ? await this._embedWeb(text)
+        : await this.nativeModule.embed(text);
+    } catch (error) {
+      console.error('Embedding failed:', error);
+      throw error;
+    }
+  }
+
+  async clearKVCache() {
+    try {
+      if (!this.isWeb) {
+        await this.nativeModule.clearKVCache();
+        await this.nativeModule.addMessageBoundary();
+      }
+      
+      this.kvCache = {
+        tokens: [],
+        size: 0,
+        maxSize: this.deviceProfile.isQuantized ? 768 : 512
+      };
+      
+      return { status: 'cleared', size: 0 };
+    } catch (error) {
+      console.error('Failed to clear KV cache:', error);
+      throw error;
+    }
+  }
+
+  async getKVCacheSize() {
+    try {
+      if (!this.isWeb) {
+        const size = await this.nativeModule.getKVCacheSize();
+        const maxSize = await this.nativeModule.getKVCacheMaxSize();
+        return { size, maxSize };
+      }
+      return { size: this.kvCache.size, maxSize: this.kvCache.maxSize };
+    } catch (error) {
+      console.error('Failed to get KV cache size:', error);
+      return { size: this.kvCache.size, maxSize: this.kvCache.maxSize };
+    }
+  }
+  
+  async addMessageBoundary() {
+    try {
+      if (!this.isWeb) {
+        await this.nativeModule.addMessageBoundary();
+      }
+      return true;
+    } catch (error) {
+      console.error('Failed to add message boundary:', error);
+      return false;
+    }
+  }
+  
+  async _generateWeb(prompt, maxTokens, temperature) {
+    return {
+      text: "Web implementation response",
+      tokensGenerated: 50,
+      kvCacheSize: 100
+    };
+  }
+  
+  async _embedWeb(text) {
+    return Array(512).fill(0.5);
+  }
+
+  async _switchQuantization(level) {
+    console.log(`Switching to ${level} quantization`);
+    // Implementation would involve downloading and loading a new model
+  }
+}
+
+export default new LLMService();

--- a/src/services/providers/bing.js
+++ b/src/services/providers/bing.js
@@ -1,0 +1,30 @@
+import { getApiKeys } from '../utils/apiKeys';
+import { bingTimeRange } from '../utils/timeRange';
+
+export async function validateKey() {
+  const { bingApiKey } = await getApiKeys();
+  return Boolean(bingApiKey);
+}
+
+export async function search(query, { maxResults, timeRange, safeSearch }) {
+  const { bingApiKey } = await getApiKeys();
+  if (!bingApiKey) {
+    throw new Error('Bing API key not configured');
+  }
+  const freshness = bingTimeRange[timeRange] || '';
+  const url = `https://api.bing.microsoft.com/v7.0/search?q=${encodeURIComponent(query)}&count=${maxResults}&freshness=${freshness}&safeSearch=${safeSearch ? 'Moderate' : 'Off'}`;
+  const response = await fetch(url, {
+    headers: { 'Ocp-Apim-Subscription-Key': bingApiKey }
+  });
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Bing API error: ${response.statusText} - ${errorText}`);
+  }
+  const data = await response.json();
+  return data.webPages?.value?.map(item => ({
+    title: item.name,
+    url: item.url,
+    snippet: item.snippet,
+    date: item.dateLastCrawled || null
+  })) || [];
+}

--- a/src/services/providers/brave.js
+++ b/src/services/providers/brave.js
@@ -1,0 +1,34 @@
+import { getApiKeys } from '../utils/apiKeys';
+import { braveTimeRange } from '../utils/timeRange';
+
+export async function validateKey() {
+  const { braveApiKey } = await getApiKeys();
+  return Boolean(braveApiKey);
+}
+
+export async function search(query, { maxResults, timeRange, safeSearch }) {
+  const { braveApiKey } = await getApiKeys();
+  if (!braveApiKey) {
+    throw new Error('Brave API key not configured');
+  }
+  const freshness = braveTimeRange[timeRange] || '';
+  const url = `https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(query)}&count=${maxResults}&freshness=${freshness}&safesearch=${safeSearch ? 'moderate' : 'off'}`;
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/json',
+      'Accept-Encoding': 'gzip',
+      'X-Subscription-Token': braveApiKey,
+    },
+  });
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(`Brave API error: ${errorData.message || response.statusText}`);
+  }
+  const data = await response.json();
+  return data.web?.results?.map(item => ({
+    title: item.title,
+    url: item.url,
+    snippet: item.description,
+    date: item.age || null,
+  })) || [];
+}

--- a/src/services/providers/duckduckgo.js
+++ b/src/services/providers/duckduckgo.js
@@ -1,0 +1,38 @@
+// DuckDuckGo does not require API keys
+
+export async function validateKey() {
+  return true;
+}
+
+// Parse DuckDuckGo HTML results
+function parseResults(html, maxResults) {
+  const results = [];
+  const resultRegex = /<a class="result__a".*?href="([^"]+)".*?>(.*?)<\/a>.*?<a class="result__snippet".*?>(.*?)<\/a>/gs;
+  let match;
+  while ((match = resultRegex.exec(html)) !== null && results.length < maxResults) {
+    if (match[1].startsWith('//ad.')) continue;
+    const url = match[1].startsWith('//') ? 'https:' + match[1] : match[1];
+    results.push({
+      title: match[2].replace(/<[^>]*>/g, ''),
+      url,
+      snippet: match[3].replace(/<[^>]*>/g, ''),
+      date: null
+    });
+  }
+  return results;
+}
+
+export async function search(query, { maxResults, safeSearch }) {
+  const safeParam = safeSearch ? 1 : -1;
+  const url = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}&s=${maxResults * 2}&p=${safeParam}`;
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+    }
+  });
+  if (!response.ok) {
+    throw new Error(`DuckDuckGo request failed: ${response.statusText}`);
+  }
+  const html = await response.text();
+  return parseResults(html, maxResults);
+}

--- a/src/services/providers/google.js
+++ b/src/services/providers/google.js
@@ -1,0 +1,29 @@
+import { getApiKeys } from '../utils/apiKeys';
+import { googleTimeRange } from '../utils/timeRange';
+
+export async function validateKey() {
+  const { googleApiKey, googleSearchEngineId } = await getApiKeys();
+  return Boolean(googleApiKey && googleSearchEngineId);
+}
+
+export async function search(query, { maxResults, timeRange, safeSearch }) {
+  const { googleApiKey, googleSearchEngineId } = await getApiKeys();
+  if (!googleApiKey || !googleSearchEngineId) {
+    throw new Error('Google API key or search engine ID not configured');
+  }
+  const dateRestrict = googleTimeRange[timeRange] || '';
+  const safe = safeSearch ? 'medium' : 'off';
+  const url = `https://www.googleapis.com/customsearch/v1?key=${encodeURIComponent(googleApiKey)}&cx=${encodeURIComponent(googleSearchEngineId)}&q=${encodeURIComponent(query)}&num=${Math.min(maxResults,10)}&safe=${safe}${dateRestrict ? `&dateRestrict=${dateRestrict}` : ''}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(`Google API error: ${errorData.error?.message || response.statusText}`);
+  }
+  const data = await response.json();
+  return data.items?.map(item => ({
+    title: item.title,
+    url: item.link,
+    snippet: item.snippet,
+    date: item.pagemap?.metatags?.[0]?.['article:published_time'] || item.pagemap?.metatags?.[0]?.['og:updated_time'] || null
+  })) || [];
+}

--- a/src/services/readabilityService.js
+++ b/src/services/readabilityService.js
@@ -1,0 +1,181 @@
+import { Readability } from '@mozilla/readability';
+import { JSDOM } from 'jsdom';
+import { Platform } from 'react-native';
+
+class ReadabilityService {
+  constructor() {
+    this.cache = new Map();
+    this.cacheTimeout = 15 * 60 * 1000; // 15 minutes cache
+  }
+
+  async extractContent(html, url) {
+    try {
+      const cacheKey = this.generateCacheKey(html, url);
+      const cached = this.cache.get(cacheKey);
+      
+      if (cached && Date.now() - cached.timestamp < this.cacheTimeout) {
+        return cached.content;
+      }
+
+      const dom = new JSDOM(html, {
+        url: url,
+        pretendToBeVisual: true,
+        resources: "usable",
+        runScripts: "dangerously"
+      });
+
+      await new Promise(resolve => {
+        if (dom.window.document.readyState === 'complete') {
+          resolve();
+        } else {
+          dom.window.addEventListener('load', resolve);
+        }
+      });
+
+      const reader = new Readability(dom.window.document);
+      const article = reader.parse();
+
+      if (!article) {
+        throw new Error('Failed to extract content with Readability');
+      }
+
+      const cleanedContent = this.cleanContent(article);
+
+      this.cache.set(cacheKey, {
+        content: cleanedContent,
+        timestamp: Date.now()
+      });
+
+      return cleanedContent;
+    } catch (error) {
+      console.error('Readability extraction failed:', error);
+      throw new Error(`Content extraction failed: ${error.message}`);
+    }
+  }
+
+  async extractFromUrl(url) {
+    try {
+      const response = await fetch(url, {
+        headers: {
+          'User-Agent': this.getUserAgent(),
+          'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+          'Accept-Language': 'en-US,en;q=0.5',
+          'Accept-Encoding': 'gzip, deflate',
+          'Connection': 'keep-alive',
+          'Upgrade-Insecure-Requests': '1',
+        }
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}: ${response.statusText}`);
+      }
+
+      const html = await response.text();
+      return await this.extractContent(html, url);
+    } catch (error) {
+      console.error('Failed to fetch URL:', error);
+      throw new Error(`Failed to fetch URL: ${error.message}`);
+    }
+  }
+
+  generateCacheKey(html, url) {
+    let hash = 0;
+    for (let i = 0; i < html.length; i++) {
+      const char = html.charCodeAt(i);
+      hash = ((hash << 5) - hash) + char;
+      hash = hash & hash;
+    }
+    return `${url}_${hash}`;
+  }
+
+  cleanContent(article) {
+    if (!article) return null;
+
+    const content = {
+      title: article.title || '',
+      content: article.content || '',
+      textContent: article.textContent || '',
+      excerpt: article.excerpt || '',
+      byline: article.byline || '',
+      length: article.length || 0,
+      siteName: this.extractSiteName(article) || '',
+      publishedTime: this.extractPublishedTime(article) || '',
+      language: this.detectLanguage(article.textContent) || 'en',
+      readingTime: this.calculateReadingTime(article.textContent)
+    };
+
+    content.content = this.optimizeForMobile(content.content);
+
+    return content;
+  }
+
+  optimizeForMobile(html) {
+    if (!html) return '';
+
+    let optimized = html
+      .replace(/<img[^>]+srcset="[^"]*"[^>]*>/gi, '')
+      .replace(/<img[^>]+sizes="[^"]*"[^>]*>/gi, '')
+      .replace(/<iframe[^>]*>.*?<\/iframe>/gi, '')
+      .replace(/<script[^>]*>.*?<\/script>/gi, '')
+      .replace(/<style[^>]*>.*?<\/style>/gi, '');
+
+    optimized = optimized
+      .replace(/<div[^>]*>/gi, '')
+      .replace(/<\/div>/gi, '')
+      .replace(/<span[^>]*>/gi, '')
+      .replace(/<\/span>/gi, '');
+
+    return optimized;
+  }
+
+  extractSiteName(article) {
+    if (article.siteName) return article.siteName;
+    
+    try {
+      const url = new URL(article.url || '');
+      return url.hostname.replace('www.', '');
+    } catch (e) {
+      return '';
+    }
+  }
+
+  extractPublishedTime(article) {
+    return '';
+  }
+
+  detectLanguage(text) {
+    const englishWords = ['the', 'and', 'of', 'to', 'a', 'in', 'is', 'it'];
+    const wordCount = englishWords.filter(word => 
+      text.toLowerCase().includes(` ${word} `)
+    ).length;
+    
+    return wordCount > 3 ? 'en' : 'unknown';
+  }
+
+  calculateReadingTime(text) {
+    const wordsPerMinute = 200;
+    const wordCount = text.split(/\s+/).length;
+    return Math.ceil(wordCount / wordsPerMinute);
+  }
+
+  getUserAgent() {
+    if (Platform.OS === 'ios') {
+      return 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1';
+    } else {
+      return 'Mozilla/5.0 (Linux; Android 10; SM-G981B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36';
+    }
+  }
+
+  clearCache() {
+    this.cache.clear();
+  }
+
+  getCacheStats() {
+    return {
+      size: this.cache.size,
+      keys: Array.from(this.cache.keys())
+    };
+  }
+}
+
+export default new ReadabilityService();

--- a/src/services/treeOfThought.js
+++ b/src/services/treeOfThought.js
@@ -1,0 +1,174 @@
+import LLMService from './llmService';
+
+export class TreeOfThoughtReasoner {
+    constructor() {
+        this.maxBranches = 5;
+        this.maxDepth = 3;
+        this.evaluationThreshold = 0.7;
+    }
+
+    async solveComplexProblem(problem, options = {}) {
+        const {
+            maxBranches = this.maxBranches,
+            maxDepth = this.maxDepth,
+            evaluationThreshold = this.evaluationThreshold
+        } = options;
+
+        // Initialize the tree with the root problem
+        const rootNode = {
+            thought: problem,
+            evaluation: 0,
+            children: [],
+            depth: 0
+        };
+
+        // Develop the tree through iterative expansion
+        await this.expandTree(rootNode, maxBranches, maxDepth, evaluationThreshold);
+
+        // Find the best solution path
+        const bestSolution = this.findBestSolution(rootNode);
+        
+        return {
+            solution: bestSolution.thought,
+            confidence: bestSolution.evaluation,
+            reasoningTree: rootNode,
+            fullExplanation: this.generateExplanation(rootNode, bestSolution)
+        };
+    }
+
+    async expandTree(node, maxBranches, maxDepth, evaluationThreshold) {
+        if (node.depth >= maxDepth || node.evaluation >= evaluationThreshold) {
+            return;
+        }
+
+        // Generate candidate thoughts
+        const candidateThoughts = await this.generateCandidateThoughts(node.thought, maxBranches);
+        
+        // Evaluate each candidate
+        for (const thought of candidateThoughts) {
+            const evaluation = await this.evaluateThought(thought, node.thought);
+            
+            const childNode = {
+                thought,
+                evaluation,
+                children: [],
+                depth: node.depth + 1,
+                parent: node
+            };
+
+            node.children.push(childNode);
+
+            // Recursively expand promising branches
+            if (evaluation > evaluationThreshold * 0.6) {
+                await this.expandTree(childNode, maxBranches, maxDepth, evaluationThreshold);
+            }
+        }
+
+        // Sort children by evaluation score
+        node.children.sort((a, b) => b.evaluation - a.evaluation);
+    }
+
+    async generateCandidateThoughts(currentThought, maxCandidates) {
+        const prompt = `Given the current thought: "${currentThought}"
+
+Generate ${maxCandidates} diverse alternative approaches or next steps. Format as a numbered list:`;
+
+        try {
+            const response = await LLMService.generate(prompt, 200, 0.8);
+            return this.parseNumberedList(response.text).slice(0, maxCandidates);
+        } catch (error) {
+            console.error('Failed to generate candidate thoughts:', error);
+            return this.generateFallbackCandidates(currentThought, maxCandidates);
+        }
+    }
+
+    parseNumberedList(text) {
+        return text.split('\n')
+            .filter(line => /^\d+[\.\)]/.test(line))
+            .map(line => line.replace(/^\d+[\.\)]\s*/, '').trim())
+            .filter(thought => thought.length > 0);
+    }
+
+    generateFallbackCandidates(thought, maxCandidates) {
+        // Fallback candidates for when LLM generation fails
+        const baseCandidates = [
+            `Consider alternative perspectives on: ${thought}`,
+            `Break down the problem: ${thought} into smaller components`,
+            `What are the assumptions behind: ${thought}`,
+            `Consider the opposite of: ${thought}`,
+            `How would an expert approach: ${thought}`
+        ];
+        
+        return baseCandidates.slice(0, maxCandidates);
+    }
+
+    async evaluateThought(thought, context) {
+        const prompt = `Evaluate the quality of this thought in the context of solving: "${context}"
+
+Thought to evaluate: "${thought}"
+
+Rate on a scale of 0.0 to 1.0 considering:
+- Relevance to the problem
+- Novelty and creativity
+- Practical feasibility
+- Logical coherence
+
+Provide only the numerical rating:`;
+
+        try {
+            const response = await LLMService.generate(prompt, 10, 0.1);
+            const rating = parseFloat(response.text.trim());
+            return isNaN(rating) ? 0.5 : Math.max(0, Math.min(1, rating));
+        } catch (error) {
+            console.error('Failed to evaluate thought:', error);
+            return 0.5; // Default neutral rating
+        }
+    }
+
+    findBestSolution(node) {
+        if (node.children.length === 0) {
+            return node;
+        }
+
+        // Find the best child and continue down that path
+        const bestChild = node.children[0];
+        return this.findBestSolution(bestChild);
+    }
+
+    generateExplanation(rootNode, solutionNode) {
+        let currentNode = solutionNode;
+        const path = [];
+        
+        // Trace back the solution path
+        while (currentNode && currentNode !== rootNode) {
+            path.unshift(currentNode.thought);
+            currentNode = currentNode.parent;
+        }
+        
+        return `Solution developed through ${path.length} steps of reasoning:\n\n${path.map((thought, index) => `Step ${index + 1}: ${thought}`).join('\n\n')}\n\nFinal solution confidence: ${(solutionNode.evaluation * 100).toFixed(1)}%`;
+    }
+
+    async parallelTreeSearch(problem, numTrees = 3) {
+        // Run multiple tree searches in parallel for better exploration
+        const trees = [];
+        
+        for (let i = 0; i < numTrees; i++) {
+            trees.push(this.solveComplexProblem(problem, {
+                maxBranches: Math.floor(this.maxBranches / numTrees),
+                maxDepth: this.maxDepth
+            }));
+        }
+        
+        const results = await Promise.allSettled(trees);
+        const successfulResults = results
+            .filter(r => r.status === 'fulfilled')
+            .map(r => r.value);
+        
+        if (successfulResults.length === 0) {
+            throw new Error('All tree searches failed');
+        }
+        
+        // Return the best solution across all trees
+        return successfulResults.sort((a, b) => b.confidence - a.confidence)[0];
+    }
+}

--- a/src/services/utils/apiKeys.js
+++ b/src/services/utils/apiKeys.js
@@ -1,0 +1,62 @@
+import { NativeModules } from 'react-native';
+
+const CONFIG = NativeModules.Config || {};
+
+export async function getApiKeys() {
+  return {
+    googleApiKey: CONFIG.GOOGLE_API_KEY,
+    googleSearchEngineId: CONFIG.GOOGLE_SEARCH_ENGINE_ID,
+    bingApiKey: CONFIG.BING_API_KEY,
+    braveApiKey: CONFIG.BRAVE_API_KEY,
+  };
+}
+
+export async function validateApiKeys(provider) {
+  const keys = await getApiKeys();
+  switch (provider) {
+    case 'google':
+      return !!(keys.googleApiKey && keys.googleSearchEngineId);
+    case 'bing':
+      return !!keys.bingApiKey;
+    case 'brave':
+      return !!keys.braveApiKey;
+    case 'duckduckgo':
+      return true;
+    default:
+      return false;
+  }
+}
+
+export async function setApiKey(provider, key, additional = {}) {
+  switch (provider) {
+    case 'google':
+      CONFIG.GOOGLE_API_KEY = key;
+      if (additional.searchEngineId) {
+        CONFIG.GOOGLE_SEARCH_ENGINE_ID = additional.searchEngineId;
+      }
+      break;
+    case 'bing':
+      CONFIG.BING_API_KEY = key;
+      break;
+    case 'brave':
+      CONFIG.BRAVE_API_KEY = key;
+      break;
+    default:
+      break;
+  }
+  return true;
+}
+
+export async function getApiKey(provider) {
+  const keys = await getApiKeys();
+  switch (provider) {
+    case 'google':
+      return { apiKey: keys.googleApiKey, searchEngineId: keys.googleSearchEngineId };
+    case 'bing':
+      return { apiKey: keys.bingApiKey };
+    case 'brave':
+      return { apiKey: keys.braveApiKey };
+    default:
+      return null;
+  }
+}

--- a/src/services/utils/timeRange.js
+++ b/src/services/utils/timeRange.js
@@ -1,0 +1,19 @@
+export const googleTimeRange = {
+  day: 'd1',
+  week: 'w1',
+  month: 'm1',
+  year: 'y1'
+};
+
+export const bingTimeRange = {
+  day: 'Day',
+  week: 'Week',
+  month: 'Month'
+};
+
+export const braveTimeRange = {
+  day: 'pd',
+  week: 'pw',
+  month: 'pm',
+  year: 'py'
+};

--- a/src/services/webSearchService.js
+++ b/src/services/webSearchService.js
@@ -1,0 +1,87 @@
+import ReadabilityService from './readabilityService';
+import * as google from './providers/google';
+import * as bing from './providers/bing';
+import * as duckduckgo from './providers/duckduckgo';
+import * as brave from './providers/brave';
+import { validateApiKeys, setApiKey, getApiKey } from './utils/apiKeys';
+
+const PROVIDERS = { google, bing, duckduckgo, brave };
+const searchCache = new Map();
+const RATE_LIMIT_DELAY = 1000;
+
+export class SearchService {
+  constructor() {
+    this.lastRequestTimes = new Map();
+  }
+
+  async performSearch(providerName, query, maxResults, timeRange, safeSearch) {
+    const provider = PROVIDERS[providerName];
+    if (!provider) throw new Error(`Unknown search provider: ${providerName}`);
+    if (!(await provider.validateKey())) {
+      throw new Error(`API key not configured for ${providerName} search`);
+    }
+
+    const cacheKey = `${providerName}:${query}:${maxResults}:${timeRange}:${safeSearch}`;
+    const cached = searchCache.get(cacheKey);
+    if (cached && Date.now() - cached.timestamp < 5 * 60 * 1000) {
+      return cached.results;
+    }
+
+    const last = this.lastRequestTimes.get(providerName) || 0;
+    const wait = RATE_LIMIT_DELAY - (Date.now() - last);
+    if (wait > 0) {
+      await new Promise(resolve => setTimeout(resolve, wait));
+    }
+
+    const results = await provider.search(query, { maxResults, timeRange, safeSearch });
+    this.lastRequestTimes.set(providerName, Date.now());
+    searchCache.set(cacheKey, { results, timestamp: Date.now() });
+    this.cleanupCache();
+    return results;
+  }
+
+  async performSearchWithContentExtraction(provider, query, maxResults, timeRange, safeSearch, extractContent = true) {
+    const results = await this.performSearch(provider, query, maxResults, timeRange, safeSearch);
+    if (!extractContent) return results;
+    const enhanced = [];
+    for (const result of results) {
+      try {
+        const content = await ReadabilityService.extractFromUrl(result.url);
+        enhanced.push({ ...result, extractedContent: content, contentExtracted: true });
+      } catch (error) {
+        console.error(`Failed to extract content from ${result.url}:`, error);
+        enhanced.push({ ...result, extractedContent: null, contentExtracted: false, extractionError: error.message });
+      }
+    }
+    return enhanced;
+  }
+
+  cleanupCache() {
+    const now = Date.now();
+    for (const [key, value] of searchCache.entries()) {
+      if (now - value.timestamp > 30 * 60 * 1000) {
+        searchCache.delete(key);
+      }
+    }
+  }
+
+  clearCache() {
+    searchCache.clear();
+  }
+}
+
+export class ApiKeyManager {
+  static async setApiKey(provider, key, additionalData = null) {
+    return setApiKey(provider, key, additionalData || {});
+  }
+
+  static async getApiKey(provider) {
+    return getApiKey(provider);
+  }
+
+  static async hasApiKey(provider) {
+    return validateApiKeys(provider);
+  }
+}
+
+export const searchService = new SearchService();

--- a/src/tools/webSearchTool.js
+++ b/src/tools/webSearchTool.js
@@ -1,0 +1,81 @@
+import { searchService } from '../services/webSearchService';
+import { validateApiKeys } from '../services/utils/apiKeys';
+
+export const webSearchTool = {
+    description: 'Search the web for information using multiple providers',
+    parameters: {
+        query: {
+            type: 'string',
+            required: true,
+            description: 'Search query'
+        },
+        maxResults: {
+            type: 'number',
+            required: false,
+            description: 'Maximum number of results to return',
+            default: 5,
+            validate: value => value > 0 && value <= 20
+        },
+        provider: {
+            type: 'string',
+            required: false,
+            description: 'Search provider to use',
+            enum: ['google', 'bing', 'duckduckgo', 'brave'],
+            default: 'google'
+        },
+        timeRange: {
+            type: 'string',
+            required: false,
+            description: 'Time range for results',
+            enum: ['day', 'week', 'month', 'year', 'any'],
+            default: 'any'
+        },
+        safeSearch: {
+            type: 'boolean',
+            required: false,
+            description: 'Enable safe search filtering',
+            default: true
+        },
+        extractContent: {
+            type: 'boolean',
+            required: false,
+            description: 'Whether to extract readable content from search results',
+            default: true
+        }
+    },
+    execute: async (parameters, context) => {
+        const { 
+            query, 
+            maxResults = 5, 
+            provider = 'google', 
+            timeRange = 'any',
+            safeSearch = true,
+            extractContent = true
+        } = parameters;
+        
+        try {
+            if (!await validateApiKeys(provider)) {
+                throw new Error(`API key not configured for ${provider} search`);
+            }
+
+            const results = await searchService.performSearchWithContentExtraction(
+                provider, query, maxResults, timeRange, safeSearch, extractContent
+            );
+
+            return {
+                results: results.slice(0, maxResults),
+                provider,
+                query,
+                success: true
+            };
+        } catch (error) {
+            console.error('Web search failed:', error);
+            return {
+                error: error.message,
+                provider,
+                query,
+                success: false
+            };
+        }
+    }
+};

--- a/src/utils/deviceUtils.js
+++ b/src/utils/deviceUtils.js
@@ -1,0 +1,166 @@
+import { Platform, NativeModules } from 'react-native';
+
+export function getDeviceProfile() {
+    let totalMemory;
+    let processorCores;
+    let isLowEndDevice = false;
+    
+    try {
+        if (Platform.OS === 'ios') {
+            totalMemory = NativeModules.DeviceInfo?.getTotalMemory?.();
+            processorCores = NativeModules.DeviceInfo?.getProcessorCount?.();
+
+            if (!totalMemory) {
+                console.warn('[DeviceProfile] getTotalMemory unavailable, using fallback value 4000MB');
+                totalMemory = 4000;
+            }
+            if (!processorCores) {
+                console.warn('[DeviceProfile] getProcessorCount unavailable, using fallback value 4 cores');
+                processorCores = 4;
+            }
+        } else {
+            totalMemory = NativeModules.DeviceInfo?.totalMemory?.();
+            processorCores = NativeModules.DeviceInfo?.processorCores?.();
+
+            if (!totalMemory) {
+                console.warn('[DeviceProfile] totalMemory unavailable, using fallback value 4000MB');
+                totalMemory = 4000;
+            }
+            if (!processorCores) {
+                console.warn('[DeviceProfile] processorCores unavailable, using fallback value 4 cores');
+                processorCores = 4;
+            }
+        }
+        
+        // Determine device tier based on memory and processor
+        let tier = 'low';
+        if (totalMemory >= 6000 && processorCores >= 6) {
+            tier = 'high';
+        } else if (totalMemory >= 3000 && processorCores >= 4) {
+            tier = 'mid';
+        } else {
+            tier = 'low';
+            isLowEndDevice = true;
+        }
+        
+        return {
+            tier,
+            totalMemory,
+            processorCores,
+            isLowEndDevice,
+            platform: Platform.OS,
+            isQuantized: totalMemory < 4000 // Use quantized models on lower memory devices
+        };
+    } catch (error) {
+        console.error('Failed to get device profile:', error);
+        
+        // Return default profile
+        return {
+            tier: 'low',
+            totalMemory: 2000,
+            processorCores: 2,
+            isLowEndDevice: true,
+            platform: Platform.OS,
+            isQuantized: true
+        };
+    }
+}
+
+export function getPerformanceMode(deviceProfile, batteryLevel = 1.0, thermalState = 'nominal') {
+    const { tier, isLowEndDevice } = deviceProfile;
+    
+    // Base mode based on device tier
+    let mode = 'balanced';
+    if (tier === 'high') {
+        mode = 'performance';
+    } else if (isLowEndDevice) {
+        mode = 'power-saving';
+    }
+    
+    // Adjust based on battery level
+    if (batteryLevel < 0.2) {
+        mode = 'power-saving';
+    } else if (batteryLevel < 0.5 && mode === 'performance') {
+        mode = 'balanced';
+    }
+    
+    // Adjust based on thermal state
+    if (thermalState === 'serious' || thermalState === 'critical') {
+        mode = 'power-saving';
+    } else if (thermalState === 'fair' && mode === 'performance') {
+        mode = 'balanced';
+    }
+    
+    return mode;
+}
+
+export function getRecommendedModelConfig(deviceProfile) {
+    const { tier, totalMemory, isQuantized } = deviceProfile;
+    
+    if (tier === 'high') {
+        return {
+            modelSize: '7B',
+            quantization: isQuantized ? 'Q4_K_M' : 'none',
+            contextSize: 8192,
+            maxBatchSize: 8
+        };
+    } else if (tier === 'mid') {
+        return {
+            modelSize: '3B',
+            quantization: 'Q4_K_S',
+            contextSize: 4096,
+            maxBatchSize: 4
+        };
+    } else {
+        return {
+            modelSize: '1B',
+            quantization: 'Q4_0',
+            contextSize: 2048,
+            maxBatchSize: 2
+        };
+    }
+}
+
+export function formatBytes(bytes, decimals = 2) {
+    if (bytes === 0) return '0 Bytes';
+
+    const k = 1024;
+    const dm = decimals < 0 ? 0 : decimals;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+
+    let i = Math.floor(Math.log(bytes) / Math.log(k));
+    if (i >= sizes.length) {
+        i = sizes.length - 1;
+    }
+
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+}
+
+export function formatMilliseconds(ms, decimals = 1) {
+    if (ms < 0) {
+        return 'Invalid duration';
+    }
+    if (ms < 1000) {
+        return ms.toFixed(decimals) + 'ms';
+    } else if (ms < 60000) {
+        return (ms / 1000).toFixed(decimals) + 's';
+    } else {
+        return (ms / 60000).toFixed(decimals) + 'min';
+    }
+}
+
+export function isDeviceCompatible(minRequirements = {}) {
+    const {
+        minMemory = 2000,
+        minProcessorCores = 2,
+        platforms = ['ios', 'android']
+    } = minRequirements;
+    
+    const deviceProfile = getDeviceProfile();
+    
+    return (
+        deviceProfile.totalMemory >= minMemory &&
+        deviceProfile.processorCores >= minProcessorCores &&
+        platforms.includes(deviceProfile.platform)
+    );
+}

--- a/src/utils/hnswVectorStore.js
+++ b/src/utils/hnswVectorStore.js
@@ -1,0 +1,544 @@
+import SQLite from 'react-native-sqlite-storage';
+import { cosineSimilarity, quantizeVector } from './vectorUtils';
+
+const HNSW_DEFAULTS = {
+    m: 16,
+    efConstruction: 100,
+    efSearch: 50,
+    maxLayer: null,
+    quantization: 'scalar'
+};
+
+export class HNSWVectorStore {
+    constructor() {
+        this.db = null;
+        this.initialized = false;
+        this.index = {
+            layers: [],
+            entryPoint: null,
+            maxLayer: 0
+        };
+        this.config = { ...HNSW_DEFAULTS };
+        this.nodeMap = new Map();
+    }
+
+    async initialize(config = {}) {
+        if (this.initialized) return;
+        
+        this.config = { ...this.config, ...config };
+        
+        try {
+            this.db = await SQLite.openDatabase({
+                name: 'hnsw_vectorstore.db',
+                location: 'default',
+                createFromLocation: 1
+            });
+            
+            await this.db.executeSql('PRAGMA foreign_keys = ON;');
+            
+            await this._createTables();
+            await this._loadIndex();
+            
+            this.initialized = true;
+            console.log('HNSW Vector Store initialized');
+        } catch (error) {
+            console.error('Failed to initialize HNSW Vector Store:', error);
+            throw error;
+        }
+    }
+
+    async _createTables() {
+        await this.db.executeSql(`
+            CREATE TABLE IF NOT EXISTS vectors (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                content TEXT NOT NULL,
+                metadata TEXT,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+        `);
+        
+        await this.db.executeSql(`
+            CREATE TABLE IF NOT EXISTS vector_data (
+                id INTEGER PRIMARY KEY,
+                vector BLOB NOT NULL,
+                quantized BLOB,
+                FOREIGN KEY (id) REFERENCES vectors (id) ON DELETE CASCADE
+            )
+        `);
+        
+        await this.db.executeSql(`
+            CREATE TABLE IF NOT EXISTS hnsw_layers (
+                layer INTEGER NOT NULL,
+                node_id INTEGER NOT NULL,
+                connections TEXT NOT NULL,
+                PRIMARY KEY (layer, node_id)
+            )
+        `);
+        
+        await this.db.executeSql(`
+            CREATE TABLE IF NOT EXISTS hnsw_config (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            )
+        `);
+        
+        await this.db.executeSql(`
+            CREATE INDEX IF NOT EXISTS idx_hnsw_layers_node 
+            ON hnsw_layers (node_id)
+        `);
+    }
+
+    async _loadIndex() {
+        const [configResults] = await this.db.executeSql(
+            'SELECT * FROM hnsw_config'
+        );
+        
+        const configRows = configResults.rows.raw();
+        configRows.forEach(row => {
+            if (row.key === 'entryPoint') {
+                this.index.entryPoint = parseInt(row.value);
+            } else if (row.key === 'maxLayer') {
+                this.index.maxLayer = parseInt(row.value);
+                this.config.maxLayer = this.index.maxLayer;
+            } else {
+                this.config[row.key] = JSON.parse(row.value);
+            }
+        });
+        
+        this.index.layers = new Array(this.index.maxLayer + 1).fill().map(() => new Map());
+        
+        const [layerResults] = await this.db.executeSql(
+            'SELECT * FROM hnsw_layers ORDER BY layer'
+        );
+        
+        layerResults.rows.raw().forEach(row => {
+            const layer = parseInt(row.layer);
+            const node_id = parseInt(row.node_id);
+            const connections = JSON.parse(row.connections);
+            
+            if (!this.index.layers[layer]) {
+                this.index.layers[layer] = new Map();
+            }
+            
+            this.index.layers[layer].set(node_id, connections);
+        });
+        
+        if (this.nodeMap.size === 0) {
+            await this._loadNodeMap();
+        }
+    }
+
+    async _loadNodeMap() {
+        const [vectorResults] = await this.db.executeSql(`
+            SELECT v.id, v.content, v.metadata, vd.vector 
+            FROM vectors v 
+            JOIN vector_data vd ON v.id = vd.id
+        `);
+        
+        vectorResults.rows.raw().forEach(row => {
+            const blob = new Uint8Array(row.vector);
+            const vector = new Float32Array(blob.buffer);
+            this.nodeMap.set(row.id, {
+                content: row.content,
+                metadata: JSON.parse(row.metadata || '{}'),
+                vector: Array.from(vector)
+            });
+        });
+    }
+
+    async addVector(content, vector, metadata = {}) {
+        if (!this.initialized) await this.initialize();
+        
+        try {
+            const [result] = await this.db.executeSql(
+                'INSERT INTO vectors (content, metadata) VALUES (?, ?)',
+                [content, JSON.stringify(metadata)]
+            );
+            const id = result.insertId;
+            
+            const quantizedVector = this._quantizeVector(vector);
+            
+            const buffer = new ArrayBuffer(vector.length * 4);
+            const view = new Float32Array(buffer);
+            vector.forEach((v, i) => view[i] = v);
+            
+            let quantizedBlob = null;
+            if (quantizedVector) {
+                const quantizedBuffer = new ArrayBuffer(quantizedVector.length);
+                const quantizedView = new Uint8Array(quantizedBuffer);
+                quantizedVector.forEach((v, i) => quantizedView[i] = v);
+                quantizedBlob = quantizedView;
+            }
+            
+            await this.db.executeSql(
+                'INSERT INTO vector_data (id, vector, quantized) VALUES (?, ?, ?)',
+                [id, new Uint8Array(buffer), quantizedBlob]
+            );
+            
+            await this._addToIndex(id, vector);
+            
+            return id;
+        } catch (error) {
+            console.error('Failed to add vector to HNSW:', error);
+            throw error;
+        }
+    }
+
+    _quantizeVector(vector) {
+        if (this.config.quantization === 'none') return null;
+        
+        if (this.config.quantization === 'scalar') {
+            return quantizeVector(vector);
+        }
+        
+        return null;
+    }
+
+    async _addToIndex(id, vector) {
+        const layer = this._getRandomLayer();
+        
+        if (this.index.entryPoint === null) {
+            this.index.entryPoint = id;
+            this.index.maxLayer = layer;
+            this.config.maxLayer = this.index.maxLayer;
+            
+            await this._saveConfig();
+            return;
+        }
+        
+        let currNode = this.index.entryPoint;
+        let currLayer = Math.min(this.index.maxLayer, layer);
+        
+        while (currLayer > layer) {
+            currNode = await this._searchLayer(vector, currNode, currLayer, 1);
+            currLayer--;
+        }
+        
+        for (let l = Math.min(layer, this.index.maxLayer); l >= 0; l--) {
+            const neighbors = await this._searchLayer(vector, currNode, l, this.config.efConstruction);
+            await this._insertNodeAtLayer(id, vector, l, neighbors);
+            
+            if (l === this.index.maxLayer && neighbors.length > 0) {
+                this.index.maxLayer = l + 1;
+                this.config.maxLayer = this.index.maxLayer;
+                await this._saveConfig();
+            }
+        }
+    }
+
+    _getRandomLayer() {
+        return Math.min(
+            Math.floor(-Math.log(Math.random()) * Math.log(this.config.m)),
+            this.config.maxLayer || 16
+        );
+    }
+
+    async _searchLayer(queryVector, enterPoint, layer, ef) {
+        const visited = new Set();
+        const candidates = new PriorityQueue((a, b) => 
+            cosineSimilarity(queryVector, this.nodeMap.get(a).vector) > 
+            cosineSimilarity(queryVector, this.nodeMap.get(b).vector)
+        );
+        const results = new PriorityQueue((a, b) => 
+            cosineSimilarity(queryVector, this.nodeMap.get(a).vector) > 
+            cosineSimilarity(queryVector, this.nodeMap.get(b).vector)
+        );
+        
+        visited.add(enterPoint);
+        candidates.add(enterPoint);
+        results.add(enterPoint);
+        
+        while (candidates.size() > 0) {
+            const current = candidates.poll();
+            const currentVector = this.nodeMap.get(current).vector;
+            const currentSimilarity = cosineSimilarity(queryVector, currentVector);
+            
+            if (results.size() >= ef && currentSimilarity < results.peekPriority()) {
+                break;
+            }
+            
+            const connections = this.index.layers[layer].get(current) || [];
+            
+            for (const neighborId of connections) {
+                if (!visited.has(neighborId)) {
+                    visited.add(neighborId);
+                    const neighborVector = this.nodeMap.get(neighborId).vector;
+                    const neighborSimilarity = cosineSimilarity(queryVector, neighborVector);
+                    
+                    candidates.add(neighborId, neighborSimilarity);
+                    
+                    if (results.size() < ef || neighborSimilarity > results.peekPriority()) {
+                        results.add(neighborId, neighborSimilarity);
+                        if (results.size() > ef) {
+                            results.poll();
+                        }
+                    }
+                }
+            }
+        }
+        
+        return results.toArray().map(item => item.value);
+    }
+
+    async _insertNodeAtLayer(nodeId, vector, layer, neighbors) {
+        if (!this.index.layers[layer]) {
+            this.index.layers[layer] = new Map();
+        }
+        
+        this.index.layers[layer].set(nodeId, [...neighbors]);
+        
+        for (const neighborId of neighbors) {
+            const neighborConnections = this.index.layers[layer].get(neighborId) || [];
+            neighborConnections.push(nodeId);
+            
+            if (neighborConnections.length > this.config.m) {
+                const trimmed = await this._searchLayer(
+                    this.nodeMap.get(neighborId).vector,
+                    neighborId,
+                    layer,
+                    this.config.m
+                );
+                this.index.layers[layer].set(neighborId, trimmed);
+            } else {
+                this.index.layers[layer].set(neighborId, neighborConnections);
+            }
+        }
+        
+        await this.db.executeSql(
+            'INSERT OR REPLACE INTO hnsw_layers (layer, node_id, connections) VALUES (?, ?, ?)',
+            [layer, nodeId, JSON.stringify(neighbors)]
+        );
+    }
+
+    async searchVectors(queryVector, limit = 5) {
+        if (!this.initialized) await this.initialize();
+        
+        try {
+            let currNode = this.index.entryPoint;
+            let currLayer = this.index.maxLayer;
+            
+            while (currLayer >= 0) {
+                currNode = await this._searchLayer(
+                    queryVector, 
+                    currNode, 
+                    currLayer, 
+                    this.config.efSearch
+                )[0] || currNode;
+                currLayer--;
+            }
+            
+            const results = await this._searchLayer(
+                queryVector, 
+                currNode, 
+                0, 
+                Math.max(this.config.efSearch, limit * 2)
+            );
+            
+            const detailedResults = [];
+            for (const id of results.slice(0, limit * 2)) {
+                const node = this.nodeMap.get(id);
+                if (node) {
+                    const similarity = cosineSimilarity(queryVector, node.vector);
+                    detailedResults.push({
+                        id,
+                        content: node.content,
+                        metadata: node.metadata,
+                        similarity
+                    });
+                }
+            }
+            
+            return detailedResults
+                .sort((a, b) => b.similarity - a.similarity)
+                .slice(0, limit);
+        } catch (error) {
+            console.error('HNSW search failed:', error);
+            return this._fallbackSearch(queryVector, limit);
+        }
+    }
+
+    async _fallbackSearch(queryVector, limit = 5) {
+        const [results] = await this.db.executeSql(`
+            SELECT v.id, v.content, v.metadata, vd.vector 
+            FROM vectors v 
+            JOIN vector_data vd ON v.id = vd.id 
+            ORDER BY v.created_at DESC 
+            LIMIT 1000
+        `);
+        
+        const rows = results.rows.raw();
+        const similarities = [];
+        
+        for (const row of rows) {
+            const blob = new Uint8Array(row.vector);
+            const storedVector = new Float32Array(blob.buffer);
+            const similarity = cosineSimilarity(
+                queryVector, 
+                Array.from(storedVector)
+            );
+            
+            similarities.push({
+                id: row.id,
+                content: row.content,
+                metadata: JSON.parse(row.metadata || '{}'),
+                similarity
+            });
+        }
+        
+        return similarities
+            .sort((a, b) => b.similarity - a.similarity)
+            .slice(0, limit);
+    }
+
+    async _saveConfig() {
+        const operations = [
+            this.db.executeSql(
+                'INSERT OR REPLACE INTO hnsw_config (key, value) VALUES (?, ?)',
+                ['entryPoint', this.index.entryPoint.toString()]
+            ),
+            this.db.executeSql(
+                'INSERT OR REPLACE INTO hnsw_config (key, value) VALUES (?, ?)',
+                ['maxLayer', this.index.maxLayer.toString()]
+            ),
+            this.db.executeSql(
+                'INSERT OR REPLACE INTO hnsw_config (key, value) VALUES (?, ?)',
+                ['m', JSON.stringify(this.config.m)]
+            ),
+            this.db.executeSql(
+                'INSERT OR REPLACE INTO hnsw_config (key, value) VALUES (?, ?)',
+                ['efConstruction', JSON.stringify(this.config.efConstruction)]
+            ),
+            this.db.executeSql(
+                'INSERT OR REPLACE INTO hnsw_config (key, value) VALUES (?, ?)',
+                ['efSearch', JSON.stringify(this.config.efSearch)]
+            )
+        ];
+        
+        await Promise.all(operations);
+    }
+    
+    async clearVectors() {
+        if (!this.initialized) await this.initialize();
+        
+        try {
+            await this.db.executeSql('DELETE FROM vectors');
+            await this.db.executeSql('DELETE FROM vector_data');
+            await this.db.executeSql('DELETE FROM hnsw_layers');
+            await this.db.executeSql('DELETE FROM hnsw_config');
+            
+            this.index = {
+                layers: [],
+                entryPoint: null,
+                maxLayer: 0
+            };
+            this.nodeMap.clear();
+            
+            return true;
+        } catch (error) {
+            console.error('Failed to clear vectors:', error);
+            return false;
+        }
+    }
+    
+    async getVectorCount() {
+        if (!this.initialized) await this.initialize();
+        
+        try {
+            const [results] = await this.db.executeSql('SELECT COUNT(*) as count FROM vectors');
+            return results.rows.raw()[0].count;
+        } catch (error) {
+            console.error('Failed to get vector count:', error);
+            return 0;
+        }
+    }
+}
+
+class PriorityQueue {
+    constructor(comparator = (a, b) => a > b) {
+        this._heap = [];
+        this._comparator = comparator;
+    }
+    
+    size() {
+        return this._heap.length;
+    }
+    
+    isEmpty() {
+        return this.size() === 0;
+    }
+    
+    peek() {
+        return this._heap[0];
+    }
+    
+    peekPriority() {
+        return this._heap[0] ? this._heap[0].priority : -Infinity;
+    }
+    
+    add(value, priority = 1) {
+        this._heap.push({ value, priority });
+        this._siftUp();
+        return this;
+    }
+    
+    poll() {
+        const result = this.peek();
+        const last = this._heap.pop();
+        if (this.size() > 0) {
+            this._heap[0] = last;
+            this._siftDown();
+        }
+        return result;
+    }
+    
+    toArray() {
+        return [...this._heap];
+    }
+    
+    _siftUp() {
+        let nodeIdx = this.size() - 1;
+        while (nodeIdx > 0 && this._compare(nodeIdx, this._parent(nodeIdx))) {
+            this._swap(nodeIdx, this._parent(nodeIdx));
+            nodeIdx = this._parent(nodeIdx);
+        }
+    }
+    
+    _siftDown() {
+        let nodeIdx = 0;
+        while (
+            (this._left(nodeIdx) < this.size() && this._compare(this._left(nodeIdx), nodeIdx)) ||
+            (this._right(nodeIdx) < this.size() && this._compare(this._right(nodeIdx), nodeIdx))
+        ) {
+            const greaterChild = 
+                this._right(nodeIdx) < this.size() && 
+                this._compare(this._right(nodeIdx), this._left(nodeIdx)) 
+                    ? this._right(nodeIdx) 
+                    : this._left(nodeIdx);
+            this._swap(nodeIdx, greaterChild);
+            nodeIdx = greaterChild;
+        }
+    }
+    
+    _compare(i, j) {
+        return this._comparator(
+            this._heap[i].priority, 
+            this._heap[j].priority
+        );
+    }
+    
+    _swap(i, j) {
+        [this._heap[i], this._heap[j]] = [this._heap[j], this._heap[i]];
+    }
+    
+    _parent(i) {
+        return (i - 1) >> 1;
+    }
+    
+    _left(i) {
+        return (i << 1) + 1;
+    }
+    
+    _right(i) {
+        return (i + 1) << 1;
+    }
+}

--- a/src/utils/quantumSafeCrypto.js
+++ b/src/utils/quantumSafeCrypto.js
@@ -1,0 +1,201 @@
+import CryptoJS from 'crypto-js';
+import { kyber } from 'noble-post-quantum';
+
+let sharedSecret;
+let keyPair;
+
+export async function initCrypto() {
+    try {
+        keyPair = await kyber.keypair();
+        const capsule = await kyber.encapsulate(keyPair.publicKey);
+        sharedSecret = await kyber.decapsulate(capsule, keyPair.privateKey);
+        
+        return true;
+    } catch (error) {
+        console.error('Failed to initialize quantum-safe cryptography:', error);
+        
+        // Fallback to traditional encryption
+        sharedSecret = CryptoJS.lib.WordArray.random(32);
+        return false;
+    }
+}
+
+export async function encrypt(plaintext) {
+    if (!sharedSecret) {
+        await initCrypto();
+    }
+    
+    try {
+        // Use Kyber for quantum-safe encryption if available
+        if (keyPair && sharedSecret) {
+            const capsule = await kyber.encapsulate(keyPair.publicKey);
+            const encrypted = await _encryptWithKyber(plaintext, sharedSecret);
+            
+            return JSON.stringify({
+                capsule: Array.from(capsule),
+                encrypted: Array.from(encrypted),
+                algorithm: 'kyber'
+            });
+        } else {
+            // Fallback to AES encryption
+            const encrypted = CryptoJS.AES.encrypt(plaintext, sharedSecret.toString()).toString();
+            
+            return JSON.stringify({
+                encrypted,
+                algorithm: 'aes'
+            });
+        }
+    } catch (error) {
+        console.error('Encryption failed:', error);
+        throw new Error('Failed to encrypt data');
+    }
+}
+
+export async function decrypt(ciphertext) {
+    if (!sharedSecret) {
+        await initCrypto();
+    }
+    
+    try {
+        const data = JSON.parse(ciphertext);
+        
+        if (data.algorithm === 'kyber') {
+            const capsule = new Uint8Array(data.capsule);
+            const encrypted = new Uint8Array(data.encrypted);
+            
+            const secret = await kyber.decapsulate(capsule, keyPair.privateKey);
+            return await _decryptWithKyber(encrypted, secret);
+        } else {
+            // AES decryption
+            const bytes = CryptoJS.AES.decrypt(data.encrypted, sharedSecret.toString());
+            return bytes.toString(CryptoJS.enc.Utf8);
+        }
+    } catch (error) {
+        console.error('Decryption failed:', error);
+        throw new Error('Failed to decrypt data');
+    }
+}
+
+async function _encryptWithKyber(plaintext, secret) {
+    // Convert plaintext to bytes
+    const encoder = new TextEncoder();
+    const plaintextBytes = encoder.encode(plaintext);
+
+    // Ensure secret is a byte array
+    const secretBytes = secret instanceof Uint8Array ? secret : new Uint8Array(secret);
+    // Use the first 32 bytes of the secret as AES key
+    const aesKey = secretBytes.slice(0, 32);
+
+    // Generate a random IV
+    const iv = CryptoJS.lib.WordArray.random(16);
+
+    // Helper to convert WordArray to Uint8Array
+    const wordArrayToUint8Array = (wordArray) => {
+        const { words, sigBytes } = wordArray;
+        const result = new Uint8Array(sigBytes);
+        for (let i = 0; i < sigBytes; i++) {
+            result[i] = (words[i >>> 2] >>> (24 - (i % 4) * 8)) & 0xff;
+        }
+        return result;
+    };
+
+    // Encrypt with AES-CBC (CryptoJS doesn't natively support AES-GCM)
+    const encrypted = CryptoJS.AES.encrypt(
+        CryptoJS.lib.WordArray.create(plaintextBytes),
+        CryptoJS.lib.WordArray.create(aesKey),
+        { iv, mode: CryptoJS.mode.CBC, padding: CryptoJS.pad.Pkcs7 }
+    );
+
+    const ivBytes = wordArrayToUint8Array(iv);
+    const cipherBytes = wordArrayToUint8Array(encrypted.ciphertext);
+
+    // Combine IV and ciphertext
+    const result = new Uint8Array(ivBytes.length + cipherBytes.length);
+    result.set(ivBytes, 0);
+    result.set(cipherBytes, ivBytes.length);
+
+    return result;
+}
+
+async function _decryptWithKyber(encrypted, secret) {
+    try {
+        // Ensure secret is a byte array
+        const secretBytes = secret instanceof Uint8Array ? secret : new Uint8Array(secret);
+        // Use the first 32 bytes of the secret as AES key
+        const aesKey = secretBytes.slice(0, 32);
+
+        // Extract IV and ciphertext
+        const iv = encrypted.slice(0, 16);
+        const ciphertext = encrypted.slice(16);
+
+        const toWordArray = (arr) => CryptoJS.lib.WordArray.create(arr);
+
+        // Decrypt with AES-CBC
+        const decrypted = CryptoJS.AES.decrypt(
+            { ciphertext: toWordArray(ciphertext) },
+            toWordArray(aesKey),
+            { iv: toWordArray(iv), mode: CryptoJS.mode.CBC, padding: CryptoJS.pad.Pkcs7 }
+        );
+
+        // Convert back to string
+        return CryptoJS.enc.Utf8.stringify(decrypted);
+    } catch (error) {
+        console.error('Kyber decryption failed:', error);
+        throw new Error('Failed to decrypt with Kyber');
+    }
+}
+
+export async function rotateKeys() {
+    try {
+        const newKeyPair = await kyber.keypair();
+        const capsule = await kyber.encapsulate(newKeyPair.publicKey);
+        sharedSecret = await kyber.decapsulate(capsule, newKeyPair.privateKey);
+        keyPair = newKeyPair;
+        
+        return true;
+    } catch (error) {
+        console.error('Failed to rotate keys:', error);
+        return false;
+    }
+}
+
+export async function generateHash(data, algorithm = 'SHA3-256') {
+    try {
+        switch (algorithm) {
+            case 'SHA3-256':
+                return CryptoJS.SHA3(data, { outputLength: 256 }).toString();
+            case 'SHA3-512':
+                return CryptoJS.SHA3(data, { outputLength: 512 }).toString();
+            case 'SHA256':
+                return CryptoJS.SHA256(data).toString();
+            default:
+                return CryptoJS.SHA3(data, { outputLength: 256 }).toString();
+        }
+    } catch (error) {
+        console.error('Hash generation failed:', error);
+        throw new Error('Failed to generate hash');
+    }
+}
+
+export async function generateSignature(data, privateKey) {
+    try {
+        // In a real implementation, this would use a quantum-safe signature algorithm
+        // For now, we use HMAC with SHA3 as a placeholder
+        return CryptoJS.HmacSHA3(data, privateKey).toString();
+    } catch (error) {
+        console.error('Signature generation failed:', error);
+        throw new Error('Failed to generate signature');
+    }
+}
+
+export async function verifySignature(data, signature, publicKey) {
+    try {
+        // In a real implementation, this would verify a quantum-safe signature
+        // For now, we use HMAC with SHA3 as a placeholder
+        const expectedSignature = CryptoJS.HmacSHA3(data, publicKey).toString();
+        return expectedSignature === signature;
+    } catch (error) {
+        console.error('Signature verification failed:', error);
+        return false;
+    }
+}

--- a/src/utils/sparseAttention.js
+++ b/src/utils/sparseAttention.js
@@ -1,0 +1,222 @@
+import { cosineSimilarity, dotProduct } from './vectorUtils';
+
+export function applySparseAttention(queryVector, contextVectors, options = {}) {
+    const {
+        topK = 5,
+        threshold = 0.5,
+        useCosine = true,
+        numClusters = 3
+    } = options;
+    
+    if (!contextVectors || contextVectors.length === 0) {
+        return [];
+    }
+    
+    // Calculate attention scores
+    const scores = contextVectors.map((vector, index) => {
+        let score;
+        
+        if (useCosine) {
+            score = cosineSimilarity(queryVector, vector);
+        } else {
+            score = dotProduct(queryVector, vector);
+        }
+        
+        return { index, score };
+    });
+    
+    // Filter by threshold and sort by score
+    const filteredScores = scores
+        .filter(item => item.score >= threshold)
+        .sort((a, b) => b.score - a.score);
+    
+    // Return top K results
+    return filteredScores
+        .slice(0, topK)
+        .map(item => item.index);
+}
+
+export function applyBlockSparseAttention(queryVector, contextVectors, blockSize = 64) {
+    if (!contextVectors || contextVectors.length === 0) {
+        return [];
+    }
+    
+    const numBlocks = Math.ceil(contextVectors.length / blockSize);
+    const blockScores = [];
+    
+    // Calculate score for each block
+    for (let i = 0; i < numBlocks; i++) {
+        const start = i * blockSize;
+        const end = Math.min(start + blockSize, contextVectors.length);
+        
+        const blockVectors = contextVectors.slice(start, end);
+        const blockRepresentative = averageVectors(blockVectors);
+        
+        const score = cosineSimilarity(queryVector, blockRepresentative);
+        blockScores.push({ blockIndex: i, score, start, end });
+    }
+    
+    // Sort blocks by score and select top ones
+    blockScores.sort((a, b) => b.score - a.score);
+    const selectedBlocks = blockScores.slice(0, Math.ceil(numBlocks / 2));
+    
+    // Get all vectors from selected blocks
+    const selectedIndices = [];
+    for (const block of selectedBlocks) {
+        for (let i = block.start; i < block.end; i++) {
+            selectedIndices.push(i);
+        }
+    }
+    
+    return selectedIndices;
+}
+
+export function applyHierarchicalSparseAttention(queryVector, contextVectors, options = {}) {
+    const {
+        numClusters = 3,
+        topKPerCluster = 2
+    } = options;
+    
+    if (!contextVectors || contextVectors.length === 0) {
+        return [];
+    }
+    
+    // Cluster the context vectors
+    const clusters = clusterVectors(contextVectors, numClusters);
+    
+    // For each cluster, find the most relevant vectors to the query
+    const selectedIndices = [];
+    
+    for (const cluster of clusters) {
+        const clusterScores = cluster.indices.map(index => {
+            const score = cosineSimilarity(queryVector, contextVectors[index]);
+            return { index, score };
+        });
+        
+        clusterScores.sort((a, b) => b.score - a.score);
+        
+        // Add top K vectors from this cluster
+        selectedIndices.push(
+            ...clusterScores
+                .slice(0, topKPerCluster)
+                .map(item => item.index)
+        );
+    }
+    
+    return selectedIndices;
+}
+
+function clusterVectors(vectors, numClusters) {
+    if (vectors.length <= numClusters) {
+        return vectors.map((vector, index) => ({
+            centroid: vector,
+            indices: [index]
+        }));
+    }
+    
+    // K-means++ centroid initialization
+    let centroids = [];
+    // Pick the first centroid randomly
+    const firstIndex = Math.floor(Math.random() * vectors.length);
+    centroids.push(vectors[firstIndex]);
+
+    while (centroids.length < numClusters) {
+        // Compute squared distances to nearest centroid for each vector
+        const distances = vectors.map(vector => {
+            let minDist = Infinity;
+            for (const centroid of centroids) {
+                const dist = vector.reduce((sum, val, idx) => sum + Math.pow(val - centroid[idx], 2), 0);
+                if (dist < minDist) minDist = dist;
+            }
+            return minDist;
+        });
+
+        // Weighted random selection
+        const totalDist = distances.reduce((a, b) => a + b, 0);
+        let r = Math.random() * totalDist;
+        let nextIndex = 0;
+        for (let i = 0; i < distances.length; i++) {
+            r -= distances[i];
+            if (r <= 0) {
+                nextIndex = i;
+                break;
+            }
+        }
+        centroids.push(vectors[nextIndex]);
+    }
+    
+    let clusters = Array(numClusters).fill().map(() => ({ indices: [] }));
+    let changed = true;
+    let iterations = 0;
+    
+    while (changed && iterations < 10) {
+        // Reset clusters
+        clusters = Array(numClusters).fill().map(() => ({ indices: [] }));
+        
+        // Assign each vector to the nearest centroid
+        for (let i = 0; i < vectors.length; i++) {
+            let minDistance = Infinity;
+            let bestCluster = 0;
+            
+            for (let j = 0; j < numClusters; j++) {
+                const distance = euclideanDistance(vectors[i], centroids[j]);
+                if (distance < minDistance) {
+                    minDistance = distance;
+                    bestCluster = j;
+                }
+            }
+            
+            clusters[bestCluster].indices.push(i);
+        }
+        
+        // Update centroids
+        changed = false;
+        for (let j = 0; j < numClusters; j++) {
+            if (clusters[j].indices.length > 0) {
+                const newCentroid = averageVectors(
+                    clusters[j].indices.map(index => vectors[index])
+                );
+                
+                if (euclideanDistance(newCentroid, centroids[j]) > 0.001) {
+                    changed = true;
+                    centroids[j] = newCentroid;
+                }
+            }
+        }
+        
+        iterations++;
+    }
+    
+    // Add centroids to clusters
+    return clusters.map((cluster, i) => ({
+        centroid: centroids[i],
+        indices: cluster.indices
+    }));
+}
+
+function averageVectors(vectors) {
+    if (!vectors || vectors.length === 0) {
+        return [];
+    }
+    
+    const dimension = vectors[0].length;
+    const result = new Array(dimension).fill(0);
+    
+    for (const vector of vectors) {
+        for (let i = 0; i < dimension; i++) {
+            result[i] += vector[i];
+        }
+    }
+    
+    return result.map(sum => sum / vectors.length);
+}
+
+function euclideanDistance(vecA, vecB) {
+    if (!vecA || !vecB || vecA.length !== vecB.length) {
+        return Infinity;
+    }
+    
+    return Math.sqrt(
+        vecA.reduce((sum, a, i) => sum + Math.pow(a - vecB[i], 2), 0)
+    );
+}

--- a/src/utils/vectorUtils.js
+++ b/src/utils/vectorUtils.js
@@ -1,0 +1,129 @@
+export function cosineSimilarity(vecA, vecB) {
+    if (!vecA || !vecB || vecA.length !== vecB.length) {
+        return 0;
+    }
+    
+    const dotProduct = vecA.reduce((sum, a, i) => sum + a * vecB[i], 0);
+    const magnitudeA = Math.sqrt(vecA.reduce((sum, a) => sum + a * a, 0));
+    const magnitudeB = Math.sqrt(vecB.reduce((sum, b) => sum + b * b, 0));
+    
+    if (magnitudeA === 0 || magnitudeB === 0) {
+        return 0;
+    }
+    
+    return dotProduct / (magnitudeA * magnitudeB);
+}
+
+export function quantizeVector(vector, bits = 4) {
+    if (!vector || vector.length === 0) return [];
+
+    const maxVal = Math.max(...vector.map(Math.abs));
+    if (maxVal === 0) {
+        return new Array(vector.length).fill(0);
+    }
+    const scale = Math.pow(2, bits - 1) - 1;
+
+    return vector.map(val => {
+        const normalized = val / maxVal;
+        return Math.round(normalized * scale);
+    });
+}
+
+export function dequantizeVector(quantized, maxVal, bits = 4) {
+    if (!quantized || quantized.length === 0) return [];
+    if (typeof maxVal !== 'number' || maxVal === 0) return [];
+
+    const scale = Math.pow(2, bits - 1) - 1;
+
+    return quantized.map(qVal => {
+        return (qVal / scale) * maxVal;
+    });
+}
+
+export function normalizeVector(vector) {
+    if (!vector || vector.length === 0) return [];
+    
+    const magnitude = Math.sqrt(vector.reduce((sum, val) => sum + val * val, 0));
+    
+    if (magnitude === 0) return vector;
+    
+    return vector.map(val => val / magnitude);
+}
+
+export function euclideanDistance(vecA, vecB) {
+    if (!vecA || !vecB || vecA.length !== vecB.length) {
+        return Infinity;
+    }
+    
+    return Math.sqrt(
+        vecA.reduce((sum, a, i) => sum + Math.pow(a - vecB[i], 2), 0)
+    );
+}
+
+export function manhattanDistance(vecA, vecB) {
+    if (!vecA || !vecB || vecA.length !== vecB.length) {
+        return Infinity;
+    }
+    
+    return vecA.reduce((sum, a, i) => sum + Math.abs(a - vecB[i]), 0);
+}
+
+export function dotProduct(vecA, vecB) {
+    if (!vecA || !vecB || vecA.length !== vecB.length) {
+        return 0;
+    }
+    
+    return vecA.reduce((sum, a, i) => sum + a * vecB[i], 0);
+}
+
+export function vectorMagnitude(vector) {
+    if (!vector || vector.length === 0) {
+        return 0;
+    }
+    
+    return Math.sqrt(vector.reduce((sum, val) => sum + val * val, 0));
+}
+
+export function addVectors(vecA, vecB) {
+    if (!vecA || !vecB || vecA.length !== vecB.length) {
+        return [];
+    }
+    
+    return vecA.map((a, i) => a + vecB[i]);
+}
+
+export function subtractVectors(vecA, vecB) {
+    if (!vecA || !vecB || vecA.length !== vecB.length) {
+        return [];
+    }
+    
+    return vecA.map((a, i) => a - vecB[i]);
+}
+
+export function multiplyVectorByScalar(vector, scalar) {
+    if (!vector || vector.length === 0) {
+        return [];
+    }
+    
+    return vector.map(val => val * scalar);
+}
+
+export function averageVectors(vectors) {
+    if (!vectors || vectors.length === 0) {
+        return [];
+    }
+
+    const dimension = vectors[0].length;
+    const result = new Array(dimension).fill(0);
+
+    for (const vector of vectors) {
+        if (!vector || vector.length !== dimension) {
+            return [];
+        }
+        for (let i = 0; i < dimension; i++) {
+            result[i] += vector[i];
+        }
+    }
+    
+    return result.map(sum => sum / vectors.length);
+}


### PR DESCRIPTION
## Summary
- centralize API key configuration and split web search into provider modules with rate-limited caching
- serialize adaptive quantization updates and track KV cache tokens in the LLM service
- harden utilities by replacing eval with a safe expression parser, improving vector quantization, and validating external links

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acce1d40c08333b8d2bfd12734e17e