### PR TITLE
Add iOS Turbo Modules for calendar and messaging integration

### DIFF
--- a/ios/MyOfflineLLMApp/CalendarTurboModule.mm
+++ b/ios/MyOfflineLLMApp/CalendarTurboModule.mm
@@ -1,0 +1,54 @@
+#import <React/RCTBridgeModule.h>
+#import <EventKit/EventKit.h>
+
+@interface CalendarTurboModule : NSObject <RCTBridgeModule>
+@end
+
+@implementation CalendarTurboModule {
+  EKEventStore *_eventStore;
+}
+
+RCT_EXPORT_MODULE();
+
+RCT_REMAP_METHOD(createEvent,
+                 title:(NSString *)title
+                 date:(NSString *)isoDate
+                 location:(NSString *)location
+                 notes:(NSString *)notes
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  _eventStore = [[EKEventStore alloc] init];
+  [_eventStore requestAccessToEntityType:EKEntityTypeEvent completion:^(BOOL granted, NSError *error) {
+    if (!granted || error) {
+      reject(@"PERMISSION_DENIED", @"Access to calendar denied", error);
+      return;
+    }
+
+    EKEvent *event = [EKEvent eventWithEventStore:self->_eventStore];
+    event.title = title;
+
+    NSDateComponents *components = [[NSDateComponents alloc] init];
+    NSISO8601DateFormatter *formatter = [[NSISO8601DateFormatter alloc] init];
+    NSDate *startDate = [formatter dateFromString:isoDate];
+    if (!startDate) {
+      reject(@"DATE_ERROR", @"Invalid ISO date", nil);
+      return;
+    }
+    event.startDate = startDate;
+    event.endDate = [startDate dateByAddingTimeInterval:3600];
+    event.location = location;
+    event.notes = notes;
+    event.calendar = [self->_eventStore defaultCalendarForNewEvents];
+
+    NSError *saveError = nil;
+    [self->_eventStore saveEvent:event span:EKSpanThisEvent commit:YES error:&saveError];
+    if (saveError) {
+      reject(@"SAVE_ERROR", saveError.localizedDescription, saveError);
+    } else {
+      resolve(@{ @"success": @YES, @"eventId": event.eventIdentifier ?: @"" });
+    }
+  }];
+}
+
+@end

--- a/ios/MyOfflineLLMApp/MessagesTurboModule.mm
+++ b/ios/MyOfflineLLMApp/MessagesTurboModule.mm
@@ -1,0 +1,27 @@
+#import <React/RCTBridgeModule.h>
+#import <MessageUI/MessageUI.h>
+
+@interface MessagesTurboModule : NSObject <RCTBridgeModule>
+@end
+
+@implementation MessagesTurboModule
+
+RCT_EXPORT_MODULE();
+
+RCT_REMAP_METHOD(sendMessage,
+                 phoneNumber:(NSString *)phoneNumber
+                 body:(NSString *)body
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  if (![MFMessageComposeViewController canSendText]) {
+    reject(@"NOT_SUPPORTED", @"SMS not available", nil);
+    return;
+  }
+
+  NSDictionary *payload = @{ @"phoneNumber": phoneNumber, @"body": body };
+  [[NSNotificationCenter defaultCenter] postNotificationName:@"SendSMSNotification" object:nil userInfo:payload];
+  resolve(@{ @"success": @YES });
+}
+
+@end

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
 import LLMService from './services/llmService';
 import { ToolRegistry } from './architecture/toolSystem';
 import { builtInTools } from './architecture/toolSystem';
+import iosTools from './tools/iosTools';
 import { PluginManager } from './architecture/pluginManager';
 import { DependencyInjector } from './architecture/dependencyInjector';
 
@@ -22,6 +23,9 @@ function App() {
       // Initialize tool registry
       const toolRegistry = new ToolRegistry();
       Object.entries(builtInTools).forEach(([name, tool]) => {
+        toolRegistry.registerTool(name, tool);
+      });
+      Object.entries(iosTools).forEach(([name, tool]) => {
         toolRegistry.registerTool(name, tool);
       });
       

--- a/src/tools/iosTools.js
+++ b/src/tools/iosTools.js
@@ -1,0 +1,30 @@
+import { NativeModules } from 'react-native';
+
+const { CalendarTurboModule, MessagesTurboModule } = NativeModules;
+
+export const iosTools = {
+  createCalendarEvent: {
+    description: 'Create a new calendar event',
+    parameters: {
+      title: { type: 'string', required: true, description: 'Event title' },
+      date: { type: 'string', required: true, description: 'Start date in ISO 8601 format' },
+      notes: { type: 'string', required: false, description: 'Event notes' },
+      location: { type: 'string', required: false, description: 'Event location' }
+    },
+    execute: async ({ title, date, notes, location }) => {
+      return await CalendarTurboModule.createEvent(title, date, location || '', notes || '');
+    }
+  },
+  sendMessage: {
+    description: 'Send a text message to a phone number',
+    parameters: {
+      phoneNumber: { type: 'string', required: true, description: 'Recipient phone number' },
+      body: { type: 'string', required: true, description: 'Message body' }
+    },
+    execute: async ({ phoneNumber, body }) => {
+      return await MessagesTurboModule.sendMessage(phoneNumber, body);
+    }
+  }
+};
+
+export default iosTools;


### PR DESCRIPTION
## Summary
- integrate new Turbo Modules for iOS Calendar and Messages
- expose calendar event creation and SMS sending tools to JS
- register native tools with app's tool registry

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68aceba326708333863ae8dab0245054