### PR TITLE
Standardize generate API usage

### DIFF
--- a/android/app/src/main/java/com/myofflinellmapp/LlamaTurboModule.java
+++ b/android/app/src/main/java/com/myofflinellmapp/LlamaTurboModule.java
@@ -142,7 +142,9 @@ public class LlamaTurboModule extends ReactContextBaseJavaModule {
                     useSparseAttention = options.getBoolean("useSparseAttention");
                 }
             }
-            String result = nativeGenerate(mCtxPtr, prompt, maxTokens, temperature, useSparseAttention);
+            String resultText = nativeGenerate(mCtxPtr, prompt, maxTokens, temperature, useSparseAttention);
+            WritableMap result = new WritableNativeMap();
+            result.putString("text", resultText);
             promise.resolve(result);
         } catch (Exception e) {
             promise.reject("GENERATE_ERROR", "Generation failed: " + e.getMessage());

--- a/src/architecture/pluginSetup.js
+++ b/src/architecture/pluginSetup.js
@@ -3,7 +3,7 @@ export function registerLLMPlugins(pluginManager, context) {
     initialize: async () => console.log('Sparse attention plugin initialized'),
     replace: {
       generate: async function (prompt, maxTokens, temperature, options = {}) {
-        const useSparse = options.useSparseAttention ||
+        const useSparseAttention = options.useSparseAttention ||
           context.deviceProfile.tier === 'low' ||
           context.kvCache.size > context.kvCache.maxSize * 0.8;
         if (context.isWeb) {
@@ -12,7 +12,7 @@ export function registerLLMPlugins(pluginManager, context) {
         const generateOptions = {
           maxTokens,
           temperature,
-          useSparseAttention: useSparse
+          useSparseAttention
         };
         return context.nativeModule.generate(prompt, generateOptions);
       }

--- a/src/architecture/pluginSetup.js
+++ b/src/architecture/pluginSetup.js
@@ -9,7 +9,12 @@ export function registerLLMPlugins(pluginManager, context) {
         if (context.isWeb) {
           return context.generateWeb(prompt, maxTokens, temperature);
         }
-        return context.nativeModule.generate(prompt, maxTokens, temperature, useSparse);
+        const generateOptions = {
+          maxTokens,
+          temperature,
+          useSparseAttention: useSparse
+        };
+        return context.nativeModule.generate(prompt, generateOptions);
       }
     }
   });

--- a/src/hooks/useChat.js
+++ b/src/hooks/useChat.js
@@ -69,7 +69,7 @@ export function useChat() {
         prompt = `Context:\n${context}\n\n${prompt}`;
       }
       const response = await LLMService.generate(prompt, 256, 0.7, { useSparseAttention: true });
-      const reply = response?.text || '';
+      const reply = response.text;
       setMessages(prev => [...prev, { id: generateId(), sender: 'assistant', text: reply }]);
       Tts.stop();
       const speechText = reply.replace(/([.?!])\s+/g, '$1 <break time="500ms"/> ');

--- a/src/services/llmService.js
+++ b/src/services/llmService.js
@@ -101,12 +101,19 @@ class LLMService {
       
       let response;
       if (this.pluginManager.isPluginEnabled('sparseAttention')) {
-        response = await this.pluginManager.execute('generate', 
+        response = await this.pluginManager.execute('generate',
           [prompt, maxTokens, temperature, options], this);
       } else {
-        response = this.isWeb
-          ? await this.generateWeb(prompt, maxTokens, temperature)
-          : await this.nativeModule.generate(prompt, maxTokens, temperature, false);
+        if (this.isWeb) {
+          response = await this.generateWeb(prompt, maxTokens, temperature);
+        } else {
+          const generateOptions = {
+            maxTokens,
+            temperature,
+            ...options
+          };
+          response = await this.nativeModule.generate(prompt, generateOptions);
+        }
       }
       
       const inferenceTime = Date.now() - startTime;


### PR DESCRIPTION
## Summary
- Pass an options object to native `generate` in sparse attention plugin
- Forward options from JS service layer to native `generate`
- Return `{ text }` from Android turbo module and consume in chat hook

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1701b53083338f210f8e1707a650

## Summary by Sourcery

Standardize the generate API by adopting an options object for parameters and normalizing the response format to {text} across service, plugin, native, and hook layers

Enhancements:
- Consolidate generate parameters into a single options object and propagate it through pluginManager, LLMService, pluginSetup, and nativeModule
- Update Android LlamaTurboModule to wrap the nativeGenerate result in a WritableMap with a text field
- Adjust useChat hook to consume the new response.text field instead of a raw string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during AI response generation to prevent empty assistant replies and surface clear errors when generation fails.

* **Refactor**
  * Unified generation options handling across platforms for more consistent behavior.
  * Standardized native generation responses to return a structured result containing the generated text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->