### PR TITLE
feat: add agent orchestrator and memory manager

### DIFF
--- a/__tests__/toolRegistry.test.js
+++ b/__tests__/toolRegistry.test.js
@@ -1,0 +1,16 @@
+jest.mock("../src/tools/iosTools", () => ({
+  getBatteryInfoTool: { name: "get_battery_info", execute: jest.fn() },
+  getCurrentLocationTool: { name: "get_current_location", execute: jest.fn() },
+  createCalendarEventTool: {
+    name: "create_calendar_event",
+    execute: jest.fn(),
+  },
+  showMapTool: { name: "show_map", execute: jest.fn() },
+}));
+
+import { toolRegistry } from "../src/core/tools/ToolRegistry";
+
+test("toolRegistry registers built-in tools", () => {
+  expect(toolRegistry.getTool("get_battery_info")).toBeDefined();
+  expect(toolRegistry.getTool("get_current_location")).toBeDefined();
+});

--- a/src/core/AgentOrchestrator.js
+++ b/src/core/AgentOrchestrator.js
@@ -1,0 +1,100 @@
+import LLMService from "../services/llmService";
+import { toolRegistry } from "./tools/ToolRegistry";
+import MemoryManager from "./memory/MemoryManager";
+import PluginSystem from "./plugins/PluginSystem";
+
+export class AgentOrchestrator {
+  constructor() {
+    this.llm = LLMService;
+    this.memory = new MemoryManager();
+    this.plugins = new PluginSystem();
+    this.plugins.loadPlugins();
+  }
+
+  async run(prompt, context = {}) {
+    const longTermMemory = await this.memory.retrieve(prompt);
+    const shortTermMemory = this.memory.getConversationHistory();
+
+    const fullContext = [...longTermMemory, ...shortTermMemory];
+    const augmentedPrompt = this._augmentPrompt(prompt, fullContext);
+
+    const initial = await this.llm.generate(augmentedPrompt);
+    const rawResponse = initial.text ?? initial;
+
+    const toolCalls = this._parseToolCalls(rawResponse);
+    if (toolCalls.length > 0) {
+      const toolResults = await this._executeToolCalls(toolCalls);
+      const finalPrompt = this._augmentPrompt(prompt, [
+        ...fullContext,
+        ...toolResults,
+      ]);
+      const final = await this.llm.generate(finalPrompt);
+      const finalText = final.text ?? final;
+      this.memory.addInteraction(prompt, finalText, toolResults);
+      return finalText;
+    }
+
+    this.memory.addInteraction(prompt, rawResponse);
+    return rawResponse;
+  }
+
+  _augmentPrompt(prompt, context) {
+    const contextStr = context.map((c) => c.content).join("\n");
+    const toolsStr = toolRegistry
+      .getAvailableTools()
+      .map(
+        (t) =>
+          `Tool: ${t.name} - ${t.description} (Params: ${JSON.stringify(
+            t.parameters
+          )})`
+      )
+      .join("\n");
+
+    return `\nYou are an AI assistant with access to the following tools:\n${toolsStr}\n\nCurrent context:\n${contextStr}\n\nUser: ${prompt}\nAssistant:`;
+  }
+
+  _parseToolCalls(response) {
+    const toolCallRegex = /TOOL_CALL: (\w+) \((.+)\)/g;
+    const matches = [...response.matchAll(toolCallRegex)];
+    return matches.map((match) => ({
+      name: match[1],
+      args: this._parseArgs(match[2]),
+    }));
+  }
+
+  _parseArgs(argString) {
+    const args = {};
+    const regex = /(\w+)='([^']+)'/g;
+    let match;
+    while ((match = regex.exec(argString)) !== null) {
+      args[match[1]] = match[2];
+    }
+    return args;
+  }
+
+  async _executeToolCalls(toolCalls) {
+    const results = [];
+    for (const call of toolCalls) {
+      const tool = toolRegistry.getTool(call.name);
+      if (tool) {
+        try {
+          const result = await tool.execute(call.args);
+          results.push({
+            role: "tool",
+            name: call.name,
+            content: JSON.stringify(result),
+          });
+        } catch (error) {
+          results.push({
+            role: "tool",
+            name: call.name,
+            content: `Error: ${error.message}`,
+          });
+        }
+      }
+    }
+    return results;
+  }
+}
+
+export default AgentOrchestrator;

--- a/src/core/memory/MemoryManager.js
+++ b/src/core/memory/MemoryManager.js
@@ -1,0 +1,74 @@
+import { HNSWVectorStore } from "../../utils/hnswVectorStore";
+import LLMService from "../../services/llmService";
+import { applySparseAttention } from "../../utils/sparseAttention";
+
+export class MemoryManager {
+  constructor() {
+    this.vectorStore = new HNSWVectorStore();
+    this.conversationHistory = [];
+    this.initialized = false;
+  }
+
+  async _ensureInitialized() {
+    if (!this.initialized) {
+      await this.vectorStore.initialize();
+      this.initialized = true;
+    }
+  }
+
+  async addInteraction(userPrompt, aiResponse, toolResults = []) {
+    await this._ensureInitialized();
+    const embedding = await LLMService.embed(userPrompt);
+    const content = `User: ${userPrompt}\nAssistant: ${aiResponse}`;
+    await this.vectorStore.addVector(content, embedding, {
+      user: userPrompt,
+      assistant: aiResponse,
+      tools: toolResults,
+      timestamp: new Date().toISOString(),
+    });
+
+    this.conversationHistory.push({ role: "user", content: userPrompt });
+    this.conversationHistory.push({ role: "assistant", content: aiResponse });
+    if (this.conversationHistory.length > 20) {
+      this.conversationHistory = this.conversationHistory.slice(-20);
+    }
+  }
+
+  async retrieve(query, maxResults = 5) {
+    await this._ensureInitialized();
+    const queryEmbedding = await LLMService.embed(query);
+    const results = await this.vectorStore.searchVectors(
+      queryEmbedding,
+      maxResults * 3
+    );
+
+    const contextItems = results.map((r) => {
+      const node = this.vectorStore.nodeMap.get(r.id);
+      return {
+        embedding: node?.vector || [],
+        content: `User: ${r.metadata.user}\nAssistant: ${r.metadata.assistant}`,
+      };
+    });
+
+    if (contextItems.length === 0) {
+      return [];
+    }
+
+    const selected = applySparseAttention(
+      queryEmbedding,
+      contextItems.map((i) => i.embedding),
+      { numClusters: 3, topK: Math.min(2, contextItems.length) }
+    );
+
+    return selected.map((index) => ({
+      role: "context",
+      content: contextItems[index].content,
+    }));
+  }
+
+  getConversationHistory() {
+    return this.conversationHistory;
+  }
+}
+
+export default MemoryManager;

--- a/src/core/plugins/PluginSystem.js
+++ b/src/core/plugins/PluginSystem.js
@@ -1,0 +1,12 @@
+export class PluginSystem {
+  constructor() {
+    this.plugins = [];
+  }
+
+  loadPlugins() {
+    // Placeholder for plugin loading logic
+    return this.plugins;
+  }
+}
+
+export default PluginSystem;

--- a/src/core/tools/ToolRegistry.js
+++ b/src/core/tools/ToolRegistry.js
@@ -1,0 +1,30 @@
+import {
+  getBatteryInfoTool,
+  getCurrentLocationTool,
+  createCalendarEventTool,
+  showMapTool,
+} from "../../tools/iosTools";
+
+export const toolRegistry = {
+  tools: new Map(),
+
+  register(name, tool) {
+    this.tools.set(name, tool);
+  },
+
+  getTool(name) {
+    return this.tools.get(name);
+  },
+
+  getAvailableTools() {
+    return Array.from(this.tools.values());
+  },
+};
+
+// Register native tools
+toolRegistry.register("get_battery_info", getBatteryInfoTool);
+toolRegistry.register("get_current_location", getCurrentLocationTool);
+toolRegistry.register("create_calendar_event", createCalendarEventTool);
+toolRegistry.register("show_map", showMapTool);
+
+export default toolRegistry;


### PR DESCRIPTION
## Summary
- add AgentOrchestrator to coordinate LLM, memory, and tools
- implement MemoryManager using HNSW and sparse attention
- register native TurboModule tools in a central tool registry
- add basic plugin system placeholder and tests for tool registration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad4080bab883338a9188f93e5e9260