### PR TITLE
feat: add tool unregistration

### DIFF
--- a/__tests__/toolRegistry.test.js
+++ b/__tests__/toolRegistry.test.js
@@ -14,3 +14,18 @@ test("toolRegistry registers built-in tools", () => {
   expect(toolRegistry.getTool("get_battery_info")).toBeDefined();
   expect(toolRegistry.getTool("get_current_location")).toBeDefined();
 });
+
+test("unregister removes tools", () => {
+  const temp = { name: "temp_tool", execute: jest.fn() };
+  toolRegistry.register(temp.name, temp);
+  expect(toolRegistry.getTool("temp_tool")).toBeDefined();
+  expect(toolRegistry.unregister("temp_tool")).toBe(true);
+  expect(toolRegistry.getTool("temp_tool")).toBeUndefined();
+  expect(toolRegistry.unregister("temp_tool")).toBe(false);
+});
+
+test("register throws for invalid tools", () => {
+  expect(() => toolRegistry.register("bad_tool", {})).toThrow(
+    "Invalid tool bad_tool: missing execute()",
+  );
+});

--- a/src/core/tools/ToolRegistry.js
+++ b/src/core/tools/ToolRegistry.js
@@ -5,28 +5,32 @@ import {
   showMapTool,
 } from "../../tools/iosTools";
 
-export const toolRegistry = {
-  tools: new Map(),
+const createToolRegistry = () => {
+  const tools = new Map();
 
-  register(name, tool) {
-    if (!tool || typeof tool.execute !== "function") {
-      throw new Error(`Invalid tool ${name}: missing execute()`);
-    }
-    this.tools.set(name, tool);
-  },
+  return {
+    register(name, tool) {
+      if (!tool || typeof tool.execute !== "function") {
+        throw new Error(`Invalid tool ${name}: missing execute()`);
+      }
+      tools.set(name, tool);
+    },
 
-  unregister(name) {
-    return this.tools.delete(name);
-  },
+    unregister(name) {
+      return tools.delete(name);
+    },
 
-  getTool(name) {
-    return this.tools.get(name);
-  },
+    getTool(name) {
+      return tools.get(name);
+    },
 
-  getAvailableTools() {
-    return Array.from(this.tools.values());
-  },
+    getAvailableTools() {
+      return Array.from(tools.values());
+    },
+  };
 };
+
+export const toolRegistry = createToolRegistry();
 
 // Register native tools
 toolRegistry.register("get_battery_info", getBatteryInfoTool);

--- a/src/core/tools/ToolRegistry.js
+++ b/src/core/tools/ToolRegistry.js
@@ -9,7 +9,14 @@ export const toolRegistry = {
   tools: new Map(),
 
   register(name, tool) {
+    if (!tool || typeof tool.execute !== "function") {
+      throw new Error(`Invalid tool ${name}: missing execute()`);
+    }
     this.tools.set(name, tool);
+  },
+
+  unregister(name) {
+    return this.tools.delete(name);
   },
 
   getTool(name) {


### PR DESCRIPTION
## Summary
- return boolean from `toolRegistry.unregister`
- test that unregister reports status and invalid tools throw

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad7b9f3f988333a142a3b89dfa19aa

## Summary by Sourcery

Introduce tool unregistration and enforce tool interface validation in the registry

New Features:
- Add unregister(name) to toolRegistry to remove tools and return a boolean status
- Validate that registered tools provide an execute() method and throw an error otherwise

Tests:
- Add tests to verify unregister() removes existing tools and returns false for missing tools
- Add a test to ensure register() throws an error when registering an invalid tool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added ability to remove tools via the unregister(name) API, returning whether removal succeeded.

- Bug Fixes
  - Tool registration now validates inputs and rejects tools without an execute() function, throwing a clear error message for invalid tools to prevent misconfiguration.

- Tests
  - Added tests covering unregister behavior (successful removal and idempotency).
  - Added tests ensuring invalid tool registration throws the expected error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->