### PR TITLE
Enable model download and unsigned iOS IPA build

### DIFF
--- a/.github/actions/ios-setup/action.yml
+++ b/.github/actions/ios-setup/action.yml
@@ -1,0 +1,52 @@
+name: iOS setup
+description: Shared steps for iOS builds
+inputs:
+  node-version:
+    description: Node version
+    required: false
+    default: "18"
+  xcode-version:
+    description: Xcode version
+    required: false
+    default: "15.4"
+  xcodegen-version:
+    description: XcodeGen version
+    required: false
+    default: "2.39.1"
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+    - name: Select Xcode ${{ inputs.xcode-version }}
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: ${{ inputs.xcode-version }}
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: npm
+    - name: Install dependencies
+      run: npm ci
+      shell: bash
+    - name: Install XcodeGen (prebuilt)
+      shell: bash
+      run: |
+        set -euxo pipefail
+        VER="${{ inputs.xcodegen-version }}"
+        curl -L "https://github.com/yonaskolb/XcodeGen/releases/download/${VER}/xcodegen-${VER}.zip" -o /tmp/xg.zip
+        unzip -q /tmp/xg.zip -d /tmp/xg
+        sudo mv /tmp/xg/xcodegen /usr/local/bin/xcodegen
+        xcodegen --version
+    - name: Install CocoaPods
+      shell: bash
+      run: |
+        gem install cocoapods --no-document
+        pod --version
+    - name: Generate Xcode project & Install Pods
+      shell: bash
+      run: |
+        (cd ios/MyOfflineLLMApp && xcodegen generate)
+        perl -0 -i -pe 's/objectVersion = \d+/objectVersion = 56/' ios/MyOfflineLLMApp/MyOfflineLLMApp.xcodeproj/project.pbxproj
+        pod repo update
+        (cd ios && pod install --repo-update)

--- a/.github/workflows/build-ios-turbomodules.yml
+++ b/.github/workflows/build-ios-turbomodules.yml
@@ -12,17 +12,31 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+      - name: Select Xcode 15.4
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "15.4"
       - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: "npm"
       - name: Install dependencies
         run: npm ci
-      - name: Install XcodeGen and CocoaPods
-        run: brew install xcodegen cocoapods
+      - name: Install XcodeGen (prebuilt)
+        run: |
+          set -euxo pipefail
+          VER="2.39.1"
+          curl -L "https://github.com/yonaskolb/XcodeGen/releases/download/${VER}/xcodegen-${VER}.zip" -o /tmp/xg.zip
+          unzip -q /tmp/xg.zip -d /tmp/xg
+          sudo mv /tmp/xg/xcodegen /usr/local/bin/xcodegen
+          xcodegen --version
+      - name: Install CocoaPods
+        run: |
+          gem install cocoapods --no-document
+          pod --version
       - name: Cache Pods
         if: ${{ hashFiles('ios/Podfile') != '' }}
         uses: actions/cache@v3

--- a/.github/workflows/ios-build-unsigned.yml
+++ b/.github/workflows/ios-build-unsigned.yml
@@ -4,11 +4,13 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-unsigned:
+  build:
     runs-on: macos-15
+
     steps:
       - uses: actions/checkout@v4
 
+      # Pin a compatible Xcode
       - name: Select Xcode 15.4
         uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -23,35 +25,41 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # ✅ Install XcodeGen from prebuilt release (avoid Homebrew)
       - name: Install XcodeGen (prebuilt)
         run: |
           set -euxo pipefail
-          VER="2.39.1"
+          VER="2.39.1"  # pick a stable version; update as needed
           curl -L "https://github.com/yonaskolb/XcodeGen/releases/download/${VER}/xcodegen-${VER}.zip" -o /tmp/xg.zip
           unzip -q /tmp/xg.zip -d /tmp/xg
           sudo mv /tmp/xg/xcodegen /usr/local/bin/xcodegen
           xcodegen --version
 
+      # CocoaPods via RubyGems (don’t brew)
       - name: Install CocoaPods
         run: |
           gem install cocoapods --no-document
           pod --version
 
-      - name: Generate Xcode project
-        working-directory: ios/MyOfflineLLMApp
-        run: xcodegen generate
+      # (Your existing XcodeGen + pods + build steps here)
+      - name: Generate Xcode project & Install Pods
+        run: |
+          (cd ios/MyOfflineLLMApp && xcodegen generate)
+          perl -0 -i -pe 's/objectVersion = \d+/objectVersion = 56/' ios/MyOfflineLLMApp/MyOfflineLLMApp.xcodeproj/project.pbxproj
+          pod repo update
+          (cd ios && pod install --repo-update)
 
-      - name: Install CocoaPods dependencies
-        working-directory: ios
-        run: pod install
-
-      - name: Make build script executable
-        run: chmod +x scripts/build_unsigned_ios.sh
-
+      # Example: unsigned build
       - name: Build unsigned IPA
-        run: ./scripts/build_unsigned_ios.sh
+        run: |
+          chmod +x scripts/build_unsigned_ios.sh
+          SCHEME=MyOfflineLLMApp \
+          WORKSPACE=ios/MyOfflineLLMApp/MyOfflineLLMApp.xcworkspace \
+          IPA_OUTPUT=$RUNNER_TEMP/MyOfflineLLMApp-unsigned.ipa \
+          ./scripts/build_unsigned_ios.sh
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload unsigned IPA
+        uses: actions/upload-artifact@v4
         with:
-          name: unsigned-ipa
-          path: MyOfflineLLMApp-unsigned.ipa
+          name: MyOfflineLLMApp-unsigned
+          path: ${{ runner.temp }}/MyOfflineLLMApp-unsigned.ipa

--- a/.github/workflows/ios-build-unsigned.yml
+++ b/.github/workflows/ios-build-unsigned.yml
@@ -8,48 +8,12 @@ jobs:
     runs-on: macos-15
 
     steps:
-      - uses: actions/checkout@v4
-
-      # Pin a compatible Xcode
-      - name: Select Xcode 15.4
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "15.4"
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - uses: ./.github/actions/ios-setup
         with:
           node-version: 18
-          cache: "npm"
+          xcode-version: "15.4"
+          xcodegen-version: "2.39.1"
 
-      - name: Install dependencies
-        run: npm ci
-
-      # ✅ Install XcodeGen from prebuilt release (avoid Homebrew)
-      - name: Install XcodeGen (prebuilt)
-        run: |
-          set -euxo pipefail
-          VER="2.39.1"  # pick a stable version; update as needed
-          curl -L "https://github.com/yonaskolb/XcodeGen/releases/download/${VER}/xcodegen-${VER}.zip" -o /tmp/xg.zip
-          unzip -q /tmp/xg.zip -d /tmp/xg
-          sudo mv /tmp/xg/xcodegen /usr/local/bin/xcodegen
-          xcodegen --version
-
-      # CocoaPods via RubyGems (don’t brew)
-      - name: Install CocoaPods
-        run: |
-          gem install cocoapods --no-document
-          pod --version
-
-      # (Your existing XcodeGen + pods + build steps here)
-      - name: Generate Xcode project & Install Pods
-        run: |
-          (cd ios/MyOfflineLLMApp && xcodegen generate)
-          perl -0 -i -pe 's/objectVersion = \d+/objectVersion = 56/' ios/MyOfflineLLMApp/MyOfflineLLMApp.xcodeproj/project.pbxproj
-          pod repo update
-          (cd ios && pod install --repo-update)
-
-      # Example: unsigned build
       - name: Build unsigned IPA
         run: |
           chmod +x scripts/build_unsigned_ios.sh

--- a/.github/workflows/ios-build-unsigned.yml
+++ b/.github/workflows/ios-build-unsigned.yml
@@ -8,23 +8,49 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+
+      - name: Select Xcode 15.4
+        uses: maxim-lobanov/setup-xcode@v1
         with:
-          node-version: 20
-          cache: npm
-      - run: npm ci
-      - name: Install build tools
-        run: brew install xcodegen cocoapods
+          xcode-version: "15.4"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install XcodeGen (prebuilt)
+        run: |
+          set -euxo pipefail
+          VER="2.39.1"
+          curl -L "https://github.com/yonaskolb/XcodeGen/releases/download/${VER}/xcodegen-${VER}.zip" -o /tmp/xg.zip
+          unzip -q /tmp/xg.zip -d /tmp/xg
+          sudo mv /tmp/xg/xcodegen /usr/local/bin/xcodegen
+          xcodegen --version
+
+      - name: Install CocoaPods
+        run: |
+          gem install cocoapods --no-document
+          pod --version
+
       - name: Generate Xcode project
         working-directory: ios/MyOfflineLLMApp
         run: xcodegen generate
+
       - name: Install CocoaPods dependencies
         working-directory: ios
         run: pod install
+
       - name: Make build script executable
         run: chmod +x scripts/build_unsigned_ios.sh
+
       - name: Build unsigned IPA
         run: ./scripts/build_unsigned_ios.sh
+
       - uses: actions/upload-artifact@v4
         with:
           name: unsigned-ipa

--- a/.github/workflows/ios-build-unsigned.yml
+++ b/.github/workflows/ios-build-unsigned.yml
@@ -1,0 +1,31 @@
+name: Build unsigned iOS IPA
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-unsigned:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Install build tools
+        run: brew install xcodegen cocoapods
+      - name: Generate Xcode project
+        working-directory: ios/MyOfflineLLMApp
+        run: xcodegen generate
+      - name: Install CocoaPods dependencies
+        working-directory: ios
+        run: pod install
+      - name: Make build script executable
+        run: chmod +x scripts/build_unsigned_ios.sh
+      - name: Build unsigned IPA
+        run: ./scripts/build_unsigned_ios.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-ipa
+          path: MyOfflineLLMApp-unsigned.ipa

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -5,40 +5,41 @@ on:
 
 jobs:
   build-ios:
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Set up Node.js
+      - name: Select Xcode 15.4
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "15.4"
+
+      - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 18
           cache: npm
 
-      - name: Install npm dependencies
-        run: npm install
+      - name: Install JS deps
+        run: npm ci
 
-      - name: Install XcodeGen
-        run: brew install xcodegen
+      - name: Install XcodeGen (prebuilt)
+        run: |
+          set -euxo pipefail
+          VER="2.39.1"
+          curl -L "https://github.com/yonaskolb/XcodeGen/releases/download/${VER}/xcodegen-${VER}.zip" -o /tmp/xg.zip
+          unzip -q /tmp/xg.zip -d /tmp/xg
+          sudo mv /tmp/xg/xcodegen /usr/local/bin/xcodegen
+          xcodegen --version
+
+      - name: Install CocoaPods
+        run: |
+          gem install cocoapods --no-document
+          pod --version
 
       - name: Generate Xcode project
         working-directory: ios/MyOfflineLLMApp
         run: xcodegen generate
-
-      - name: Cache Ruby gems
-        uses: actions/cache@v4
-        with:
-          path: ios/vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('ios/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-
-      - name: Install Ruby gems
-        working-directory: ios
-        run: |
-          bundle config set path 'vendor/bundle'
-          bundle install --jobs 4 --retry 3
 
       - name: Cache CocoaPods
         uses: actions/cache@v4
@@ -52,7 +53,7 @@ jobs:
 
       - name: Install CocoaPods dependencies
         working-directory: ios
-        run: bundle exec pod install
+        run: pod install --repo-update
 
       - name: Decode and import signing certificate
         env:
@@ -100,9 +101,9 @@ jobs:
             -exportOptionsPlist exportOptions.plist \
             -exportPath build_output
 
-      - name: Clean up keychain
+      - name: Cleanup temp keychain
         if: always()
-        run: security delete-keychain build.keychain
+        run: security delete-keychain build.keychain || true
 
       - name: Upload IPA artifact
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ chat interface allows you to talk to the assistant via text or voice.
 ## Features
 
 - **On‑device inference** using a quantized Llama model via llama.cpp on
-  Android and MLX on iOS. Models can be swapped by placing the file on
-  your device and updating the path in `App.js`.
+  Android and MLX on iOS. Models can be swapped by updating the model URL in
+  `App.js`, which downloads the file to your device on first run.
 - **Chat interface** with support for multi‑turn conversations. Messages are
   displayed in a scrollable list and you can speak queries using the built-in
   microphone button. Responses are read aloud using `react‑native‑tts`.
@@ -43,10 +43,10 @@ The assistant can optionally store vector embeddings of conversation snippets in
 
    > A stub `android/gradlew` script is included so CI environments can invoke `npm run build:android` without the Android SDK. Replace this stub with a full Gradle wrapper for real builds.
 
-2. Place a compatible Llama model file on your device (e.g. in the app's
-   documents directory) and update the path in `App.js` where
-   `LLMService.loadModel` is called. Quantized models (Q4 or Q5) are
-   recommended for mobile. The app will automatically configure context
+2. Provide a URL to a compatible Llama model file in `App.js`. The helper
+   will download the model to the app's documents directory on first launch and
+   pass the local path to `LLMService.loadModel`. Quantized models (Q4 or Q5)
+   are recommended for mobile. The app will automatically configure context
    lengths and enable sparse attention for quantized models.
 
 3. On the first launch the assistant will load the model, initialize the
@@ -97,6 +97,10 @@ TurboModules on macOS runners. The spec lives at `ios/MyOfflineLLMApp/project.ym
 when the XcodeGen spec or Podfile are missing and builds the generated workspace explicitly.
 
 Another workflow, `ios-build.yml`, compiles and signs the app on macOS runners and uploads a signed `.ipa` artifact. Provide your distribution certificate, provisioning profile, and export options plist as base64‑encoded secrets (`IOS_CERTIFICATE_BASE64`, `IOS_CERT_PASSWORD`, `IOS_PROVISION_PROFILE_BASE64`, `IOS_EXPORT_OPTIONS_PLIST`) and supply a random keychain password via `IOS_KEYCHAIN_PASSWORD`.
+
+Use the script at `scripts/build_unsigned_ios.sh` to create an unsigned `.ipa`
+for testing. The `ios-build-unsigned.yml` workflow runs this script on
+`macos-15` and uploads the resulting artifact.
 
 An additional script at `ios/MyOfflineLLMApp/Scripts/verify_deployment_target.sh` runs during the Xcode build to ensure the
 deployment target remains set to iOS 14.0.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ chat interface allows you to talk to the assistant via text or voice.
 ## Features
 
 - **On‑device inference** using a quantized Llama model via llama.cpp on
-  Android and MLX on iOS. Models can be swapped by updating the model URL in
-  `App.js`, which downloads the file to your device on first run.
+  Android and MLX on iOS. Models can be swapped by setting the `MODEL_URL`
+  configuration value, which downloads the file to your device on first run.
 - **Chat interface** with support for multi‑turn conversations. Messages are
   displayed in a scrollable list and you can speak queries using the built-in
   microphone button. Responses are read aloud using `react‑native‑tts`.
@@ -43,7 +43,8 @@ The assistant can optionally store vector embeddings of conversation snippets in
 
    > A stub `android/gradlew` script is included so CI environments can invoke `npm run build:android` without the Android SDK. Replace this stub with a full Gradle wrapper for real builds.
 
-2. Provide a URL to a compatible Llama model file in `App.js`. The helper
+2. Set the `MODEL_URL` environment variable (or corresponding config) to a
+   compatible Llama model file. The helper
    will download the model to the app's documents directory on first launch and
    pass the local path to `LLMService.loadModel`. Quantized models (Q4 or Q5)
    are recommended for mobile. The app will automatically configure context
@@ -63,6 +64,7 @@ The assistant can optionally store vector embeddings of conversation snippets in
 - `MEMORY_MAX_MB` – maximum size of memory database in megabytes (default `10`).
 - `MEMORY_ENCRYPTION_KEY` – 32 byte key used for AES‑GCM encryption.
 - `EMOTION_AUDIO_ENABLED` – enable on‑device audio prosody detection.
+- `MODEL_URL` – remote URL of the model file downloaded at startup.
 
 ## Development notes
 
@@ -100,7 +102,8 @@ Another workflow, `ios-build.yml`, compiles and signs the app on macOS runners a
 
 Use the script at `scripts/build_unsigned_ios.sh` to create an unsigned `.ipa`
 for testing. The `ios-build-unsigned.yml` workflow runs this script on
-`macos-15` and uploads the resulting artifact.
+`macos-15` and uploads the resulting artifact. Shared setup steps live in the
+reusable action at `.github/actions/ios-setup`.
 
 An additional script at `ios/MyOfflineLLMApp/Scripts/verify_deployment_target.sh` runs during the Xcode build to ensure the
 deployment target remains set to iOS 14.0.

--- a/scripts/build_unsigned_ios.sh
+++ b/scripts/build_unsigned_ios.sh
@@ -15,6 +15,17 @@ xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -configuration Release -arc
 
 APP_PATH="$ARCHIVE_PATH/Products/Applications/${SCHEME}.app"
 PAYLOAD_DIR="Payload"
+
+# Validate paths before removal to avoid accidental data loss
+if [[ -z "$PAYLOAD_DIR" || "$PAYLOAD_DIR" == "/" ]]; then
+  echo "Error: PAYLOAD_DIR is not set correctly. Aborting to prevent data loss."
+  exit 1
+fi
+if [[ -z "$IPA_OUTPUT" || "$IPA_OUTPUT" == "/" ]]; then
+  echo "Error: IPA_OUTPUT is not set correctly. Aborting to prevent data loss."
+  exit 1
+fi
+
 rm -rf "$PAYLOAD_DIR" "$IPA_OUTPUT"
 mkdir -p "$PAYLOAD_DIR"
 cp -R "$APP_PATH" "$PAYLOAD_DIR"

--- a/scripts/build_unsigned_ios.sh
+++ b/scripts/build_unsigned_ios.sh
@@ -2,12 +2,12 @@
 # Build an unsigned iOS IPA.
 # Environment variables:
 #   SCHEME    - Xcode scheme (default: MyOfflineLLMApp)
-#   WORKSPACE - Xcode workspace path (default: ios/MyOfflineLLMApp.xcworkspace)
+#   WORKSPACE - Xcode workspace path (default: ios/MyOfflineLLMApp/MyOfflineLLMApp.xcworkspace)
 #   IPA_OUTPUT- Output path for the unsigned IPA (default: ${PWD}/${SCHEME}-unsigned.ipa)
 set -euo pipefail
 
 SCHEME=${SCHEME:-MyOfflineLLMApp}
-WORKSPACE=${WORKSPACE:-ios/MyOfflineLLMApp.xcworkspace}
+WORKSPACE=${WORKSPACE:-ios/MyOfflineLLMApp/MyOfflineLLMApp.xcworkspace}
 IPA_OUTPUT=${IPA_OUTPUT:-${PWD}/${SCHEME}-unsigned.ipa}
 ARCHIVE_PATH="build/${SCHEME}.xcarchive"
 

--- a/scripts/build_unsigned_ios.sh
+++ b/scripts/build_unsigned_ios.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Build an unsigned iOS IPA.
+# Environment variables:
+#   SCHEME    - Xcode scheme (default: MyOfflineLLMApp)
+#   WORKSPACE - Xcode workspace path (default: ios/MyOfflineLLMApp.xcworkspace)
+#   IPA_OUTPUT- Output path for the unsigned IPA (default: ${PWD}/${SCHEME}-unsigned.ipa)
+set -euo pipefail
+
+SCHEME=${SCHEME:-MyOfflineLLMApp}
+WORKSPACE=${WORKSPACE:-ios/MyOfflineLLMApp.xcworkspace}
+IPA_OUTPUT=${IPA_OUTPUT:-${PWD}/${SCHEME}-unsigned.ipa}
+ARCHIVE_PATH="build/${SCHEME}.xcarchive"
+
+xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -configuration Release -archivePath "$ARCHIVE_PATH" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO archive
+
+APP_PATH="$ARCHIVE_PATH/Products/Applications/${SCHEME}.app"
+PAYLOAD_DIR="Payload"
+rm -rf "$PAYLOAD_DIR" "$IPA_OUTPUT"
+mkdir -p "$PAYLOAD_DIR"
+cp -R "$APP_PATH" "$PAYLOAD_DIR"
+zip -r "$IPA_OUTPUT" "$PAYLOAD_DIR"
+rm -rf "$PAYLOAD_DIR" "$ARCHIVE_PATH"
+echo "Created unsigned IPA at $IPA_OUTPUT"

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import {
 } from "react-native";
 import LLMService from "./services/llmService";
 import { ensureModelDownloaded } from "./utils/modelDownloader";
+import { getEnv } from "./config";
 import { ToolRegistry, builtInTools } from "./architecture/toolSystem";
 import {
   createCalendarEventTool,
@@ -98,7 +99,8 @@ function App() {
         });
       }
       const pluginManager = new PluginManager();
-      const MODEL_URL = "https://example.com/model.bin"; // TODO: set actual model URL
+      // Set MODEL_URL in your environment or config to point to the model file
+      const MODEL_URL = getEnv("MODEL_URL");
       const modelPath = await ensureModelDownloaded(MODEL_URL);
       await LLMService.loadModel(modelPath);
       dependencyInjector.register("toolRegistry", toolRegistry);

--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import {
   Platform,
 } from "react-native";
 import LLMService from "./services/llmService";
+import { ensureModelDownloaded } from "./utils/modelDownloader";
 import { ToolRegistry, builtInTools } from "./architecture/toolSystem";
 import {
   createCalendarEventTool,
@@ -97,7 +98,9 @@ function App() {
         });
       }
       const pluginManager = new PluginManager();
-      await LLMService.loadModel("path/to/default/model");
+      const MODEL_URL = "https://example.com/model.bin"; // TODO: set actual model URL
+      const modelPath = await ensureModelDownloaded(MODEL_URL);
+      await LLMService.loadModel(modelPath);
       dependencyInjector.register("toolRegistry", toolRegistry);
       dependencyInjector.register("pluginManager", pluginManager);
       dependencyInjector.register("llmService", LLMService);

--- a/src/utils/modelDownloader.js
+++ b/src/utils/modelDownloader.js
@@ -1,32 +1,56 @@
 import RNFS from "react-native-fs";
 
 /**
- * Downloads a model file from a remote URL to the device's documents directory.
+ * Download a model file to the device's documents directory, retrying on failures.
  * If the file already exists, the download is skipped.
+ *
  * @param {string} url Remote URL of the model file.
+ * @param {{retries?: number, baseDelay?: number}} options Retry options.
  * @returns {Promise<string>} Local file path to the downloaded model.
  */
-export async function ensureModelDownloaded(url) {
-  try {
-    if (!url) {
-      throw new Error("Model URL is required");
-    }
-
-    const filename = url.split("/").pop()?.split("?")[0];
-    const localPath = `${RNFS.DocumentDirectoryPath}/${filename}`;
-
-    const exists = await RNFS.exists(localPath);
-    if (!exists) {
-      const download = RNFS.downloadFile({ fromUrl: url, toFile: localPath });
-      const result = await download.promise;
-      if (result.statusCode !== 200) {
-        throw new Error(`Download failed with status ${result.statusCode}`);
-      }
-    }
-
-    return localPath;
-  } catch (error) {
-    console.error("Model download failed:", error);
-    throw error;
+export async function ensureModelDownloaded(url, options = {}) {
+  if (!url) {
+    throw new Error("Model URL is required");
   }
+
+  let filename;
+  try {
+    const parsedUrl = new URL(url);
+    filename = decodeURIComponent(parsedUrl.pathname.split("/").pop() || "");
+    if (!filename) {
+      throw new Error("Could not extract filename from URL");
+    }
+  } catch (err) {
+    throw new Error(
+      `Invalid URL or unable to extract filename: ${err.message}`
+    );
+  }
+
+  const localPath = `${RNFS.DocumentDirectoryPath}/${filename}`;
+
+  if (await RNFS.exists(localPath)) {
+    return localPath;
+  }
+
+  const { retries = 3, baseDelay = 1000 } = options;
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const { statusCode } = await RNFS.downloadFile({
+        fromUrl: url,
+        toFile: localPath,
+      }).promise;
+      if (statusCode === 200) {
+        return localPath;
+      }
+      throw new Error(`Download failed with status ${statusCode}`);
+    } catch (err) {
+      if (attempt === retries) {
+        throw err;
+      }
+      const delay = baseDelay * Math.pow(2, attempt - 1);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  return localPath;
 }

--- a/src/utils/modelDownloader.js
+++ b/src/utils/modelDownloader.js
@@ -1,0 +1,32 @@
+import RNFS from "react-native-fs";
+
+/**
+ * Downloads a model file from a remote URL to the device's documents directory.
+ * If the file already exists, the download is skipped.
+ * @param {string} url Remote URL of the model file.
+ * @returns {Promise<string>} Local file path to the downloaded model.
+ */
+export async function ensureModelDownloaded(url) {
+  try {
+    if (!url) {
+      throw new Error("Model URL is required");
+    }
+
+    const filename = url.split("/").pop()?.split("?")[0];
+    const localPath = `${RNFS.DocumentDirectoryPath}/${filename}`;
+
+    const exists = await RNFS.exists(localPath);
+    if (!exists) {
+      const download = RNFS.downloadFile({ fromUrl: url, toFile: localPath });
+      const result = await download.promise;
+      if (result.statusCode !== 200) {
+        throw new Error(`Download failed with status ${result.statusCode}`);
+      }
+    }
+
+    return localPath;
+  } catch (error) {
+    console.error("Model download failed:", error);
+    throw error;
+  }
+}


### PR DESCRIPTION
### **User description**
## Summary
- add helper to download model files on demand and load them during app initialization
- script and CI workflow to build unsigned iOS IPA artifacts
- document new model flow and iOS build script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a05ae06c83339fc54bccefce01a1

## Summary by Sourcery

Enable runtime model downloads and add capability to build unsigned iOS IPA artifacts

New Features:
- Add ensureModelDownloaded utility to fetch Llama model files from a remote URL at runtime
- Update App.js to download and load the model from a specified URL on first launch
- Add build_unsigned_ios.sh script and GitHub Actions workflow to generate unsigned iOS IPA artifacts for testing

CI:
- Introduce ios-build-unsigned.yml workflow to build and upload unsigned iOS IPA

Documentation:
- Update README to document the new on-demand model download flow and unsigned iOS IPA build process


___

### **PR Type**
Enhancement


___

### **Description**
- Add on-demand model downloading with URL-based configuration

- Introduce unsigned iOS IPA build script and CI workflow

- Update documentation for new model download flow

- Replace hardcoded model paths with remote URL fetching


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["App.js"] --> B["ensureModelDownloaded()"]
  B --> C["Download Model"]
  C --> D["LLMService.loadModel()"]
  E["build_unsigned_ios.sh"] --> F["Unsigned IPA"]
  G["GitHub Workflow"] --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.js</strong><dd><code>Integrate on-demand model downloading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/App.js

<ul><li>Import <code>ensureModelDownloaded</code> utility function<br> <li> Replace hardcoded model path with URL-based download<br> <li> Add model URL configuration with TODO placeholder</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/offLLM/pull/25/files#diff-3d74dddefb6e35fbffe3c76ec0712d5c416352d9449e2fcc8210a9dee57dff67">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>modelDownloader.js</strong><dd><code>Add model download utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/modelDownloader.js

<ul><li>Create utility to download models from remote URLs<br> <li> Check if model exists locally before downloading<br> <li> Handle download errors and return local file path</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/offLLM/pull/25/files#diff-75d7d526db6b583f1be80615be913d0e6c5852f2b8bb71b3b24d3aab8c738747">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>build_unsigned_ios.sh</strong><dd><code>Add unsigned iOS build script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/build_unsigned_ios.sh

<ul><li>Create bash script for unsigned iOS IPA builds<br> <li> Support configurable scheme, workspace, and output paths<br> <li> Archive, package, and clean up build artifacts</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/offLLM/pull/25/files#diff-717bd18360eb47068fe1b5a7393d247ba58bb76602e98a17de931d7172c175cf">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ios-build-unsigned.yml</strong><dd><code>Add unsigned iOS CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ios-build-unsigned.yml

<ul><li>Add GitHub workflow for unsigned IPA builds<br> <li> Configure macOS-15 runner with Node.js and build tools<br> <li> Upload unsigned IPA as workflow artifact</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/offLLM/pull/25/files#diff-9edcb1f0e7bc1ae1c5bbc0fe97ca2cb10d2260e54fd506cd57c9bb04da9f6c44">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation for new features</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Update model setup instructions for URL-based downloads<br> <li> Document new unsigned iOS build script and workflow<br> <li> Replace device file placement with remote URL configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/offLLM/pull/25/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+10/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App downloads a Llama model from a configured MODEL_URL on first launch, caches it locally, and loads it automatically; retains quantized-model optimizations.

* **Documentation**
  * Getting-started updated for MODEL_URL usage, first-launch initialization (model load, vector store, tool registration), and added iOS unsigned build notes and deployment-target safeguard.

* **Chores**
  * Added automation to produce and upload unsigned iOS IPA artifacts and a shared iOS build/setup action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->