### PR TITLE
fix: correct iOS workspace path

### DIFF
--- a/.github/actions/ios-setup/action.yml
+++ b/.github/actions/ios-setup/action.yml
@@ -29,10 +29,12 @@ runs:
         ls -la /tmp/xg
         echo "Contents of /tmp/xg/xcodegen:"
         ls -la /tmp/xg/xcodegen
-        chmod +x /tmp/xg/xcodegen/xcodegen
+        echo "Contents of /tmp/xg/xcodegen/bin:"
+        ls -la /tmp/xg/xcodegen/bin
+        chmod +x /tmp/xg/xcodegen/bin/xcodegen
         INSTALL_DIR="/opt/homebrew/bin"
         sudo mkdir -p "$INSTALL_DIR"
-        sudo mv /tmp/xg/xcodegen/xcodegen "$INSTALL_DIR/xcodegen"
+        sudo mv /tmp/xg/xcodegen/bin/xcodegen "$INSTALL_DIR/xcodegen"
         echo "$INSTALL_DIR" >> "$GITHUB_PATH"
         /opt/homebrew/bin/xcodegen --version
 

--- a/.github/actions/ios-setup/action.yml
+++ b/.github/actions/ios-setup/action.yml
@@ -25,13 +25,16 @@ runs:
         VER="2.39.1"
         curl -L "https://github.com/yonaskolb/XcodeGen/releases/download/${VER}/xcodegen.zip" -o /tmp/xg.zip
         unzip -q /tmp/xg.zip -d /tmp/xg
-        XCODEGEN_BIN=$(find /tmp/xg -type f -name xcodegen -perm -111 | head -n 1)
+        echo "Contents of /tmp/xg:"
+        ls -la /tmp/xg
+        echo "Contents of /tmp/xg/xcodegen:"
+        ls -la /tmp/xg/xcodegen
+        chmod +x /tmp/xg/xcodegen/xcodegen
         INSTALL_DIR="/opt/homebrew/bin"
         sudo mkdir -p "$INSTALL_DIR"
-        sudo mv "$XCODEGEN_BIN" "$INSTALL_DIR/xcodegen"
-        chmod +x "$INSTALL_DIR/xcodegen"
+        sudo mv /tmp/xg/xcodegen/xcodegen "$INSTALL_DIR/xcodegen"
         echo "$INSTALL_DIR" >> "$GITHUB_PATH"
-        "$INSTALL_DIR/xcodegen" --version
+        /opt/homebrew/bin/xcodegen --version
 
     - name: Install CocoaPods
       shell: bash

--- a/.github/actions/ios-setup/action.yml
+++ b/.github/actions/ios-setup/action.yml
@@ -26,12 +26,15 @@ runs:
         curl -L "https://github.com/yonaskolb/XcodeGen/releases/download/${VER}/xcodegen.zip" -o /tmp/xg.zip
         unzip -q /tmp/xg.zip -d /tmp/xg
         XCODEGEN_BIN=$(find /tmp/xg -type f -name xcodegen -perm -111 | head -n 1)
-        INSTALL_DIR="/opt/homebrew/bin"
-        sudo mkdir -p "$INSTALL_DIR"
-        sudo mv "$XCODEGEN_BIN" "$INSTALL_DIR/xcodegen"
-        chmod +x "$INSTALL_DIR/xcodegen"
-        echo "$INSTALL_DIR" >> "$GITHUB_PATH"
-        "$INSTALL_DIR/xcodegen" --version
+        XCODEGEN_DIR=$(dirname "$(dirname "$XCODEGEN_BIN")")
+        INSTALL_BIN_DIR="/opt/homebrew/bin"
+        INSTALL_SHARE_DIR="/opt/homebrew/share"
+        sudo mkdir -p "$INSTALL_BIN_DIR" "$INSTALL_SHARE_DIR"
+        sudo mv "$XCODEGEN_BIN" "$INSTALL_BIN_DIR/xcodegen"
+        sudo mv "$XCODEGEN_DIR/share/XcodeGen" "$INSTALL_SHARE_DIR"
+        chmod +x "$INSTALL_BIN_DIR/xcodegen"
+        echo "$INSTALL_BIN_DIR" >> "$GITHUB_PATH"
+        "$INSTALL_BIN_DIR/xcodegen" --version
 
     - name: Install CocoaPods
       shell: bash

--- a/.github/actions/ios-setup/action.yml
+++ b/.github/actions/ios-setup/action.yml
@@ -25,18 +25,13 @@ runs:
         VER="2.39.1"
         curl -L "https://github.com/yonaskolb/XcodeGen/releases/download/${VER}/xcodegen.zip" -o /tmp/xg.zip
         unzip -q /tmp/xg.zip -d /tmp/xg
-        echo "Contents of /tmp/xg:"
-        ls -la /tmp/xg
-        echo "Contents of /tmp/xg/xcodegen:"
-        ls -la /tmp/xg/xcodegen
-        echo "Contents of /tmp/xg/xcodegen/bin:"
-        ls -la /tmp/xg/xcodegen/bin
-        chmod +x /tmp/xg/xcodegen/bin/xcodegen
+        XCODEGEN_BIN=$(find /tmp/xg -type f -name xcodegen -perm -111 | head -n 1)
         INSTALL_DIR="/opt/homebrew/bin"
         sudo mkdir -p "$INSTALL_DIR"
-        sudo mv /tmp/xg/xcodegen/bin/xcodegen "$INSTALL_DIR/xcodegen"
+        sudo mv "$XCODEGEN_BIN" "$INSTALL_DIR/xcodegen"
+        chmod +x "$INSTALL_DIR/xcodegen"
         echo "$INSTALL_DIR" >> "$GITHUB_PATH"
-        /opt/homebrew/bin/xcodegen --version
+        "$INSTALL_DIR/xcodegen" --version
 
     - name: Install CocoaPods
       shell: bash

--- a/.github/workflows/ios-build-unsigned.yml
+++ b/.github/workflows/ios-build-unsigned.yml
@@ -12,11 +12,12 @@ jobs:
       - uses: ./.github/actions/ios-setup
 
       - name: Build unsigned IPA
+        env:
+          SCHEME: MyOfflineLLMApp
+          WORKSPACE: ios/MyOfflineLLMApp.xcworkspace
+          IPA_OUTPUT: ${{ runner.temp }}/MyOfflineLLMApp-unsigned.ipa
         run: |
           chmod +x scripts/build_unsigned_ios.sh
-          SCHEME=MyOfflineLLMApp \
-          WORKSPACE=ios/MyOfflineLLMApp/MyOfflineLLMApp.xcworkspace \
-          IPA_OUTPUT=$RUNNER_TEMP/MyOfflineLLMApp-unsigned.ipa \
           ./scripts/build_unsigned_ios.sh
 
       - name: Upload unsigned IPA

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -30,7 +30,11 @@ jobs:
         run: pod install --repo-update
 
       - name: Import signing certificate
-        if: ${{ secrets.CERT_BASE64 != '' && secrets.CERT_PASSWORD != '' && secrets.KEYCHAIN_PASSWORD != '' }}
+        if: ${{ secrets.CERT_BASE64 && secrets.CERT_PASSWORD && secrets.KEYCHAIN_PASSWORD }}
+        env:
+          CERT_BASE64: ${{ secrets.CERT_BASE64 }}
+          CERT_PASSWORD: ${{ secrets.CERT_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
           printf "%s" "$CERT_BASE64" | base64 -D > /tmp/cert.p12
           security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain

--- a/scripts/build_unsigned_ios.sh
+++ b/scripts/build_unsigned_ios.sh
@@ -14,6 +14,11 @@ ARCHIVE_PATH="build/${SCHEME}.xcarchive"
 echo "Checking iOS directory structure..."
 ls -la ios/
 ls -la ios/MyOfflineLLMApp/
+if [[ ! -f "$WORKSPACE" ]]; then
+  echo "Workspace not found at $WORKSPACE" >&2
+  exit 1
+fi
+
 xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -configuration Release -archivePath "$ARCHIVE_PATH" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO archive
 
 APP_PATH="$ARCHIVE_PATH/Products/Applications/${SCHEME}.app"

--- a/scripts/build_unsigned_ios.sh
+++ b/scripts/build_unsigned_ios.sh
@@ -2,18 +2,25 @@
 # Build an unsigned iOS IPA.
 # Environment variables:
 #   SCHEME    - Xcode scheme (default: MyOfflineLLMApp)
-#   WORKSPACE - Xcode workspace path (default: ios/MyOfflineLLMApp/MyOfflineLLMApp.xcworkspace)
+#   WORKSPACE - Xcode workspace path (default: ios/MyOfflineLLMApp.xcworkspace)
 #   IPA_OUTPUT- Output path for the unsigned IPA (default: ${PWD}/${SCHEME}-unsigned.ipa)
 set -euo pipefail
 
 SCHEME=${SCHEME:-MyOfflineLLMApp}
-WORKSPACE=${WORKSPACE:-ios/MyOfflineLLMApp/MyOfflineLLMApp.xcworkspace}
+WORKSPACE=${WORKSPACE:-ios/MyOfflineLLMApp.xcworkspace}
 IPA_OUTPUT=${IPA_OUTPUT:-${PWD}/${SCHEME}-unsigned.ipa}
 ARCHIVE_PATH="build/${SCHEME}.xcarchive"
+
+echo "Generating Xcode project with XcodeGen..."
+xcodegen generate --spec ios/MyOfflineLLMApp/project.yml --project ios/MyOfflineLLMApp/MyOfflineLLMApp.xcodeproj
+
+echo "Installing CocoaPods dependencies..."
+pod install --project-directory=ios
 
 echo "Checking iOS directory structure..."
 ls -la ios/
 ls -la ios/MyOfflineLLMApp/
+ls -la ios/*.xcworkspace 2>/dev/null || true
 if [[ ! -f "$WORKSPACE" ]]; then
   echo "Workspace not found at $WORKSPACE" >&2
   exit 1

--- a/scripts/build_unsigned_ios.sh
+++ b/scripts/build_unsigned_ios.sh
@@ -11,6 +11,9 @@ WORKSPACE=${WORKSPACE:-ios/MyOfflineLLMApp/MyOfflineLLMApp.xcworkspace}
 IPA_OUTPUT=${IPA_OUTPUT:-${PWD}/${SCHEME}-unsigned.ipa}
 ARCHIVE_PATH="build/${SCHEME}.xcarchive"
 
+echo "Checking iOS directory structure..."
+ls -la ios/
+ls -la ios/MyOfflineLLMApp/
 xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -configuration Release -archivePath "$ARCHIVE_PATH" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO archive
 
 APP_PATH="$ARCHIVE_PATH/Products/Applications/${SCHEME}.app"
@@ -32,3 +35,4 @@ cp -R "$APP_PATH" "$PAYLOAD_DIR"
 zip -r "$IPA_OUTPUT" "$PAYLOAD_DIR"
 rm -rf "$PAYLOAD_DIR" "$ARCHIVE_PATH"
 echo "Created unsigned IPA at $IPA_OUTPUT"
+

--- a/scripts/build_unsigned_ios.sh
+++ b/scripts/build_unsigned_ios.sh
@@ -11,9 +11,13 @@ WORKSPACE=${WORKSPACE:-ios/MyOfflineLLMApp.xcworkspace}
 IPA_OUTPUT=${IPA_OUTPUT:-${PWD}/${SCHEME}-unsigned.ipa}
 ARCHIVE_PATH="build/${SCHEME}.xcarchive"
 
-if ! command -v xcodegen >/dev/null 2>&1; then
-  echo "xcodegen is required but not installed" >&2
-  exit 1
+echo "Checking iOS directory structure..."
+if [ -n "${WORKSPACE:-}" ]; then
+  ls -la "$(dirname "$WORKSPACE")" || true
+  ls -la "$WORKSPACE" || true
+else
+  ls -la "ios" || true
+fi
 fi
 
 echo "Generating Xcode project with XcodeGen..."

--- a/scripts/build_unsigned_ios.sh
+++ b/scripts/build_unsigned_ios.sh
@@ -11,6 +11,11 @@ WORKSPACE=${WORKSPACE:-ios/MyOfflineLLMApp.xcworkspace}
 IPA_OUTPUT=${IPA_OUTPUT:-${PWD}/${SCHEME}-unsigned.ipa}
 ARCHIVE_PATH="build/${SCHEME}.xcarchive"
 
+if ! command -v xcodegen >/dev/null 2>&1; then
+  echo "xcodegen is required but not installed" >&2
+  exit 1
+fi
+
 echo "Generating Xcode project with XcodeGen..."
 xcodegen generate --spec ios/MyOfflineLLMApp/project.yml --project ios/MyOfflineLLMApp/MyOfflineLLMApp.xcodeproj
 


### PR DESCRIPTION
## Summary
- fix typo in iOS workspace path for unsigned builds
- add directory listing to verify iOS workspace before archiving

## Testing
- `npx prettier scripts/build_unsigned_ios.sh --write` *(fails: No parser could be inferred)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ecab23188333bd8a510d65f34857

## Summary by Sourcery

Fix the iOS unsigned build script by correcting the default workspace path and adding directory listings for debugging before archiving.

Bug Fixes:
- Correct the default iOS workspace path for unsigned builds

Enhancements:
- Add directory listing commands to verify the iOS workspace structure before archiving

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Hardened unsigned iOS packaging: added preflight project/dependency generation, directory validations, safer path guards, automatic cleanup, and clearer success/error messages.
  - Improved packaging flow with centralized payload handling and stricter sanity checks to prevent accidental overwrites.

- CI
  - Simplified certificate import checks to a single truthiness condition and passed secrets into steps as environment variables for more reliable runs.
  - Switched build step to supply required env vars at the step level for cleaner invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->