### PR TITLE
chore(ios): add clean build script and pin deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 > Offline LLM assistant for mobile devices built with React Native.
 
-![Node](https://img.shields.io/badge/node-%3E=20.19.4-43853d?logo=node.js) ![React Native](https://img.shields.io/badge/React%20Native-0.81.x-61DAFB?logo=react)
+![Node](https://img.shields.io/badge/node-%3E=18.0.0-43853d?logo=node.js) ![React Native](https://img.shields.io/badge/React%20Native-0.81.x-61DAFB?logo=react)
 
 ## Quick Start
 
 ### Prereqs
 
-- Node >= 20.19.4
+- Node >= 18.0.0
 - Xcode 16.x with command line tools
 - Ruby & Bundler
 - CocoaPods
@@ -35,6 +35,12 @@ npx react-native run-ios
 
 ```bash
 npm test
+```
+
+### Clean iOS build
+
+```bash
+./scripts/clean-build-ios.sh
 ```
 
 ## Installation & Setup

--- a/app.json
+++ b/app.json
@@ -1,4 +1,12 @@
 {
   "name": "MyOfflineLLMApp",
-  "displayName": "MyOfflineLLMApp"
+  "displayName": "MyOfflineLLMApp",
+  "ios": {
+    "bundleIdentifier": "com.myofflinellmapp",
+    "buildNumber": "1",
+    "target": "18.0"
+  },
+  "android": {
+    "package": "com.myofflinellmapp"
+  }
 }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,3 +1,4 @@
+# Ensure the platform is set to iOS 18.0
 platform :ios, '18.0'
 ENV['RCT_NEW_ARCH_ENABLED'] = "1" # Enable Fabric/TurboModules
 install! 'cocoapods', :disable_input_output_paths => true
@@ -36,6 +37,7 @@ target app_target do
   end
 
   post_install do |installer|
+    # Normalize the deployment target for all pods to 18.0
     installer.pods_project.build_configurations.each do |c|
       c.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '18.0'
       # Build Simulator for arm64 on Apple Silicon runners

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@react-native-voice/voice": "^3.2.4",
         "@xenova/transformers": "^2.17.2",
         "cheerio": "^1.1.2",
-        "crypto-js": "^4.2.0",
+        "crypto-js": "4.2.0",
         "langchain": "^0.3.31",
         "react": "18.2.0",
         "react-native": "0.81.1",
@@ -55,7 +55,7 @@
         "typescript": "5.9.2"
       },
       "engines": {
-        "node": ">=20.19.4"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@react-native-voice/voice": "^3.2.4",
     "@xenova/transformers": "^2.17.2",
     "cheerio": "^1.1.2",
-    "crypto-js": "^4.2.0",
+    "crypto-js": "4.2.0",
     "langchain": "^0.3.31",
     "react": "18.2.0",
     "react-native": "0.81.1",
@@ -70,7 +70,7 @@
     "@types/react": "^19.1.12"
   },
   "engines": {
-    "node": ">=20.19.4"
+    "node": ">=18.0.0"
   },
   "react-native": {
     "hermes": true

--- a/scripts/clean-build-ios.sh
+++ b/scripts/clean-build-ios.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Starting clean iOS build process..."
+
+# Step 1: Clean JavaScript dependencies
+rm -rf node_modules package-lock.json
+
+# Step 2: Clean iOS native dependencies and build artifacts
+pushd ios >/dev/null
+rm -rf Pods Podfile.lock build
+popd >/dev/null
+
+# Step 3: Reinstall all dependencies
+npm install
+pushd ios >/dev/null
+pod install --repo-update
+popd >/dev/null
+
+# Step 4: Reset the React Native bundler cache
+npx react-native start --reset-cache &
+BUNDLER_PID=$!
+sleep 10
+
+# Step 5: Build the iOS application
+npx react-native build-ios --mode Release
+
+# Step 6: Kill the bundler process
+kill $BUNDLER_PID
+
+echo "✅ Clean iOS build process completed successfully."


### PR DESCRIPTION
## Summary
- document iOS 18 deployment target and normalize pods
- pin crypto-js version and relax Node engine to >=18
- add helper script to clean and rebuild iOS
- document Node 18 requirement and clean build usage

## Testing
- `bundle exec pod install --repo-update` *(fails: bundler: command not found: pod)*
- `npm test`
- `npm run lint` *(fails: 21 errors, 2 warnings)*
- `npm run format:check` *(fails: Code style issues found in 51 files)*

------
https://chatgpt.com/codex/tasks/task_e_68b4941f26848333ad4adc54955830cb