### PR TITLE
feat(privacy): enhance consent management

### DIFF
--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -17,7 +17,7 @@ env:
   WORKSPACE: "ios/MyOfflineLLMApp.xcworkspace"
   ENABLE_SIGNED_EXPORT: "false"   # set to "true" if you want the optional signed export steps
   IOS_SIM_DEVICE: "iPhone 16 Pro"
-  IOS_SIM_OS: "18.5"              # default runtime; Boot step falls back if missing
+  IOS_SIM_OS: "18.6"              # default runtime; Boot step falls back to 18.4 if missing
 
 jobs:
   sim-build:
@@ -38,7 +38,7 @@ jobs:
         run: npm run ci:install
 
       - name: Run tests
-        run: npm test
+        run: npm run test:ci
 
       - name: Set up Xcode 16.4
         run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
@@ -91,8 +91,8 @@ jobs:
         run: |
           set -euo pipefail
           if ! xcrun simctl list runtimes | grep -q "iOS ${IOS_SIM_OS}"; then
-            echo "::warning::iOS ${IOS_SIM_OS} not found, falling back to latest available"
-            IOS_SIM_OS=$(xcrun simctl list runtimes | grep -o "iOS 18.[0-9]" | sort -V | tail -1 | awk '{print $2}')
+            echo "::warning::iOS ${IOS_SIM_OS} not found, falling back to 18.4"
+            IOS_SIM_OS="18.4"
             echo "IOS_SIM_OS=$IOS_SIM_OS" >> "$GITHUB_ENV"
           fi
           RUNTIME_ID=$(xcrun simctl list runtimes -j | python3 -c 'import json,sys,os; j=json.load(sys.stdin); t=os.environ["IOS_SIM_OS"]; print(next((r["identifier"] for r in j["runtimes"] if r.get("platform")=="iOS" and r.get("version")==t and r.get("isAvailable",True)), ""))')

--- a/.github/workflows/ios-xcresult-json.yml
+++ b/.github/workflows/ios-xcresult-json.yml
@@ -1,4 +1,4 @@
-name: iOS Build - xcresult JSON (iPhone 16 Pro iOS 18.x fallback 18.6→18.5→18.4)
+name: iOS Build - xcresult JSON (iPhone 16 Pro iOS 18.x fallback 18.6→18.4)
 
 on:
   workflow_dispatch:
@@ -33,6 +33,9 @@ jobs:
 
       - name: Install JS deps
         run: npm ci
+
+      - name: Run tests
+        run: npm run test:ci
 
       - name: Setup Ruby & CocoaPods
         uses: ruby/setup-ruby@v1
@@ -76,7 +79,7 @@ jobs:
           fi
           jq --version || true
 
-      # Prefer iOS 18.6, then 18.5, then 18.4; create iPhone 16 Pro if missing
+      # Prefer iOS 18.6, then 18.4; create iPhone 16 Pro if missing
       - name: Resolve/create & boot Simulator (iPhone 16 Pro; iOS 18.x highest available)
         id: sim
         shell: bash
@@ -84,7 +87,6 @@ jobs:
           set -euo pipefail
 
           WANT_RUNTIMES=("com.apple.CoreSimulator.SimRuntime.iOS-18-6" \
-                         "com.apple.CoreSimulator.SimRuntime.iOS-18-5" \
                          "com.apple.CoreSimulator.SimRuntime.iOS-18-4")
 
           RUNTIME=""
@@ -99,7 +101,7 @@ jobs:
           done
 
           if [ -z "$RUNTIME" ]; then
-            echo "::error::No iOS 18.6 / 18.5 / 18.4 runtime found on this runner."
+            echo "::error::No iOS 18.6 / 18.4 runtime found on this runner."
             xcrun simctl list runtimes
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -110,6 +110,26 @@ npm run format:check
 - `MODEL_URL` – remote model to download on first run.
 - `MEMORY_ENABLED` / `MEMORY_MAX_MB` – toggle and size for on-device memory.
 
+## Consent Management
+
+The app uses a privacy-focused consent system (`src/privacy/consents.ts`) to manage permissions for features like camera and location.
+
+- Validates consent keys (`camera`, `location`, `contacts`, `photos`, `microphone`).
+- Stores consents with timestamps in AsyncStorage.
+- Logs operations for debugging.
+- Throws `ConsentError` for invalid keys.
+
+```typescript
+import { getConsent, setConsent } from './src/privacy/consents';
+
+async function requestCameraAccess() {
+  const consent = await getConsent('camera');
+  if (!consent?.value) {
+    await setConsent('camera', true);
+  }
+}
+```
+
 ## Troubleshooting
 
 - **npm ERESOLVE**: installs ignore peers via `.npmrc` or `npm run ci:install`.

--- a/__tests__/consents.test.js
+++ b/__tests__/consents.test.js
@@ -9,6 +9,7 @@ jest.mock('@react-native-async-storage/async-storage', () => {
       delete store[k];
     },
     getAllKeys: async () => Object.keys(store),
+    multiGet: async (keys) => keys.map((k) => [k, store[k] || null]),
     __clear: () => {
       store = {};
     },
@@ -21,11 +22,40 @@ const AsyncStorage = require('@react-native-async-storage/async-storage');
 
 beforeEach(() => AsyncStorage.__clear());
 
-test('consent set/get/list', async () => {
-  await setConsent('camera', true);
-  expect((await getConsent('camera')).value).toBe(true);
-  const list = await listConsents();
-  expect(list.camera.value).toBe(true);
-  await revokeConsent('camera');
-  expect(await getConsent('camera')).toBeNull();
+describe('Consent Management', () => {
+  test('set and get valid consent', async () => {
+    await setConsent('camera', true);
+    const consent = await getConsent('camera');
+    expect(consent).toEqual({ key: 'camera', value: true, timestamp: expect.any(Number) });
+  });
+
+  test('reject invalid consent key', async () => {
+    await expect(setConsent('invalid', true)).rejects.toThrow('Invalid consent key');
+    expect(await getConsent('invalid')).toBeNull();
+  });
+
+  test('list consents', async () => {
+    await setConsent('camera', true);
+    await setConsent('location', false);
+    const consents = await listConsents();
+    expect(consents).toEqual({
+      camera: { key: 'camera', value: true, timestamp: expect.any(Number) },
+      location: { key: 'location', value: false, timestamp: expect.any(Number) },
+    });
+  });
+
+  test('revoke consent', async () => {
+    await setConsent('camera', true);
+    await revokeConsent('camera');
+    expect(await getConsent('camera')).toBeNull();
+  });
+
+  test('revoke invalid key does not throw', async () => {
+    await expect(revokeConsent('invalid')).resolves.toBeUndefined();
+  });
+
+  test('handle AsyncStorage error gracefully', async () => {
+    jest.spyOn(AsyncStorage, 'setItem').mockRejectedValueOnce(new Error('Storage error'));
+    await expect(setConsent('camera', true)).rejects.toThrow('Storage error');
+  });
 });

--- a/src/privacy/consents.ts
+++ b/src/privacy/consents.ts
@@ -1,29 +1,86 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Logger } from '../utils/logger';
 
-const PREFIX = 'consent:';
+const VALID_CONSENTS = ['camera', 'location', 'contacts', 'photos', 'microphone'] as const;
+type ConsentKey = (typeof VALID_CONSENTS)[number];
 
-export async function setConsent(tool: string, value: boolean) {
-  const record = { value, timestamp: Date.now() };
-  await AsyncStorage.setItem(PREFIX + tool, JSON.stringify(record));
+interface ConsentRecord {
+  key: ConsentKey;
+  value: boolean;
+  timestamp: number;
 }
 
-export async function getConsent(tool: string) {
-  const raw = await AsyncStorage.getItem(PREFIX + tool);
-  return raw ? JSON.parse(raw) : null;
-}
+const CONSENT_PREFIX = 'consent_';
 
-export async function revokeConsent(tool: string) {
-  await AsyncStorage.removeItem(PREFIX + tool);
-}
-
-export async function listConsents() {
-  const keys = await AsyncStorage.getAllKeys();
-  const consents: Record<string, any> = {};
-  for (const key of keys) {
-    if (key.startsWith(PREFIX)) {
-      const val = await AsyncStorage.getItem(key);
-      if (val) consents[key.slice(PREFIX.length)] = JSON.parse(val);
-    }
+class ConsentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConsentError';
   }
-  return consents;
+}
+
+export async function setConsent(key: string, value: boolean): Promise<void> {
+  if (!VALID_CONSENTS.includes(key as ConsentKey)) {
+    Logger.error(`Invalid consent key: ${key}`);
+    throw new ConsentError(
+      `Invalid consent key: ${key}. Allowed: ${VALID_CONSENTS.join(', ')}`,
+    );
+  }
+  const record: ConsentRecord = { key: key as ConsentKey, value, timestamp: Date.now() };
+  try {
+    await AsyncStorage.setItem(`${CONSENT_PREFIX}${key}`, JSON.stringify(record));
+    Logger.info(`Consent set: ${key} = ${value}`);
+  } catch (error: any) {
+    Logger.error(`Failed to set consent for ${key}: ${error.message}`);
+    throw error;
+  }
+}
+
+export async function getConsent(key: string): Promise<ConsentRecord | null> {
+  if (!VALID_CONSENTS.includes(key as ConsentKey)) {
+    Logger.warn(`Attempted to get invalid consent key: ${key}`);
+    return null;
+  }
+  try {
+    const value = await AsyncStorage.getItem(`${CONSENT_PREFIX}${key}`);
+    return value ? (JSON.parse(value) as ConsentRecord) : null;
+  } catch (error: any) {
+    Logger.error(`Failed to get consent for ${key}: ${error.message}`);
+    return null;
+  }
+}
+
+export async function revokeConsent(key: string): Promise<void> {
+  if (!VALID_CONSENTS.includes(key as ConsentKey)) {
+    Logger.warn(`Attempted to revoke invalid consent key: ${key}`);
+    return;
+  }
+  try {
+    await AsyncStorage.removeItem(`${CONSENT_PREFIX}${key}`);
+    Logger.info(`Consent revoked: ${key}`);
+  } catch (error: any) {
+    Logger.error(`Failed to revoke consent for ${key}: ${error.message}`);
+    throw error;
+  }
+}
+
+export async function listConsents(): Promise<Record<ConsentKey, ConsentRecord>> {
+  try {
+    const keys = await AsyncStorage.getAllKeys();
+    const consentKeys = keys.filter((k) => k.startsWith(CONSENT_PREFIX));
+    const entries = await AsyncStorage.multiGet(consentKeys);
+    const result: Partial<Record<ConsentKey, ConsentRecord>> = {};
+    for (const [key, value] of entries) {
+      if (value) {
+        const consentKey = key.replace(CONSENT_PREFIX, '') as ConsentKey;
+        if (VALID_CONSENTS.includes(consentKey)) {
+          result[consentKey] = JSON.parse(value) as ConsentRecord;
+        }
+      }
+    }
+    return result as Record<ConsentKey, ConsentRecord>;
+  } catch (error: any) {
+    Logger.error(`Failed to list consents: ${error.message}`);
+    return {} as Record<ConsentKey, ConsentRecord>;
+  }
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,13 @@
+export class Logger {
+  static info(message: string): void {
+    console.log(`[INFO] ${message}`);
+  }
+
+  static warn(message: string): void {
+    console.warn(`[WARN] ${message}`);
+  }
+
+  static error(message: string): void {
+    console.error(`[ERROR] ${message}`);
+  }
+}


### PR DESCRIPTION
### **User description**
## Summary
- validate consent keys and log operations
- document consent management usage
- target iOS 18.6 with fallback to 18.4 in workflows

## Testing
- `npm test`
- `npm run lint` *(fails: no-unused-vars and others)*
- `npm run format:check` *(warn: code style issues in 51 files)*

------
https://chatgpt.com/codex/tasks/task_e_68b49fccdf548333b2fb65301fe6a0e7


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhanced consent management with validation and logging

- Added comprehensive test coverage for consent operations

- Updated iOS CI workflows to target 18.6 with 18.4 fallback

- Added logger utility for debugging and error tracking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Consent Request"] --> B["Validate Key"]
  B --> C["Store with Timestamp"]
  C --> D["Log Operation"]
  B --> E["Throw ConsentError"]
  F["AsyncStorage"] --> G["Logger Utility"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>consents.test.js</strong><dd><code>Comprehensive consent management test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

__tests__/consents.test.js

<ul><li>Added <code>multiGet</code> mock to AsyncStorage<br> <li> Restructured tests with describe block and comprehensive test cases<br> <li> Added validation, error handling, and edge case tests<br> <li> Enhanced test assertions with timestamp and structure validation</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/offLLM/pull/45/files#diff-310fbd94ef9e9e3bacbe43cfe7751a8fa0eef088b04bde8034f1dbc641eec69a">+37/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>consents.ts</strong><dd><code>Enhanced consent management with validation and logging</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/privacy/consents.ts

<ul><li>Added consent key validation with predefined allowed keys<br> <li> Implemented ConsentRecord interface with timestamp tracking<br> <li> Added comprehensive error handling and logging throughout<br> <li> Enhanced listConsents with multiGet for better performance</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/offLLM/pull/45/files#diff-3fa478f017cd17321aab9288ea339cc70265a1ddeab7f4639d5369de3bf5458c">+74/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>logger.ts</strong><dd><code>New Logger utility for structured logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/logger.ts

<ul><li>Created new Logger utility class<br> <li> Implemented info, warn, and error logging methods<br> <li> Added structured console output with prefixes</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/offLLM/pull/45/files#diff-0b242f99cdb5b36e8a0aa886862c30c2f480aca7512bcfc3e2fa4889055d4544">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ios-unsigned.yml</strong><dd><code>iOS CI workflow updates for 18.6 target</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ios-unsigned.yml

<ul><li>Updated iOS simulator OS target from 18.5 to 18.6<br> <li> Changed fallback logic to use 18.4 instead of latest available<br> <li> Updated test command to use <code>npm run test:ci</code></ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/offLLM/pull/45/files#diff-e8c67420ada68ed2aa9e0a16e2a0a78b28b236ba97af834b0fac50e8bf6fefb7">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ios-xcresult-json.yml</strong><dd><code>iOS xcresult workflow configuration updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ios-xcresult-json.yml

<ul><li>Updated workflow name to reflect 18.6→18.4 fallback<br> <li> Removed 18.5 from runtime fallback chain<br> <li> Added test execution step with <code>npm run test:ci</code></ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/offLLM/pull/45/files#diff-4b321074d9dff6edc7a9189af200164b0451639ee94131c54b26bc1a1c53cbd8">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Added consent management documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added comprehensive consent management documentation section<br> <li> Included usage examples with TypeScript code<br> <li> Documented consent validation, storage, and error handling features</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/offLLM/pull/45/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

