### PR TITLE
fix(ios): disable optimization for Debug pod builds

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -10,7 +10,8 @@ project_candidates = Dir['*.xcodeproj'] + Dir['**/*.xcodeproj']
 project_path = project_candidates.first
 raise "No .xcodeproj found near Podfile (#{__dir__})" unless project_path
 
-project project_path
+# Map build configurations so CocoaPods knows which are debug vs release
+project project_path, 'Debug' => :debug, 'Release' => :release
 app_target = File.basename(project_path, '.xcodeproj')
 
 USE_FLIPPER = ENV['USE_FLIPPER'] == '1'
@@ -37,17 +38,25 @@ target app_target do
   end
 
   post_install do |installer|
-    # Normalize the deployment target for all pods to 18.0
+    # Normalize the deployment target and disable optimization in Debug for SwiftUI previews
     installer.pods_project.build_configurations.each do |c|
       c.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '18.0'
       # Build Simulator for arm64 on Apple Silicon runners
       c.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'x86_64'
+      # Force -Onone for Debug builds so previews work
+      if c.name.include?('Debug')
+        c.build_settings['SWIFT_OPTIMIZATION_LEVEL'] = '-Onone'
+      end
     end
     installer.pods_project.targets.each do |t|
       t.build_configurations.each do |c|
         c.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '18.0'
         c.build_settings['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] = 'NO'
         c.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'x86_64'
+        # Force -Onone for Debug builds so previews work
+        if c.name.include?('Debug')
+          c.build_settings['SWIFT_OPTIMIZATION_LEVEL'] = '-Onone'
+        end
       end
     end
     react_native_post_install(installer)


### PR DESCRIPTION
## Summary
- map build configurations so CocoaPods recognizes Debug vs Release
- force `-Onone` Swift optimization level for pod Debug builds to keep SwiftUI previews

## Testing
- `bundle exec pod install --repo-update --allow-root` *(fails: No .xcodeproj found near Podfile)*
- `npm test`
- `npm run lint`
- `npm run format:check` *(fails: Code style issues found in 50 files)*

------
https://chatgpt.com/codex/tasks/task_e_68b630c0fdd88333b7771b30d51aafd7