### PR TITLE
fix(ios): harden post_integrate Hermes cleanup

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,7 +3,7 @@ name: Android
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
   workflow_call:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [main]
 
 permissions:
   contents: read
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm  # built-in caching per docs
+          cache: npm # built-in caching per docs
       # keeps installs fast while using lockfile determinism.
 
       - name: Install deps from lockfile

--- a/.github/workflows/ios-simulator.yml
+++ b/.github/workflows/ios-simulator.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Scrub Hermes script phases
         working-directory: ios
         run: |
-          bundle exec ruby ../scripts/strip_hermes_phase.rb Pods/Pods.xcodeproj MyOfflineLLMApp.xcodeproj
+          bundle exec ruby ../scripts/strip_hermes_phase.rb $(find Pods -name "*.xcodeproj") MyOfflineLLMApp.xcodeproj
 
       - name: Assert Hermes phase is gone
         run: |

--- a/.github/workflows/ios-simulator.yml
+++ b/.github/workflows/ios-simulator.yml
@@ -2,7 +2,7 @@ name: iOS Simulator
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
   pull_request:
 
 jobs:
@@ -16,6 +16,7 @@ jobs:
       SCHEME: MyOfflineLLMApp
       CONFIGURATION: Debug
       SIM_DEVICE: iPhone 16 Pro
+      BUILD_DIR: build
     steps:
       - uses: actions/checkout@v4
 
@@ -70,16 +71,10 @@ jobs:
       - name: Resolve Swift package dependencies
         run: xcodebuild -resolvePackageDependencies -workspace ios/MyOfflineLLMApp.xcworkspace -scheme MyOfflineLLMApp -UseModernBuildSystem=YES
 
-      - name: Verify Hermes script removed
-        run: |
-          if /usr/bin/grep -R --include=project.pbxproj --line-number -i "replace hermes" ios/Pods 2>/dev/null; then
-            echo "::error::Forbidden Hermes 'Replace Hermes' script phase detected after pod install."
-            exit 1
-          fi
-
       - name: Build (Simulator)
         run: |
           set -euo pipefail
+          mkdir -p "${BUILD_DIR}"
           xcodebuild \
             -workspace ios/MyOfflineLLMApp.xcworkspace \
             -scheme "${SCHEME}" \
@@ -88,4 +83,21 @@ jobs:
             -destination "platform=iOS Simulator,name=${SIM_DEVICE}" \
             -UseModernBuildSystem=YES \
             CODE_SIGNING_ALLOWED=NO \
-            clean build | xcpretty
+            clean build | tee "${BUILD_DIR}/xcodebuild.log" | xcpretty
+
+      - name: Upload xcodebuild log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xcodebuild-log
+          path: ${{ env.BUILD_DIR }}/xcodebuild.log
+
+      - name: Summarize build log
+        if: always()
+        run: |
+          if [ -f "${BUILD_DIR}/xcodebuild.log" ]; then
+            echo "Summary of warnings and errors:"
+            grep -iE "error|warning|failed" "${BUILD_DIR}/xcodebuild.log" | tail -n 200 || true
+          else
+            echo "No xcodebuild.log found"
+          fi

--- a/.github/workflows/ios-simulator.yml
+++ b/.github/workflows/ios-simulator.yml
@@ -76,22 +76,11 @@ jobs:
       - name: Assert Hermes phase is gone
         run: |
           set -euo pipefail
-          ruby -e '
-            require "xcodeproj";
-            p = Xcodeproj::Project.open("ios/Pods/Pods.xcodeproj");
-            offenders = [];
-            p.targets.each do |t|
-              t.build_phases.select{ |bp| bp.isa=="PBXShellScriptBuildPhase" }.each do |bp|
-                name = (bp.name || "").downcase;
-                body = (bp.shell_script || "").downcase;
-                offenders << "#{t.name} :: #{bp.name}" if name.include?("replace hermes") || body.include?("replace hermes");
-              end;
-            end;
-            if offenders.any?
-              warn "Remaining Hermes phases:\n  #{offenders.join("\n  ")}";
-              exit 1;
-            end;
-          '
+          if /usr/bin/grep -R --include=project.pbxproj --line-number -i "Replace Hermes|\[Hermes\]" \
+               ios/Pods ios/MyOfflineLLMApp.xcodeproj 2>/dev/null; then
+            echo "::error::Forbidden Hermes 'Replace Hermes' script phase still present after scrubbing."
+            exit 1
+          fi
           echo "✅ Hermes phase not found."
 
       - name: Snapshot Pods shell script phases (forensics)

--- a/.github/workflows/ios-simulator.yml
+++ b/.github/workflows/ios-simulator.yml
@@ -68,6 +68,28 @@ jobs:
         working-directory: ios
         run: bundle exec pod install --repo-update
 
+      - name: Scrub Hermes script phases
+        run: |
+          ruby scripts/strip_hermes_phase.rb ios/Pods/Pods.xcodeproj ios/MyOfflineLLMApp.xcodeproj
+
+      - name: Assert Hermes phase is gone
+        run: |
+          set -euo pipefail
+          if /usr/bin/grep -R --line-number -E "Replace Hermes|\\[Hermes\\]" ios/Pods/Pods.xcodeproj/project.pbxproj ios/MyOfflineLLMApp.xcodeproj/project.pbxproj; then
+            echo "::error::Forbidden Hermes 'Replace Hermes' script phase still present after scrubbing."
+            exit 1
+          fi
+          echo "✅ Hermes phase not found."
+
+      - name: Upload Xcode project files (debug)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xcode-projects-after-scrub
+          path: |
+            ios/Pods/Pods.xcodeproj/project.pbxproj
+            ios/MyOfflineLLMApp.xcodeproj/project.pbxproj
+
       - name: Resolve Swift package dependencies
         run: xcodebuild -resolvePackageDependencies -workspace ios/MyOfflineLLMApp.xcworkspace -scheme MyOfflineLLMApp -UseModernBuildSystem=YES
 

--- a/.github/workflows/ios-simulator.yml
+++ b/.github/workflows/ios-simulator.yml
@@ -1,0 +1,91 @@
+name: iOS Simulator
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  build:
+    name: Simulator build (iPhone 16 Pro / iOS 18)
+    runs-on: macos-15
+    env:
+      NODE_OPTIONS: --max_old_space_size=4096
+      RCT_NEW_ARCH_ENABLED: 1
+      USE_HERMES: true
+      SCHEME: MyOfflineLLMApp
+      CONFIGURATION: Debug
+      SIM_DEVICE: iPhone 16 Pro
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Node deps
+        run: npm ci
+
+      - name: Cache Bundler
+        uses: actions/cache@v4
+        with:
+          path: ios/vendor/bundle
+          key: ${{ runner.os }}-bundler-${{ hashFiles('ios/Gemfile.lock') }}
+          restore-keys: ${{ runner.os }}-bundler-
+
+      - name: Bundle config path
+        working-directory: ios
+        run: bundle config set path vendor/bundle
+
+      - name: Bundle install
+        working-directory: ios
+        run: bundle install
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Clean DerivedData
+        run: rm -rf ~/Library/Developer/Xcode/DerivedData/*
+
+      - name: Generate Xcode project
+        run: xcodegen generate --spec ios/project.yml
+
+      - name: Clean CocoaPods sandbox if stale
+        working-directory: ios
+        run: |
+          set -euo pipefail
+          rm -f Pods/Manifest.lock
+          rm -rf Pods/Headers || true
+
+      - name: Set NODE_BINARY for Xcode scripts
+        run: |
+          rm -f ios/.xcode.env.local
+          printf 'export NODE_BINARY="%s"\n' "$(command -v node)" > ios/.xcode.env
+
+      - name: Install Pods (bundler)
+        working-directory: ios
+        run: bundle exec pod install --repo-update
+
+      - name: Resolve Swift package dependencies
+        run: xcodebuild -resolvePackageDependencies -workspace ios/MyOfflineLLMApp.xcworkspace -scheme MyOfflineLLMApp -UseModernBuildSystem=YES
+
+      - name: Verify Hermes script removed
+        run: |
+          if /usr/bin/grep -R --include=project.pbxproj --line-number -i "replace hermes" ios/Pods 2>/dev/null; then
+            echo "::error::Forbidden Hermes 'Replace Hermes' script phase detected after pod install."
+            exit 1
+          fi
+
+      - name: Build (Simulator)
+        run: |
+          set -euo pipefail
+          xcodebuild \
+            -workspace ios/MyOfflineLLMApp.xcworkspace \
+            -scheme "${SCHEME}" \
+            -configuration "${CONFIGURATION}" \
+            -sdk iphonesimulator \
+            -destination "platform=iOS Simulator,name=${SIM_DEVICE}" \
+            -UseModernBuildSystem=YES \
+            CODE_SIGNING_ALLOWED=NO \
+            clean build | xcpretty

--- a/.github/workflows/ios-simulator.yml
+++ b/.github/workflows/ios-simulator.yml
@@ -71,27 +71,53 @@ jobs:
       - name: Scrub Hermes script phases
         working-directory: ios
         run: |
-          bundle exec ruby ../scripts/strip_hermes_phase.rb Pods/Pods.xcodeproj ../ios/MyOfflineLLMApp.xcodeproj
+          bundle exec ruby ../scripts/strip_hermes_phase.rb Pods/Pods.xcodeproj MyOfflineLLMApp.xcodeproj
 
       - name: Assert Hermes phase is gone
         run: |
           set -euo pipefail
-          if /usr/bin/grep -R --line-number -E "Replace Hermes|\\[Hermes\\]" \
-               ios/Pods/Pods.xcodeproj/project.pbxproj ios/MyOfflineLLMApp.xcodeproj/project.pbxproj; then
-            echo "::error::Forbidden Hermes 'Replace Hermes' script phase still present after scrubbing."
-            exit 1
-          fi
+          ruby -e '
+            require "xcodeproj";
+            p = Xcodeproj::Project.open("ios/Pods/Pods.xcodeproj");
+            offenders = [];
+            p.targets.each do |t|
+              t.build_phases.select{ |bp| bp.isa=="PBXShellScriptBuildPhase" }.each do |bp|
+                name = (bp.name || "").downcase;
+                body = (bp.shell_script || "").downcase;
+                offenders << "#{t.name} :: #{bp.name}" if name.include?("replace hermes") || body.include?("replace hermes");
+              end;
+            end;
+            if offenders.any?
+              warn "Remaining Hermes phases:\n  #{offenders.join("\n  ")}";
+              exit 1;
+            end;
+          '
           echo "✅ Hermes phase not found."
 
-      - name: Upload Xcode project files (debug)
+      - name: Snapshot Pods shell script phases (forensics)
         if: always()
+        run: |
+          mkdir -p build
+          ruby - <<'RUBY' > build/pods_shell_scripts.txt
+            require 'xcodeproj'
+            p = Xcodeproj::Project.open('ios/Pods/Pods.xcodeproj')
+            p.targets.each do |t|
+              t.build_phases
+               .select { |bp| bp.isa == 'PBXShellScriptBuildPhase' }
+               .each { |bp| puts "#{t.name} :: #{bp.name}" }
+            end
+          RUBY
+
+      - name: Upload Pods/Xcode projects on failure
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: xcode-projects-after-scrub
+          name: ios-forensics-${{ github.job }}
           path: |
             ios/Podfile.lock
             ios/Pods/Pods.xcodeproj/project.pbxproj
             ios/MyOfflineLLMApp.xcodeproj/project.pbxproj
+            build/pods_shell_scripts.txt
 
       - name: Resolve Swift package dependencies
         run: xcodebuild -resolvePackageDependencies -workspace ios/MyOfflineLLMApp.xcworkspace -scheme MyOfflineLLMApp -UseModernBuildSystem=YES

--- a/.github/workflows/ios-simulator.yml
+++ b/.github/workflows/ios-simulator.yml
@@ -69,13 +69,15 @@ jobs:
         run: bundle exec pod install --repo-update
 
       - name: Scrub Hermes script phases
+        working-directory: ios
         run: |
-          ruby scripts/strip_hermes_phase.rb ios/Pods/Pods.xcodeproj ios/MyOfflineLLMApp.xcodeproj
+          bundle exec ruby ../scripts/strip_hermes_phase.rb Pods/Pods.xcodeproj ../ios/MyOfflineLLMApp.xcodeproj
 
       - name: Assert Hermes phase is gone
         run: |
           set -euo pipefail
-          if /usr/bin/grep -R --line-number -E "Replace Hermes|\\[Hermes\\]" ios/Pods/Pods.xcodeproj/project.pbxproj ios/MyOfflineLLMApp.xcodeproj/project.pbxproj; then
+          if /usr/bin/grep -R --line-number -E "Replace Hermes|\\[Hermes\\]" \
+               ios/Pods/Pods.xcodeproj/project.pbxproj ios/MyOfflineLLMApp.xcodeproj/project.pbxproj; then
             echo "::error::Forbidden Hermes 'Replace Hermes' script phase still present after scrubbing."
             exit 1
           fi
@@ -87,6 +89,7 @@ jobs:
         with:
           name: xcode-projects-after-scrub
           path: |
+            ios/Podfile.lock
             ios/Pods/Pods.xcodeproj/project.pbxproj
             ios/MyOfflineLLMApp.xcodeproj/project.pbxproj
 

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -75,22 +75,11 @@ jobs:
       - name: Assert Hermes phase is gone
         run: |
           set -euo pipefail
-          ruby -e '
-            require "xcodeproj";
-            p = Xcodeproj::Project.open("ios/Pods/Pods.xcodeproj");
-            offenders = [];
-            p.targets.each do |t|
-              t.build_phases.select{ |bp| bp.isa=="PBXShellScriptBuildPhase" }.each do |bp|
-                name = (bp.name || "").downcase;
-                body = (bp.shell_script || "").downcase;
-                offenders << "#{t.name} :: #{bp.name}" if name.include?("replace hermes") || body.include?("replace hermes");
-              end;
-            end;
-            if offenders.any?
-              warn "Remaining Hermes phases:\n  #{offenders.join("\n  ")}";
-              exit 1;
-            end;
-          '
+          if /usr/bin/grep -R --include=project.pbxproj --line-number -i "Replace Hermes|\[Hermes\]" \
+               ios/Pods ios/MyOfflineLLMApp.xcodeproj 2>/dev/null; then
+            echo "::error::Forbidden Hermes 'Replace Hermes' script phase detected after pod install."
+            exit 1
+          fi
           echo "✅ Hermes phase not found."
 
       - name: Snapshot Pods shell script phases (forensics)

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -68,13 +68,15 @@ jobs:
         run: bundle exec pod install --repo-update
 
       - name: Scrub Hermes script phases
+        working-directory: ios
         run: |
-          ruby scripts/strip_hermes_phase.rb ios/Pods/Pods.xcodeproj ios/MyOfflineLLMApp.xcodeproj
+          bundle exec ruby ../scripts/strip_hermes_phase.rb Pods/Pods.xcodeproj ../ios/MyOfflineLLMApp.xcodeproj
 
       - name: Assert Hermes phase is gone
         run: |
           set -euo pipefail
-          if /usr/bin/grep -R --line-number -E "Replace Hermes|\\[Hermes\\]" ios/Pods/Pods.xcodeproj/project.pbxproj ios/MyOfflineLLMApp.xcodeproj/project.pbxproj; then
+          if /usr/bin/grep -R --line-number -E "Replace Hermes|\\[Hermes\\]" \
+               ios/Pods/Pods.xcodeproj/project.pbxproj ios/MyOfflineLLMApp.xcodeproj/project.pbxproj; then
             echo "::error::Forbidden Hermes 'Replace Hermes' script phase still present after scrubbing."
             exit 1
           fi
@@ -86,6 +88,7 @@ jobs:
         with:
           name: xcode-projects-after-scrub
           path: |
+            ios/Podfile.lock
             ios/Pods/Pods.xcodeproj/project.pbxproj
             ios/MyOfflineLLMApp.xcodeproj/project.pbxproj
 

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -67,12 +67,35 @@ jobs:
         working-directory: ios
         run: bundle exec pod install --repo-update
 
+      - name: Scrub Hermes script phases
+        run: |
+          ruby scripts/strip_hermes_phase.rb ios/Pods/Pods.xcodeproj ios/MyOfflineLLMApp.xcodeproj
+
+      - name: Assert Hermes phase is gone
+        run: |
+          set -euo pipefail
+          if /usr/bin/grep -R --line-number -E "Replace Hermes|\\[Hermes\\]" ios/Pods/Pods.xcodeproj/project.pbxproj ios/MyOfflineLLMApp.xcodeproj/project.pbxproj; then
+            echo "::error::Forbidden Hermes 'Replace Hermes' script phase still present after scrubbing."
+            exit 1
+          fi
+          echo "✅ Hermes phase not found."
+
+      - name: Upload Xcode project files (debug)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xcode-projects-after-scrub
+          path: |
+            ios/Pods/Pods.xcodeproj/project.pbxproj
+            ios/MyOfflineLLMApp.xcodeproj/project.pbxproj
+
       - name: Resolve Swift package dependencies
         run: xcodebuild -resolvePackageDependencies -workspace ios/MyOfflineLLMApp.xcworkspace -scheme MyOfflineLLMApp -UseModernBuildSystem=YES
 
       - name: Archive (no codesign)
         run: |
           set -euo pipefail
+          mkdir -p "${BUILD_DIR}"
           xcodebuild clean archive \
             -workspace ios/MyOfflineLLMApp.xcworkspace \
             -scheme "${SCHEME}" \

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -70,27 +70,53 @@ jobs:
       - name: Scrub Hermes script phases
         working-directory: ios
         run: |
-          bundle exec ruby ../scripts/strip_hermes_phase.rb Pods/Pods.xcodeproj ../ios/MyOfflineLLMApp.xcodeproj
+          bundle exec ruby ../scripts/strip_hermes_phase.rb Pods/Pods.xcodeproj MyOfflineLLMApp.xcodeproj
 
       - name: Assert Hermes phase is gone
         run: |
           set -euo pipefail
-          if /usr/bin/grep -R --line-number -E "Replace Hermes|\\[Hermes\\]" \
-               ios/Pods/Pods.xcodeproj/project.pbxproj ios/MyOfflineLLMApp.xcodeproj/project.pbxproj; then
-            echo "::error::Forbidden Hermes 'Replace Hermes' script phase still present after scrubbing."
-            exit 1
-          fi
+          ruby -e '
+            require "xcodeproj";
+            p = Xcodeproj::Project.open("ios/Pods/Pods.xcodeproj");
+            offenders = [];
+            p.targets.each do |t|
+              t.build_phases.select{ |bp| bp.isa=="PBXShellScriptBuildPhase" }.each do |bp|
+                name = (bp.name || "").downcase;
+                body = (bp.shell_script || "").downcase;
+                offenders << "#{t.name} :: #{bp.name}" if name.include?("replace hermes") || body.include?("replace hermes");
+              end;
+            end;
+            if offenders.any?
+              warn "Remaining Hermes phases:\n  #{offenders.join("\n  ")}";
+              exit 1;
+            end;
+          '
           echo "✅ Hermes phase not found."
 
-      - name: Upload Xcode project files (debug)
+      - name: Snapshot Pods shell script phases (forensics)
         if: always()
+        run: |
+          mkdir -p build
+          ruby - <<'RUBY' > build/pods_shell_scripts.txt
+            require 'xcodeproj'
+            p = Xcodeproj::Project.open('ios/Pods/Pods.xcodeproj')
+            p.targets.each do |t|
+              t.build_phases
+               .select { |bp| bp.isa == 'PBXShellScriptBuildPhase' }
+               .each { |bp| puts "#{t.name} :: #{bp.name}" }
+            end
+          RUBY
+
+      - name: Upload Pods/Xcode projects on failure
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: xcode-projects-after-scrub
+          name: ios-forensics-${{ github.job }}
           path: |
             ios/Podfile.lock
             ios/Pods/Pods.xcodeproj/project.pbxproj
             ios/MyOfflineLLMApp.xcodeproj/project.pbxproj
+            build/pods_shell_scripts.txt
 
       - name: Resolve Swift package dependencies
         run: xcodebuild -resolvePackageDependencies -workspace ios/MyOfflineLLMApp.xcworkspace -scheme MyOfflineLLMApp -UseModernBuildSystem=YES

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Scrub Hermes script phases
         working-directory: ios
         run: |
-          bundle exec ruby ../scripts/strip_hermes_phase.rb Pods/Pods.xcodeproj MyOfflineLLMApp.xcodeproj
+          bundle exec ruby ../scripts/strip_hermes_phase.rb $(find Pods -name "*.xcodeproj") MyOfflineLLMApp.xcodeproj
 
       - name: Assert Hermes phase is gone
         run: |

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -2,7 +2,7 @@ name: iOS Unsigned IPA
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
   pull_request:
 
 jobs:
@@ -70,13 +70,6 @@ jobs:
       - name: Resolve Swift package dependencies
         run: xcodebuild -resolvePackageDependencies -workspace ios/MyOfflineLLMApp.xcworkspace -scheme MyOfflineLLMApp -UseModernBuildSystem=YES
 
-      - name: Verify Hermes script removed
-        run: |
-          if /usr/bin/grep -R --include=project.pbxproj --line-number -i "replace hermes" ios/Pods 2>/dev/null; then
-            echo "::error::Forbidden Hermes 'Replace Hermes' script phase detected after pod install."
-            exit 1
-          fi
-
       - name: Archive (no codesign)
         run: |
           set -euo pipefail
@@ -97,6 +90,16 @@ jobs:
           path: |
             ${{ env.BUILD_DIR }}/xcodebuild.log
             ${{ env.BUILD_DIR }}/MyOfflineLLMApp.xcresult
+
+      - name: Summarize build log
+        if: always()
+        run: |
+          if [ -f "${BUILD_DIR}/xcodebuild.log" ]; then
+            echo "Summary of warnings and errors:"
+            grep -iE "error|warning|failed" "${BUILD_DIR}/xcodebuild.log" | tail -n 200 || true
+          else
+            echo "No xcodebuild.log found"
+          fi
 
       - name: Locate built .app and dSYMs
         id: locate

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -1,4 +1,4 @@
-name: iOS (Simulator + Unsigned IPA)
+name: iOS Unsigned IPA
 
 on:
   push:
@@ -6,138 +6,13 @@ on:
   pull_request:
 
 jobs:
-  sim-build:
-    name: Simulator build (iPhone 16 Pro / iOS 18)
-    runs-on: macos-15
-    env:
-      NODE_OPTIONS: --max_old_space_size=4096
-      RCT_NEW_ARCH_ENABLED: 1
-      SCHEME: MyOfflineLLMApp
-      CONFIGURATION: Debug
-      SIM_DEVICE: iPhone 16 Pro
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install Node deps
-        run: npm ci
-
-      # ---- Bundler for CocoaPods (deterministic) ----
-      - name: Cache Bundler
-        uses: actions/cache@v4
-        with:
-          path: ios/vendor/bundle
-          key: ${{ runner.os }}-bundler-${{ hashFiles('ios/Gemfile.lock') }}
-          restore-keys: ${{ runner.os }}-bundler-
-
-      - name: Bundle config path
-        working-directory: ios
-        run: bundle config set path vendor/bundle
-
-      - name: Bundle install
-        working-directory: ios
-        run: bundle install
-
-      - name: Install XcodeGen
-        run: brew install xcodegen
-
-      # ---- XcodeGen BEFORE pods (auto-discover) ----
-      - name: Generate Xcode project (XcodeGen auto-discover)
-        shell: bash
-        run: |
-          set -euo pipefail
-          SPEC="$(/usr/bin/find ios -maxdepth 2 -name project.yml -print -quit || true)"
-          if [[ -n "${SPEC}" ]]; then
-            echo "🛠  Found XcodeGen spec at: ${SPEC}"
-            pushd "$(dirname "${SPEC}")"
-            xcodegen generate
-            popd
-          else
-            echo "ℹ️  No XcodeGen project.yml found; skipping"
-          fi
-
-      - name: Verify generated project
-        shell: bash
-        run: |
-          set -euo pipefail
-          FOUND="$(/usr/bin/find ios -maxdepth 3 -name '*.xcodeproj' -print -quit || true)"
-          if [[ -z "${FOUND}" ]]; then
-            echo "❌ No .xcodeproj generated!"
-            exit 1
-          fi
-          echo "📁 Using project: ${FOUND}"
-
-      - name: Debug Xcode projects
-        run: find ios -maxdepth 3 -name "*.xcodeproj" -print
-
-      # ---- CocoaPods (clean + install via Bundler) ----
-      - name: Clean CocoaPods sandbox if stale
-        working-directory: ios
-        run: |
-          set -euo pipefail
-          rm -f Pods/Manifest.lock
-          rm -rf Pods/Headers || true
-
-      - name: Set NODE_BINARY for Xcode scripts
-        run: |
-          rm -f ios/.xcode.env.local
-          printf 'export NODE_BINARY="%s"\n' "$(command -v node)" > ios/.xcode.env
-
-      - name: Install Pods (bundler)
-        working-directory: ios
-        run: bundle exec pod install --repo-update
-
-      - name: Resolve Swift package dependencies
-        run: |
-          WS="$(/usr/bin/find ios -maxdepth 1 -name '*.xcworkspace' -print -quit || true)"
-          xcodebuild -resolvePackageDependencies -workspace "$WS" -scheme "${SCHEME}"
-
-      - name: Verify Hermes script removed
-        run: |
-          if /usr/bin/grep -R --include=project.pbxproj --line-number -i "replace hermes" ios/Pods 2>/dev/null; then
-            echo "::error::Forbidden Hermes 'Replace Hermes' script phase detected after pod install."
-            exit 1
-          fi
-
-      # (Optional) sanity: show workspace & schemes
-      - name: List workspaces & schemes
-        run: |
-          set -euo pipefail
-          WS="$(/usr/bin/find ios -maxdepth 1 -name '*.xcworkspace' -print -quit || true)"
-          if [[ -z "$WS" ]]; then
-            echo "::error::No .xcworkspace found after pod install"
-            exit 1
-          fi
-          echo "Using workspace: $WS"
-          xcodebuild -list -workspace "$WS" || true
-
-      # ---- Build Simulator (no signing required) ----
-      - name: Build (Simulator)
-        run: |
-          set -euo pipefail
-          WS="$(/usr/bin/find ios -maxdepth 1 -name '*.xcworkspace' -print -quit || true)"
-          if [[ -z "$WS" ]]; then
-            echo "::error::No .xcworkspace found for simulator build"
-            exit 1
-          fi
-          xcodebuild \
-            -workspace "$WS" \
-            -scheme "${SCHEME}" \
-            -configuration "${CONFIGURATION}" \
-            -sdk iphonesimulator \
-            -destination "platform=iOS Simulator,name=${SIM_DEVICE}" \
-            clean build | xcpretty
-
   unsigned-ipa:
     name: Unsigned device IPA (Release, no codesign)
     runs-on: macos-15
     env:
       NODE_OPTIONS: --max_old_space_size=4096
       RCT_NEW_ARCH_ENABLED: 1
+      USE_HERMES: true
       SCHEME: MyOfflineLLMApp
       CONFIGURATION: Release
       BUILD_DIR: build
@@ -152,7 +27,6 @@ jobs:
       - name: Install Node deps
         run: npm ci
 
-      # ---- Bundler for CocoaPods ----
       - name: Cache Bundler
         uses: actions/cache@v4
         with:
@@ -171,36 +45,12 @@ jobs:
       - name: Install XcodeGen
         run: brew install xcodegen
 
-      # ---- XcodeGen BEFORE pods (auto-discover) ----
-      - name: Generate Xcode project (XcodeGen auto-discover)
-        shell: bash
-        run: |
-          set -euo pipefail
-          SPEC="$(/usr/bin/find ios -maxdepth 2 -name project.yml -print -quit || true)"
-          if [[ -n "${SPEC}" ]]; then
-            echo "🛠  Found XcodeGen spec at: ${SPEC}"
-            pushd "$(dirname "${SPEC}")"
-            xcodegen generate
-            popd
-          else
-            echo "ℹ️  No XcodeGen project.yml found; skipping"
-          fi
+      - name: Clean DerivedData
+        run: rm -rf ~/Library/Developer/Xcode/DerivedData/*
 
-      - name: Verify generated project
-        shell: bash
-        run: |
-          set -euo pipefail
-          FOUND="$(/usr/bin/find ios -maxdepth 3 -name '*.xcodeproj' -print -quit || true)"
-          if [[ -z "${FOUND}" ]]; then
-            echo "❌ No .xcodeproj generated!"
-            exit 1
-          fi
-          echo "📁 Using project: ${FOUND}"
+      - name: Generate Xcode project
+        run: xcodegen generate --spec ios/project.yml
 
-      - name: Debug Xcode projects
-        run: find ios -maxdepth 3 -name "*.xcodeproj" -print
-
-      # ---- CocoaPods (clean + install via Bundler) ----
       - name: Clean CocoaPods sandbox if stale
         working-directory: ios
         run: |
@@ -218,9 +68,7 @@ jobs:
         run: bundle exec pod install --repo-update
 
       - name: Resolve Swift package dependencies
-        run: |
-          WS="$(/usr/bin/find ios -maxdepth 1 -name '*.xcworkspace' -print -quit || true)"
-          xcodebuild -resolvePackageDependencies -workspace "$WS" -scheme "${SCHEME}"
+        run: xcodebuild -resolvePackageDependencies -workspace ios/MyOfflineLLMApp.xcworkspace -scheme MyOfflineLLMApp -UseModernBuildSystem=YES
 
       - name: Verify Hermes script removed
         run: |
@@ -229,16 +77,18 @@ jobs:
             exit 1
           fi
 
-      # ---- Archive (no codesign) ----
       - name: Archive (no codesign)
         run: |
           set -euo pipefail
-          WS="$(/usr/bin/find ios -maxdepth 1 -name '*.xcworkspace' -print -quit || true)"
-          if [[ -z "$WS" ]]; then
-            echo "::error::No .xcworkspace found for device archive"
-            exit 1
-          fi
-          xcodebuild clean archive -workspace "$WS" -scheme "${SCHEME}" -configuration "${CONFIGURATION}" -destination 'generic/platform=iOS' -archivePath "${BUILD_DIR}/MyOfflineLLMApp.xcarchive" -resultBundlePath "${BUILD_DIR}/MyOfflineLLMApp.xcresult" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | tee "${BUILD_DIR}/xcodebuild.log"
+          xcodebuild clean archive \
+            -workspace ios/MyOfflineLLMApp.xcworkspace \
+            -scheme "${SCHEME}" \
+            -configuration "${CONFIGURATION}" \
+            -destination 'generic/platform=iOS' \
+            -archivePath "${BUILD_DIR}/MyOfflineLLMApp.xcarchive" \
+            -resultBundlePath "${BUILD_DIR}/MyOfflineLLMApp.xcresult" \
+            -UseModernBuildSystem=YES \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | tee "${BUILD_DIR}/xcodebuild.log"
 
       - name: Upload xcodebuild logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -229,42 +229,39 @@ jobs:
             exit 1
           fi
 
-      # ---- Build device .app (no code signing) ----
-      - name: Build device .app (no code signing)
+      # ---- Archive (no codesign) ----
+      - name: Archive (no codesign)
         run: |
           set -euo pipefail
           WS="$(/usr/bin/find ios -maxdepth 1 -name '*.xcworkspace' -print -quit || true)"
           if [[ -z "$WS" ]]; then
-            echo "::error::No .xcworkspace found for device build"
+            echo "::error::No .xcworkspace found for device archive"
             exit 1
           fi
-          xcodebuild \
-            -workspace "$WS" \
-            -scheme "${SCHEME}" \
-            -configuration "${CONFIGURATION}" \
-            -sdk iphoneos \
-            -destination 'generic/platform=iOS' \
-            CODE_SIGNING_ALLOWED=NO \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_IDENTITY="" \
-            clean build \
-            BUILD_DIR="${BUILD_DIR}" \
-            | xcpretty
+          xcodebuild clean archive -workspace "$WS" -scheme "${SCHEME}" -configuration "${CONFIGURATION}" -destination 'generic/platform=iOS' -archivePath "${BUILD_DIR}/MyOfflineLLMApp.xcarchive" -resultBundlePath "${BUILD_DIR}/MyOfflineLLMApp.xcresult" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | tee "${BUILD_DIR}/xcodebuild.log"
+
+      - name: Upload xcodebuild logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: xcodebuild-logs
+          path: |
+            ${{ env.BUILD_DIR }}/xcodebuild.log
+            ${{ env.BUILD_DIR }}/MyOfflineLLMApp.xcresult
 
       - name: Locate built .app and dSYMs
         id: locate
         run: |
           set -euo pipefail
-          APP_PATH="$(/usr/bin/find "${BUILD_DIR}/Build/Products/${CONFIGURATION}-iphoneos" -maxdepth 1 -name '*.app' -print -quit)"
+          ARCHIVE_PATH="${BUILD_DIR}/MyOfflineLLMApp.xcarchive"
+          APP_PATH="$(/usr/bin/find "${ARCHIVE_PATH}/Products/Applications" -maxdepth 1 -name '*.app' -print -quit)"
           if [[ -z "${APP_PATH}" ]]; then
-            echo "::error::Could not find built .app in ${BUILD_DIR}/Build/Products/${CONFIGURATION}-iphoneos"
-            ls -la "${BUILD_DIR}/Build/Products/${CONFIGURATION}-iphoneos" || true
+            echo "::error::Could not find built .app in ${ARCHIVE_PATH}/Products/Applications"
             exit 1
           fi
           echo "app_path=${APP_PATH}" >> "$GITHUB_OUTPUT"
           echo "✅ Found app: ${APP_PATH}"
 
-          DSYM_DIR="${BUILD_DIR}/Build/Products/${CONFIGURATION}-iphoneos"
+          DSYM_DIR="${ARCHIVE_PATH}/dSYMs"
           DSYM_ZIP="${BUILD_DIR}/MyOfflineLLMApp.dSYMs.zip"
           if compgen -G "${DSYM_DIR}/*.dSYM" > /dev/null; then
             /usr/bin/zip -qry "${DSYM_ZIP}" "${DSYM_DIR}"/*.dSYM

--- a/.github/workflows/ios-xcresult-json.yml
+++ b/.github/workflows/ios-xcresult-json.yml
@@ -3,7 +3,7 @@ name: iOS Build - xcresult JSON (iPhone 16 Pro iOS 18.6 fallback 18.4)
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   ios:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 permissions:
-  contents: write  # to create a Release
+  contents: write # to create a Release
 
 jobs:
   build-ios:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,12 @@
 - Build with Xcode 16.x (command line tools installed).
 - Deployment target stays **18.0** in [`ios/project.yml`](ios/project.yml), [`ios/MyOfflineLLMApp/project.yml`](ios/MyOfflineLLMApp/project.yml), and `Podfile` post_install.
 - When editing these files, update comments and re-run `bundle exec pod install --repo-update`.
-- **Do not enable CocoaPods input/output file lists** with static pods (`:disable_input_output_paths => true` stays). Keep the Hermes "Replace Hermes..." user script neutralized and `ENABLE_USER_SCRIPT_SANDBOXING` set to `NO` in `post_install` for CI stability.
+- **Do not enable CocoaPods input/output file lists** with static pods (`:disable_input_output_paths => true` stays). Set `ENABLE_USER_SCRIPT_SANDBOXING` to `NO` in `post_install` for CI stability.
 - When editing project.yml or Podfile, ensure no legacy .xcfilelist references or invalid Podfile hooks are reintroduced.
+
+## Agent Learning
+
+- Log modifications and build results to track changes and help future iterations avoid regressions.
 
 ## Testing & Quality Gates
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,37 @@
 
 - Log modifications and build results to track changes and help future iterations avoid regressions.
 
+## Task: Read iOS Build Diagnostic Report and apply fixes
+
+**Goal:** Make the iOS CI build pass reliably.
+
+**Inputs:**
+
+- `ios-build-diagnostics` artifact from the latest CI run
+  - `build_report.md`
+  - `xcodebuild.log`
+  - `MyOfflineLLMApp.xcresult` (if present)
+
+**Instructions:**
+
+1. Open `build_report.md`. Identify the **first fatal error** (not just warnings). Cross-check in `xcodebuild.log` and `xcresult` issues.
+2. Classify the failure:
+   - Swift build-system/compiler crash
+   - Script phase failure
+   - Linker issue
+   - Codegen/spec generation issue
+   - Deployment target / platform mismatch
+3. Propose **minimal, concrete fixes**. For each fix:
+   - Describe the root cause in one sentence.
+   - Provide exact code/config changes (Podfile hooks, SPM pin, Xcode build setting, YAML change).
+   - Note any tradeoffs.
+4. Update CI to reduce flakiness:
+   - Add/adjust cache cleaning or `-jobs 1` retry only when hitting known race/crash signatures.
+   - Ensure `-resultBundlePath` and artifact upload steps are present.
+5. Output:
+   - A patch-style snippet that can be applied directly.
+   - A short “why this works” note.
+
 ## Testing & Quality Gates
 
 - Run `npm test` before committing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@
 - Deployment target stays **18.0** in [`ios/project.yml`](ios/project.yml), [`ios/MyOfflineLLMApp/project.yml`](ios/MyOfflineLLMApp/project.yml), and `Podfile` post_install.
 - When editing these files, update comments and re-run `bundle exec pod install --repo-update`.
 - **Do not enable CocoaPods input/output file lists** with static pods (`:disable_input_output_paths => true` stays). Keep the Hermes "Replace Hermes..." user script neutralized and `ENABLE_USER_SCRIPT_SANDBOXING` set to `NO` in `post_install` for CI stability.
+- When editing project.yml or Podfile, ensure no legacy .xcfilelist references or invalid Podfile hooks are reintroduced.
 
 ## Testing & Quality Gates
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ npm test
 
 ### Codegen
 
- - `npm run codegen` reads [src/specs/](src/specs/) and generates TurboModule headers under `ios/build/generated/ios`.
- - Re-run after editing specs.
- - CI sets safe defaults for `CODEGEN_OUTPUT_DIR` and `TEMPLATE_SRC_DIR` to avoid path resolution errors.
+- `npm run codegen` reads [src/specs/](src/specs/) and generates TurboModule headers under `ios/build/generated/ios`.
+- Re-run after editing specs.
+- CI sets safe defaults for `CODEGEN_OUTPUT_DIR` and `TEMPLATE_SRC_DIR` to avoid path resolution errors.
 
 ### iOS build
 
@@ -80,14 +80,14 @@ npm test
 
 ## Scripts Reference
 
-| Command              | Description                     |
-| -------------------- | ------------------------------- |
-| `npm ci`             | Install deps from lockfile      |
-| `npm run ci:install` | CI install wrapper for `npm ci` |
-| `npm run codegen`    | Generate Turbo headers          |
-| `npm test`           | Run Jest suite                  |
-| `npm run lint`       | ESLint                          |
-| `npm run ios`        | Run iOS simulator               |
+| Command                           | Description                        |
+| --------------------------------- | ---------------------------------- |
+| `npm ci`                          | Install deps from lockfile         |
+| `npm run ci:install`              | CI install wrapper for `npm ci`    |
+| `npm run codegen`                 | Generate Turbo headers             |
+| `npm test`                        | Run Jest suite                     |
+| `npm run lint`                    | ESLint                             |
+| `npm run ios`                     | Run iOS simulator                  |
 | `./scripts/build-ios-unsigned.sh` | Clean install & unsigned IPA build |
 
 ## iOS Unsigned Build (Simulator)
@@ -120,12 +120,12 @@ The app uses a privacy-focused consent system (`src/privacy/consents.ts`) to man
 - Throws `ConsentError` for invalid keys.
 
 ```typescript
-import { getConsent, setConsent } from './src/privacy/consents';
+import { getConsent, setConsent } from "./src/privacy/consents";
 
 async function requestCameraAccess() {
-  const consent = await getConsent('camera');
+  const consent = await getConsent("camera");
   if (!consent?.value) {
-    await setConsent('camera', true);
+    await setConsent("camera", true);
   }
 }
 ```

--- a/__tests__/consents.test.js
+++ b/__tests__/consents.test.js
@@ -1,4 +1,4 @@
-jest.mock('@react-native-async-storage/async-storage', () => {
+jest.mock("@react-native-async-storage/async-storage", () => {
   let store = {};
   return {
     setItem: async (k, v) => {
@@ -16,46 +16,63 @@ jest.mock('@react-native-async-storage/async-storage', () => {
   };
 });
 
-import { setConsent, getConsent, revokeConsent, listConsents } from '../src/privacy/consents';
+import {
+  setConsent,
+  getConsent,
+  revokeConsent,
+  listConsents,
+} from "../src/privacy/consents";
 
-const AsyncStorage = require('@react-native-async-storage/async-storage');
+const AsyncStorage = require("@react-native-async-storage/async-storage");
 
 beforeEach(() => AsyncStorage.__clear());
 
-describe('Consent Management', () => {
-  test('set and get valid consent', async () => {
-    await setConsent('camera', true);
-    const consent = await getConsent('camera');
-    expect(consent).toEqual({ key: 'camera', value: true, timestamp: expect.any(Number) });
-  });
-
-  test('reject invalid consent key', async () => {
-    await expect(setConsent('invalid', true)).rejects.toThrow('Invalid consent key');
-    expect(await getConsent('invalid')).toBeNull();
-  });
-
-  test('list consents', async () => {
-    await setConsent('camera', true);
-    await setConsent('location', false);
-    const consents = await listConsents();
-    expect(consents).toEqual({
-      camera: { key: 'camera', value: true, timestamp: expect.any(Number) },
-      location: { key: 'location', value: false, timestamp: expect.any(Number) },
+describe("Consent Management", () => {
+  test("set and get valid consent", async () => {
+    await setConsent("camera", true);
+    const consent = await getConsent("camera");
+    expect(consent).toEqual({
+      key: "camera",
+      value: true,
+      timestamp: expect.any(Number),
     });
   });
 
-  test('revoke consent', async () => {
-    await setConsent('camera', true);
-    await revokeConsent('camera');
-    expect(await getConsent('camera')).toBeNull();
+  test("reject invalid consent key", async () => {
+    await expect(setConsent("invalid", true)).rejects.toThrow(
+      "Invalid consent key",
+    );
+    expect(await getConsent("invalid")).toBeNull();
   });
 
-  test('revoke invalid key does not throw', async () => {
-    await expect(revokeConsent('invalid')).resolves.toBeUndefined();
+  test("list consents", async () => {
+    await setConsent("camera", true);
+    await setConsent("location", false);
+    const consents = await listConsents();
+    expect(consents).toEqual({
+      camera: { key: "camera", value: true, timestamp: expect.any(Number) },
+      location: {
+        key: "location",
+        value: false,
+        timestamp: expect.any(Number),
+      },
+    });
   });
 
-  test('handle AsyncStorage error gracefully', async () => {
-    jest.spyOn(AsyncStorage, 'setItem').mockRejectedValueOnce(new Error('Storage error'));
-    await expect(setConsent('camera', true)).rejects.toThrow('Storage error');
+  test("revoke consent", async () => {
+    await setConsent("camera", true);
+    await revokeConsent("camera");
+    expect(await getConsent("camera")).toBeNull();
+  });
+
+  test("revoke invalid key does not throw", async () => {
+    await expect(revokeConsent("invalid")).resolves.toBeUndefined();
+  });
+
+  test("handle AsyncStorage error gracefully", async () => {
+    jest
+      .spyOn(AsyncStorage, "setItem")
+      .mockRejectedValueOnce(new Error("Storage error"));
+    await expect(setConsent("camera", true)).rejects.toThrow("Storage error");
   });
 });

--- a/__tests__/prosodyDetector.test.js
+++ b/__tests__/prosodyDetector.test.js
@@ -1,13 +1,13 @@
-import ProsodyDetector from '../src/emotion/ProsodyDetector';
+import ProsodyDetector from "../src/emotion/ProsodyDetector";
 
-test('ProsodyDetector disabled returns null emotion', async () => {
+test("ProsodyDetector disabled returns null emotion", async () => {
   const det = new ProsodyDetector();
   const res = await det.analyze(new Float32Array([0, 0, 0]));
   expect(res.emotion).toBeNull();
 });
 
-test('ProsodyDetector confidence gating', async () => {
-  process.env.EMOTION_AUDIO_ENABLED = 'true';
+test("ProsodyDetector confidence gating", async () => {
+  process.env.EMOTION_AUDIO_ENABLED = "true";
   const det = new ProsodyDetector();
   const res = await det.analyze(new Float32Array([1, 1, 1]));
   expect(res.confidence).toBeGreaterThan(0);

--- a/__tests__/sample.test.js
+++ b/__tests__/sample.test.js
@@ -1,3 +1,3 @@
-test('dummy test', () => {
+test("dummy test", () => {
   expect(true).toBe(true);
 });

--- a/__tests__/toolHandler.test.js
+++ b/__tests__/toolHandler.test.js
@@ -4,7 +4,7 @@ const handler = new ToolHandler({ getTool: () => null });
 
 test("ToolHandler parses mixed-quote arguments", () => {
   const args = handler._parseArgs(
-    "a='one' b=\"two and \\\"quote\\\"\" c='single \\'quote\\'' d=\"path \\\\test\""
+    "a='one' b=\"two and \\\"quote\\\"\" c='single \\'quote\\'' d=\"path \\\\test\"",
   );
   expect(args).toEqual({
     a: "one",
@@ -16,7 +16,7 @@ test("ToolHandler parses mixed-quote arguments", () => {
 
 test("ToolHandler parses nested JSON and paths", () => {
   const args = handler._parseArgs(
-    "config='{\"a\":1,\"b\":{\"c\":2}}' path=\"C:\\\\Program Files\\\\App\""
+    'config=\'{"a":1,"b":{"c":2}}\' path="C:\\\\Program Files\\\\App"',
   );
   expect(args).toEqual({
     config: { a: 1, b: { c: 2 } },
@@ -25,8 +25,10 @@ test("ToolHandler parses nested JSON and paths", () => {
 });
 
 test("ToolHandler throws on malformed args", () => {
-  expect(() => handler._parseArgs("a='one b=\"two\""))
-    .toThrow("Malformed argument string");
-  expect(() => handler._parseArgs("json='{\"a\":1"))
-    .toThrow("Malformed argument string");
+  expect(() => handler._parseArgs('a=\'one b="two"')).toThrow(
+    "Malformed argument string",
+  );
+  expect(() => handler._parseArgs('json=\'{"a":1')).toThrow(
+    "Malformed argument string",
+  );
 });

--- a/__tests__/toolRegistry.test.js
+++ b/__tests__/toolRegistry.test.js
@@ -1,23 +1,25 @@
-jest.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
+jest.mock("react-native", () => ({ Platform: { OS: "ios" } }));
 
-jest.mock('../src/tools/iosTools', () => ({
-  toolOne: { name: 'tool_one', execute: jest.fn() },
-  toolTwo: { name: 'tool_two', execute: jest.fn() },
-  notATool: { foo: 'bar' },
+jest.mock("../src/tools/iosTools", () => ({
+  toolOne: { name: "tool_one", execute: jest.fn() },
+  toolTwo: { name: "tool_two", execute: jest.fn() },
+  notATool: { foo: "bar" },
 }));
 
-import { toolRegistry } from '../src/core/tools/ToolRegistry';
+import { toolRegistry } from "../src/core/tools/ToolRegistry";
 
-test('toolRegistry auto registers tools with execute', () => {
-  expect(toolRegistry.getTool('tool_one')).toBeDefined();
-  expect(toolRegistry.getTool('tool_two')).toBeDefined();
+test("toolRegistry auto registers tools with execute", () => {
+  expect(toolRegistry.getTool("tool_one")).toBeDefined();
+  expect(toolRegistry.getTool("tool_two")).toBeDefined();
   expect(toolRegistry.getAvailableTools().length).toBe(2);
 });
 
-test('unregister and invalid registration', () => {
-  const temp = { name: 'temp_tool', execute: jest.fn() };
+test("unregister and invalid registration", () => {
+  const temp = { name: "temp_tool", execute: jest.fn() };
   toolRegistry.register(temp.name, temp);
-  expect(toolRegistry.getTool('temp_tool')).toBeDefined();
-  expect(toolRegistry.unregister('temp_tool')).toBe(true);
-  expect(() => toolRegistry.register('bad', {})).toThrow('Invalid tool bad: missing execute()');
+  expect(toolRegistry.getTool("temp_tool")).toBeDefined();
+  expect(toolRegistry.unregister("temp_tool")).toBe(true);
+  expect(() => toolRegistry.register("bad", {})).toThrow(
+    "Invalid tool bad: missing execute()",
+  );
 });

--- a/__tests__/vectorMemory.test.js
+++ b/__tests__/vectorMemory.test.js
@@ -1,30 +1,30 @@
-import fs from 'fs';
-import VectorMemory from '../src/memory/VectorMemory';
+import fs from "fs";
+import VectorMemory from "../src/memory/VectorMemory";
 
 beforeEach(() => {
-  if (fs.existsSync('vector_memory.dat')) fs.unlinkSync('vector_memory.dat');
+  if (fs.existsSync("vector_memory.dat")) fs.unlinkSync("vector_memory.dat");
 });
 
-test('VectorMemory recall returns deterministic top-k', async () => {
+test("VectorMemory recall returns deterministic top-k", async () => {
   const vm = new VectorMemory({ maxMB: 1 });
   await vm.load();
   await vm.remember([
-    { vector: [1, 0], content: 'hello' },
-    { vector: [0, 1], content: 'world' },
+    { vector: [1, 0], content: "hello" },
+    { vector: [0, 1], content: "world" },
   ]);
   const res = await vm.recall([1, 0], 1);
-  expect(res[0].content).toBe('hello');
+  expect(res[0].content).toBe("hello");
 });
 
-test('VectorMemory encrypts data at rest', async () => {
+test("VectorMemory encrypts data at rest", async () => {
   const vm = new VectorMemory({ maxMB: 1 });
   await vm.load();
-  await vm.remember([{ vector: [1, 0], content: 'secret' }]);
-  const raw = fs.readFileSync('vector_memory.dat', 'utf8');
-  expect(raw.includes('secret')).toBe(false);
+  await vm.remember([{ vector: [1, 0], content: "secret" }]);
+  const raw = fs.readFileSync("vector_memory.dat", "utf8");
+  expect(raw.includes("secret")).toBe(false);
 });
 
-test('VectorMemory migrations run', async () => {
+test("VectorMemory migrations run", async () => {
   const vm = new VectorMemory({ maxMB: 1 });
   await vm.load();
   vm.data.version = 0;
@@ -33,7 +33,7 @@ test('VectorMemory migrations run', async () => {
   expect(vm.data.version).toBe(1);
 });
 
-test('VectorMemory enforces size cap', async () => {
+test("VectorMemory enforces size cap", async () => {
   const vm = new VectorMemory({ maxMB: 0.0001 });
   await vm.load();
   for (let i = 0; i < 10; i++) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-import {AppRegistry} from 'react-native';
-import App from './src/App';
-import {name as appName} from './app.json';
-import './src/specs/registerTurboModules';
+import { AppRegistry } from "react-native";
+import App from "./src/App";
+import { name as appName } from "./app.json";
+import "./src/specs/registerTurboModules";
 
 AppRegistry.registerComponent(appName, () => App);

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -15,7 +15,7 @@ install! 'cocoapods',
 project_candidates = Dir['*.xcodeproj'] + Dir['**/*.xcodeproj']
 project_path = project_candidates.first
 raise "No .xcodeproj found near Podfile (#{__dir__})" unless project_path
-puts "📁 Using Xcode project at: #{project_path}"
+puts "Using Xcode project at: #{project_path}"
 
 # Map build configurations so CocoaPods knows which are debug vs release
 project project_path, 'Debug' => :debug, 'Release' => :release
@@ -60,7 +60,7 @@ post_install do |installer|
         phase.input_paths = [] if phase.respond_to?(:input_paths=)
         phase.output_paths = [] if phase.respond_to?(:output_paths=)
       rescue => e
-        puts "⚠️  Skipping scrub for phase #{phase.name}: #{e}"
+        puts "WARN: Skipping scrub for phase #{phase.name}: #{e}"
       end
     end
   end
@@ -82,7 +82,7 @@ post_install do |installer|
       cfg.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] ||= 'gnu++17'
       cfg.build_settings['SWIFT_VERSION'] ||= '5.0'
 
-      # Bump pods that declare an iOS deployment target lower than Xcode’s supported floor
+      # Bump pods that declare an iOS deployment target lower than Xcode's supported floor
       floor = '12.0'
       current = cfg.build_settings['IPHONEOS_DEPLOYMENT_TARGET']
       if current.nil? || Gem::Version.new(current) < Gem::Version.new(floor)
@@ -117,7 +117,7 @@ post_integrate do |installer|
       next unless t.name == 'hermes-engine'
       t.shell_script_build_phases.each do |phase|
         if phase.name&.include?('Replace Hermes for the right configuration')
-          UI.puts "\uD83E\uDDF9 Removing Hermes script phase from #{t.name}"
+          UI.puts "Removing Hermes script phase from #{t.name}"
           t.build_phases.delete(phase)
         end
       end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -106,22 +106,29 @@ post_install do |installer|
   installer.pods_project.save
 end
 
-# Silences "will be run during every build" warnings for shell phases with no I/O,
-# and scrubs any Hermes "Replace Hermes" phases that may be (re)introduced.
-post_integrate do |installer|
-  pods_project = installer.pods_project
+ # Silences "will be run during every build" warnings for shell phases with no I/O,
+ # and scrubs any Hermes "Replace Hermes" phases that may be (re)introduced.
+ post_integrate do |installer|
+  pods_projects =
+    if installer.respond_to?(:generated_projects) && installer.generated_projects.any?
+      installer.generated_projects.select { |p| p.path.basename.to_s.include?('Pods') }
+    else
+      [installer.pods_project].compact
+    end
 
-  # --- Remove the forbidden Hermes script (only from Pods project)
+  # --- Remove the forbidden Hermes script from ALL Pods projects (CI only)
   if ENV['CI'] == 'true'
-    pods_project.targets.each do |t|
-      next unless t.name == 'hermes-engine'
-      t.shell_script_build_phases.each do |phase|
-        if phase.name&.include?('Replace Hermes for the right configuration')
-          t.build_phases.delete(phase)
+    pods_projects.each do |proj|
+      proj.targets.each do |t|
+        next unless t.name == 'hermes-engine'
+        t.shell_script_build_phases.each do |phase|
+          if phase.name&.include?('Replace Hermes for the right configuration')
+            t.build_phases.delete(phase)
+          end
         end
       end
+      proj.save
     end
-    pods_project.save
   end
 
   # --- Collect real Xcode *projects* only (avoid Pod::PodTarget, etc.)
@@ -131,7 +138,7 @@ post_integrate do |installer|
     .uniq { |p| p.path.to_s }
 
   # Mark [CP] phases without I/O as always out-of-date to silence Xcode warnings
-  ([pods_project] + user_projects).each do |proj|
+  (pods_projects + user_projects).each do |proj|
     proj.targets.each do |t|
       t.build_phases
         .select { |p| p.isa == 'PBXShellScriptBuildPhase' && p.name&.start_with?('[CP]') }
@@ -142,15 +149,17 @@ post_integrate do |installer|
     proj.save
   end
 
-  # --- Guard: fail if any Hermes replacement script remains
+  # --- Guard: fail if any Hermes replacement script remains in any Pods project
   if ENV['CI'] == 'true'
     offending = []
-    pods_project.targets.each do |t|
-      next unless t.name == 'hermes-engine'
-      t.shell_script_build_phases.each do |phase|
-        name = (phase.name || '').downcase
-        body = (phase.shell_script || '').downcase
-        offending << "#{t.name} :: #{phase.name}" if name.include?('replace hermes') || body.include?('replace hermes')
+    pods_projects.each do |proj|
+      proj.targets.each do |t|
+        next unless t.name == 'hermes-engine'
+        t.shell_script_build_phases.each do |phase|
+          name = (phase.name || '').downcase
+          body = (phase.shell_script || '').downcase
+          offending << "#{proj.path} :: #{t.name} :: #{phase.name}" if name.include?('replace hermes') || body.include?('replace hermes')
+        end
       end
     end
     unless offending.empty?

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -81,6 +81,13 @@ post_install do |installer|
       # Ensure mixed C++ headers compile under gnu++17 and Swift 5
       cfg.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] ||= 'gnu++17'
       cfg.build_settings['SWIFT_VERSION'] ||= '5.0'
+
+      # Bump pods that declare an iOS deployment target lower than Xcode’s supported floor
+      floor = '12.0'
+      current = cfg.build_settings['IPHONEOS_DEPLOYMENT_TARGET']
+      if current.nil? || Gem::Version.new(current) < Gem::Version.new(floor)
+        cfg.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = floor
+      end
     end
   end
 
@@ -96,89 +103,66 @@ post_install do |installer|
     user_project.save
   end
 
-  # ---- Hermes Fix 2: Remove "Replace Hermes" script phases everywhere ----
-  forbidden_markers = [
-    'Replace Hermes for the right configuration, if needed',
-    'Replace Hermes'
-  ]
-
-  # 1) Scrub Pods project targets (e.g., hermes-engine, React-hermes, etc.)
-  installer.pods_project.targets.each do |t|
-    t.build_phases
-      .select { |p| p.respond_to?(:name) && forbidden_markers.any? { |m| p.name.to_s.include?(m) } }
-      .each { |p| t.build_phases.delete(p) }
-  end
-
-  # 2) Scrub the user projects (your app/workspace targets) that CocoaPods touches
-  installer.aggregate_targets.each do |agg|
-    agg.user_project.native_targets.each do |nt|
-      nt.build_phases
-        .select { |p| p.respond_to?(:name) && forbidden_markers.any? { |m| p.name.to_s.include?(m) } }
-        .each { |p| nt.build_phases.delete(p) }
-    end
-
-    # Save the user project after mutation
-    agg.user_project.save
-  end
-
-  # Save the Pods project after mutation
   installer.pods_project.save
 end
 
-# Silences "will be run during every build" warnings for [CP] phases lacking I/O paths
+# Silences "will be run during every build" warnings for shell phases with no I/O,
+# and scrubs any Hermes "Replace Hermes" phases that may be (re)introduced.
 post_integrate do |installer|
-  pods_project = installer.pods_project
-
-  # --- Remove any Hermes "Replace Hermes" script phases from ALL pods ---
-  removed_count = 0
-  pods_project.targets.each do |t|
-    phases = t.build_phases.select do |p|
-      p.isa == 'PBXShellScriptBuildPhase' &&
-        (p.name || '').to_s.downcase.include?('replace hermes')
+  pods_projects =
+    if installer.respond_to?(:generated_projects) && installer.generated_projects.any?
+      installer.generated_projects
+    else
+      [installer.pods_project].compact
     end
-    phases.each do |phase|
-      t.build_phases.delete(phase)
-      removed_count += 1
-    end
-  end
-  pods_project.save if removed_count > 0
 
-  # --- Collect real Xcode *projects* (avoid Pod::PodTarget, etc.) ---
   user_projects = installer.aggregate_targets
-    .select { |agg| agg.respond_to?(:user_project) && agg.user_project }
-    .map(&:user_project)
-    .uniq { |p| p.path.to_s }
+                  .select { |agg| agg.respond_to?(:user_project) && agg.user_project }
+                  .map(&:user_project)
+                  .uniq { |p| p.path.to_s }
 
-  # Mark [CP] phases without I/O paths as always out-of-date to silence warnings
-  ([pods_project] + user_projects).each do |proj|
+  # --- Scrub ANY Hermes replacement script phases (by name or body), Pods + user projects
+  scrub_hermes = proc do |proj|
     proj.targets.each do |t|
       t.build_phases
-        .select { |p| p.isa == 'PBXShellScriptBuildPhase' && p.name&.start_with?('[CP]') }
-        .each do |run|
-          if (run.input_paths || []).empty? && (run.output_paths || []).empty?
-            run.always_out_of_date = '1'
-          end
-        end
+        .select { |p|
+          p.isa == 'PBXShellScriptBuildPhase' &&
+          (
+            (p.name || '').include?('Replace Hermes') ||
+            (p.shell_script || '').include?('Replace Hermes')
+          )
+        }.each { |p| t.build_phases.delete(p) }
+    end
+    proj.save
+  end
+  (pods_projects + user_projects).each { |proj| scrub_hermes.call(proj) }
+
+  # --- Mark ANY shell phase with empty I/O as always out-of-date to silence warnings
+  (pods_projects + user_projects).each do |proj|
+    proj.targets.each do |t|
+      t.build_phases.grep(Xcodeproj::Project::Object::PBXShellScriptBuildPhase).each do |run|
+        in_empty  = (run.input_paths  || []).empty?
+        out_empty = (run.output_paths || []).empty?
+        run.always_out_of_date = '1' if in_empty && out_empty
+      end
     end
     proj.save
   end
 
-  # --- Guard: fail if any Hermes replacement script remains (CI & local) ---
-  offenders = []
-  pods_project.targets.each do |t|
-    t.build_phases.select { |p| p.isa == 'PBXShellScriptBuildPhase' }.each do |phase|
-      n = (phase.name || '').downcase
-      s = (phase.shell_script || '').downcase
-      if n.include?('replace hermes') || s.include?('replace hermes')
-        offenders << "#{t.name} :: #{phase.name}"
+  # --- CI guard: fail if any Hermes replacement script remains
+  if ENV['CI'] == 'true'
+    offenders = []
+    (pods_projects + user_projects).each do |proj|
+      proj.targets.each do |t|
+        t.build_phases.grep(Xcodeproj::Project::Object::PBXShellScriptBuildPhase).each do |phase|
+          name = (phase.name || '')
+          body = (phase.shell_script || '')
+          if name.include?('Replace Hermes') || body.include?('Replace Hermes')
+            offenders << "#{proj.path} :: #{t.name} :: #{name}"
+          end
+        end
       end
     end
-  end
-  unless offenders.empty?
-    raise <<~MSG
-      Detected forbidden Hermes script phase(s) AFTER post_integrate:
-        #{offenders.join("\n  ")}
-      Policy: the "[Hermes] Replace Hermes ..." script must not exist after pod install.
-    MSG
+    raise "Forbidden Hermes script phases remain:\n  #{offenders.join("\n  ")}" unless offenders.empty?
   end
 end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -109,60 +109,57 @@ end
 # Silences "will be run during every build" warnings for shell phases with no I/O,
 # and scrubs any Hermes "Replace Hermes" phases that may be (re)introduced.
 post_integrate do |installer|
-  pods_projects =
-    if installer.respond_to?(:generated_projects) && installer.generated_projects.any?
-      installer.generated_projects.select { |p| p.is_a?(Xcodeproj::Project) }
-    else
-      [installer.pods_project].compact
-    end
+  pods_project = installer.pods_project
 
-  user_projects = installer.aggregate_targets
-                  .select { |agg| agg.respond_to?(:user_project) && agg.user_project }
-                  .map(&:user_project)
-                  .uniq { |p| p.path.to_s }
-
-  # --- Scrub ANY Hermes replacement script phases (by name or body), Pods + user projects
-  scrub_hermes = proc do |proj|
-    proj.targets.each do |t|
-      t.build_phases
-        .select { |p|
-          p.isa == 'PBXShellScriptBuildPhase' &&
-          (
-            (p.name || '').include?('Replace Hermes') ||
-            (p.shell_script || '').include?('Replace Hermes')
-          )
-        }.each { |p| t.build_phases.delete(p) }
-    end
-    proj.save
-  end
-  (pods_projects + user_projects).each { |proj| scrub_hermes.call(proj) }
-
-  # --- Mark ANY shell phase with empty I/O as always out-of-date to silence warnings
-  (pods_projects + user_projects).each do |proj|
-    proj.targets.each do |t|
-      t.build_phases.grep(Xcodeproj::Project::Object::PBXShellScriptBuildPhase).each do |run|
-        in_empty  = (run.input_paths  || []).empty?
-        out_empty = (run.output_paths || []).empty?
-        run.always_out_of_date = '1' if in_empty && out_empty
-      end
-    end
-    proj.save
-  end
-
-  # --- CI guard: fail if any Hermes replacement script remains
+  # --- Remove the forbidden Hermes script (only from Pods project)
   if ENV['CI'] == 'true'
-    offenders = []
-    (pods_projects + user_projects).each do |proj|
-      proj.targets.each do |t|
-        t.build_phases.grep(Xcodeproj::Project::Object::PBXShellScriptBuildPhase).each do |phase|
-          name = (phase.name || '')
-          body = (phase.shell_script || '')
-          if name.include?('Replace Hermes') || body.include?('Replace Hermes')
-            offenders << "#{proj.path} :: #{t.name} :: #{name}"
-          end
+    pods_project.targets.each do |t|
+      next unless t.name == 'hermes-engine'
+      t.shell_script_build_phases.each do |phase|
+        if phase.name&.include?('Replace Hermes for the right configuration')
+          UI.puts "\uD83E\uDDF9 Removing Hermes script phase from #{t.name}"
+          t.build_phases.delete(phase)
         end
       end
     end
-    raise "Forbidden Hermes script phases remain:\n  #{offenders.join("\n  ")}" unless offenders.empty?
+    pods_project.save
+  end
+
+  # --- Collect real Xcode *projects* only (avoid Pod::PodTarget, etc.)
+  user_projects = installer.aggregate_targets
+    .select { |agg| agg.respond_to?(:user_project) && agg.user_project }
+    .map(&:user_project)
+    .uniq { |p| p.path.to_s }
+
+  # Mark [CP] phases without I/O as always out-of-date to silence Xcode warnings
+  ([pods_project] + user_projects).each do |proj|
+    proj.targets.each do |t|
+      t.build_phases
+        .select { |p| p.isa == 'PBXShellScriptBuildPhase' && p.name&.start_with?('[CP]') }
+        .each do |run|
+          run.always_out_of_date = '1' if (run.input_paths || []).empty? && (run.output_paths || []).empty?
+        end
+    end
+    proj.save
+  end
+
+  # --- Guard: fail if any Hermes replacement script remains
+  if ENV['CI'] == 'true'
+    offending = []
+    pods_project.targets.each do |t|
+      next unless t.name == 'hermes-engine'
+      t.shell_script_build_phases.each do |phase|
+        name = (phase.name || '').downcase
+        body = (phase.shell_script || '').downcase
+        offending << "#{t.name} :: #{phase.name}" if name.include?('replace hermes') || body.include?('replace hermes')
+      end
+    end
+    unless offending.empty?
+      raise <<~MSG
+        Detected forbidden Hermes script phase(s):
+          #{offending.join("\n  ")}
+        CI policy: the "[Hermes] Replace Hermes" script must not exist after pod install.
+      MSG
+    end
   end
 end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -129,55 +129,56 @@ end
 post_integrate do |installer|
   pods_project = installer.pods_project
 
-  # --- Remove the forbidden Hermes script (only from Pods project)
-  if ENV['CI'] == 'true'
-    pods_project.targets.each do |t|
-      next unless t.name == 'hermes-engine'
-      t.shell_script_build_phases.each do |phase|
-        if phase.name&.include?('Replace Hermes for the right configuration')
-          UI.puts "🧹 Removing Hermes script phase from #{t.name}"
-          t.build_phases.delete(phase)
-        end
-      end
+  # --- Remove any Hermes "Replace Hermes" script phases from ALL pods ---
+  removed_count = 0
+  pods_project.targets.each do |t|
+    phases = t.build_phases.select do |p|
+      p.isa == 'PBXShellScriptBuildPhase' &&
+        (p.name || '').to_s.downcase.include?('replace hermes')
     end
-    pods_project.save
+    phases.each do |phase|
+      t.build_phases.delete(phase)
+      removed_count += 1
+    end
   end
+  pods_project.save if removed_count > 0
 
-  # --- Collect real Xcode *projects* only (avoid Pod::PodTarget, etc.)
+  # --- Collect real Xcode *projects* (avoid Pod::PodTarget, etc.) ---
   user_projects = installer.aggregate_targets
     .select { |agg| agg.respond_to?(:user_project) && agg.user_project }
     .map(&:user_project)
     .uniq { |p| p.path.to_s }
 
-  # Mark [CP] phases without I/O as always out-of-date to silence Xcode warnings
+  # Mark [CP] phases without I/O paths as always out-of-date to silence warnings
   ([pods_project] + user_projects).each do |proj|
     proj.targets.each do |t|
       t.build_phases
         .select { |p| p.isa == 'PBXShellScriptBuildPhase' && p.name&.start_with?('[CP]') }
         .each do |run|
-          run.always_out_of_date = '1' if (run.input_paths || []).empty? && (run.output_paths || []).empty?
+          if (run.input_paths || []).empty? && (run.output_paths || []).empty?
+            run.always_out_of_date = '1'
+          end
         end
     end
     proj.save
   end
 
-  # --- Guard: fail if any Hermes replacement script remains
-  if ENV['CI'] == 'true'
-    offending = []
-    pods_project.targets.each do |t|
-      next unless t.name == 'hermes-engine'
-      t.shell_script_build_phases.each do |phase|
-        name = (phase.name || '').downcase
-        body = (phase.shell_script || '').downcase
-        offending << "#{t.name} :: #{phase.name}" if name.include?('replace hermes') || body.include?('replace hermes')
+  # --- Guard: fail if any Hermes replacement script remains (CI & local) ---
+  offenders = []
+  pods_project.targets.each do |t|
+    t.build_phases.select { |p| p.isa == 'PBXShellScriptBuildPhase' }.each do |phase|
+      n = (phase.name || '').downcase
+      s = (phase.shell_script || '').downcase
+      if n.include?('replace hermes') || s.include?('replace hermes')
+        offenders << "#{t.name} :: #{phase.name}"
       end
     end
-    unless offending.empty?
-      raise <<~MSG
-        Detected forbidden Hermes script phase(s):
-          #{offending.join("\n  ")}
-        CI policy: the "[Hermes] Replace Hermes" script must not exist after pod install.
-      MSG
-    end
+  end
+  unless offenders.empty?
+    raise <<~MSG
+      Detected forbidden Hermes script phase(s) AFTER post_integrate:
+        #{offenders.join("\n  ")}
+      Policy: the "[Hermes] Replace Hermes ..." script must not exist after pod install.
+    MSG
   end
 end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -97,72 +97,58 @@ post_install do |installer|
   end
 end
 
-# Silences warnings for [CP] phases w/o I/O lists AND removes Hermes script on CI
+# Silences "will be run during every build" warnings for [CP] phases lacking I/O paths
 post_integrate do |installer|
-  # All Pods *.xcodeproj projects CocoaPods generated
-  pods_projects =
-    if installer.respond_to?(:generated_projects) && installer.generated_projects.any?
-      installer.generated_projects
-    else
-      [installer.pods_project].compact  # fallback for older CocoaPods
-    end
+  pods_project = installer.pods_project
 
-  # All user *.xcodeproj projects CocoaPods integrated
-  user_projects = (installer.respond_to?(:generated_aggregate_targets) ?
-                    installer.generated_aggregate_targets :
-                    installer.aggregate_targets
-                  ).map(&:user_project).compact.uniq
-
-  projects = (pods_projects + user_projects).uniq
-
-  # CI: remove the Hermes "Replace Hermes..." script phase if present
+  # --- Remove the forbidden Hermes script (only from Pods project)
   if ENV['CI'] == 'true'
-    pods_projects.each do |proj|
-      proj.targets.each do |t|
-        next unless t.name == 'hermes-engine'
-        t.shell_script_build_phases.each do |phase|
-          if phase.name&.include?('Replace Hermes for the right configuration')
-            UI.puts "🧹 Removing Hermes script phase from #{t.name} in #{proj.path.basename}"
-            t.build_phases.delete(phase)
-          end
+    pods_project.targets.each do |t|
+      next unless t.name == 'hermes-engine'
+      t.shell_script_build_phases.each do |phase|
+        if phase.name&.include?('Replace Hermes for the right configuration')
+          UI.puts "🧹 Removing Hermes script phase from #{t.name}"
+          t.build_phases.delete(phase)
         end
       end
-      proj.save
     end
+    pods_project.save
   end
 
-  # Mark empty [CP] phases as always out of date (silences Xcode warnings)
-  projects.each do |proj|
+  # --- Collect real Xcode *projects* only (avoid Pod::PodTarget, etc.)
+  user_projects = installer.aggregate_targets
+    .select { |agg| agg.respond_to?(:user_project) && agg.user_project }
+    .map(&:user_project)
+    .uniq { |p| p.path.to_s }
+
+  # Mark [CP] phases without I/O as always out-of-date to silence Xcode warnings
+  ([pods_project] + user_projects).each do |proj|
     proj.targets.each do |t|
       t.build_phases
         .select { |p| p.isa == 'PBXShellScriptBuildPhase' && p.name&.start_with?('[CP]') }
         .each do |run|
-          if (run.input_paths || []).empty? && (run.output_paths || []).empty?
-            run.always_out_of_date = '1'
-          end
+          run.always_out_of_date = '1' if (run.input_paths || []).empty? && (run.output_paths || []).empty?
         end
     end
     proj.save
   end
 
-  # CI guard: fail fast if any Hermes script remains
+  # --- Guard: fail if any Hermes replacement script remains
   if ENV['CI'] == 'true'
-    offenders = []
-    pods_projects.each do |proj|
-      proj.targets.each do |t|
-        next unless t.name == 'hermes-engine'
-        t.shell_script_build_phases.each do |phase|
-          name = (phase.name || '').downcase
-          body = (phase.shell_script || '').downcase
-          offenders << "#{proj.path.basename} • #{t.name} • #{phase.name}" if name.include?('replace hermes') || body.include?('replace hermes')
-        end
+    offending = []
+    pods_project.targets.each do |t|
+      next unless t.name == 'hermes-engine'
+      t.shell_script_build_phases.each do |phase|
+        name = (phase.name || '').downcase
+        body = (phase.shell_script || '').downcase
+        offending << "#{t.name} :: #{phase.name}" if name.include?('replace hermes') || body.include?('replace hermes')
       end
     end
-    unless offenders.empty?
+    unless offending.empty?
       raise <<~MSG
-        Forbidden Hermes script phase(s) still present:
-          #{offenders.join("\n  ")}
-        They must be removed during post_integrate on CI.
+        Detected forbidden Hermes script phase(s):
+          #{offending.join("\n  ")}
+        CI policy: the "[Hermes] Replace Hermes" script must not exist after pod install.
       MSG
     end
   end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -100,20 +100,27 @@ end
 # Silences "will be run during every build" warnings for [CP] phases lacking I/O paths
 # and removes the Hermes "Replace Hermes..." phase on CI after CocoaPods has integrated.
 post_integrate do |installer|
-  pods_project = installer.pods_project
+  pods_projects =
+    if installer.respond_to?(:generated_projects) && installer.generated_projects.any?
+      installer.generated_projects.select { |proj| proj.path.to_s.include?('/Pods/') }
+    else
+      [installer.pods_project].compact
+    end
 
-  # --- Remove the forbidden Hermes script (only from Pods project)
+  # --- Remove the forbidden Hermes script (from ALL Pods projects)
   if ENV['CI'] == 'true'
-    pods_project.targets.each do |t|
-      next unless t.name == 'hermes-engine'
-      t.shell_script_build_phases.each do |phase|
-        if phase.name&.include?('Replace Hermes for the right configuration')
-          UI.puts "🧹 Removing Hermes script phase from #{t.name}"
-          t.build_phases.delete(phase)
+    pods_projects.each do |proj|
+      proj.targets.each do |t|
+        next unless t.name == 'hermes-engine'
+        t.shell_script_build_phases.each do |phase|
+          if phase.name&.include?('Replace Hermes for the right configuration')
+            UI.puts "🧹 Removing Hermes script phase from #{t.name}"
+            t.build_phases.delete(phase)
+          end
         end
       end
+      proj.save
     end
-    pods_project.save
   end
 
   # --- Collect real Xcode *projects* only (avoid Pod::PodTarget, etc.)
@@ -123,7 +130,7 @@ post_integrate do |installer|
     .uniq { |p| p.path.to_s }
 
   # Mark [CP] phases without I/O as always out-of-date to silence Xcode warnings
-  ([pods_project] + user_projects).each do |proj|
+  (pods_projects + user_projects).each do |proj|
     next unless proj.respond_to?(:targets)
 
     proj.targets.each do |t|
@@ -144,12 +151,16 @@ post_integrate do |installer|
   # --- Guard: fail if any Hermes replacement script remains
   if ENV['CI'] == 'true'
     offending = []
-    pods_project.targets.each do |t|
-      next unless t.name == 'hermes-engine'
-      t.shell_script_build_phases.each do |phase|
-        name = (phase.name || '').downcase
-        body = (phase.shell_script || '').downcase
-        offending << "#{t.name} :: #{phase.name}" if name.include?('replace hermes') || body.include?('replace hermes')
+    pods_projects.each do |proj|
+      proj.targets.each do |t|
+        next unless t.name == 'hermes-engine'
+        t.shell_script_build_phases.each do |phase|
+          name = (phase.name || '').downcase
+          body = (phase.shell_script || '').downcase
+          if name.include?('replace hermes') || body.include?('replace hermes')
+            offending << "#{proj.path.basename} :: #{t.name} :: #{phase.name}"
+          end
+        end
       end
     end
     unless offending.empty?

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -98,25 +98,10 @@ post_install do |installer|
 end
 
 # Silences "will be run during every build" warnings for [CP] phases lacking I/O paths
-# and removes the Hermes "Replace Hermes..." phase on CI after CocoaPods has integrated.
 post_integrate do |installer|
   pods_project = installer.pods_project
 
-  # --- Remove the forbidden Hermes script (only from Pods project)
-  if ENV['CI'] == 'true'
-    pods_project.targets.each do |t|
-      next unless t.name == 'hermes-engine'
-      t.shell_script_build_phases.each do |phase|
-        if phase.name&.include?('Replace Hermes for the right configuration')
-          UI.puts "🧹 Removing Hermes script phase from #{t.name}"
-          t.build_phases.delete(phase)
-        end
-      end
-    end
-    pods_project.save
-  end
-
-  # --- Collect real Xcode *projects* only (avoid Pod::PodTarget, etc.)
+  # Collect real Xcode *projects* only (avoid Pod::PodTarget, etc.)
   user_projects = installer.aggregate_targets
     .select { |agg| agg.respond_to?(:user_project) && agg.user_project }
     .map(&:user_project)
@@ -132,25 +117,5 @@ post_integrate do |installer|
         end
     end
     proj.save
-  end
-
-  # --- Guard: fail if any Hermes replacement script remains
-  if ENV['CI'] == 'true'
-    offending = []
-    pods_project.targets.each do |t|
-      next unless t.name == 'hermes-engine'
-      t.shell_script_build_phases.each do |phase|
-        name = (phase.name || '').downcase
-        body = (phase.shell_script || '').downcase
-        offending << "#{t.name} :: #{phase.name}" if name.include?('replace hermes') || body.include?('replace hermes')
-      end
-    end
-    unless offending.empty?
-      raise <<~MSG
-        Detected forbidden Hermes script phase(s):
-          #{offending.join("\n  ")}
-        CI policy: the "[Hermes] Replace Hermes" script must not exist after pod install.
-      MSG
-    end
   end
 end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -111,7 +111,7 @@ end
 post_integrate do |installer|
   pods_projects =
     if installer.respond_to?(:generated_projects) && installer.generated_projects.any?
-      installer.generated_projects
+      installer.generated_projects.select { |p| p.is_a?(Xcodeproj::Project) }
     else
       [installer.pods_project].compact
     end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -102,32 +102,27 @@ end
 post_integrate do |installer|
   pods_project = installer.pods_project
 
-  # 1) On CI, remove the Hermes "[Hermes] Replace Hermes..." phase from the Pods project
+  # --- Remove the forbidden Hermes script (only from Pods project)
   if ENV['CI'] == 'true'
-    begin
-      pods_project.targets
-        .select { |t| t.name == 'hermes-engine' }
-        .each do |t|
-          t.shell_script_build_phases.each do |phase|
-            if (phase.name || '').include?('Replace Hermes for the right configuration')
-              UI.puts "🧹 Removing Hermes script phase from #{t.name}"
-              t.build_phases.delete(phase)
-            end
-          end
+    pods_project.targets.each do |t|
+      next unless t.name == 'hermes-engine'
+      t.shell_script_build_phases.each do |phase|
+        if phase.name&.include?('Replace Hermes for the right configuration')
+          UI.puts "🧹 Removing Hermes script phase from #{t.name}"
+          t.build_phases.delete(phase)
         end
-      pods_project.save
-    rescue => e
-      UI.puts "[warn] post_integrate Hermes cleanup failed: #{e}"
+      end
     end
+    pods_project.save
   end
 
-  # 2) Collect user Xcode projects safely
+  # --- Collect real Xcode *projects* only (avoid Pod::PodTarget, etc.)
   user_projects = installer.aggregate_targets
-                    .map { |agg| agg.user_project }
-                    .compact
-                    .uniq
+    .select { |agg| agg.respond_to?(:user_project) && agg.user_project }
+    .map(&:user_project)
+    .uniq { |p| p.path.to_s }
 
-  # 3) For Pods project + each user project, silence [CP] “always out of date” warnings if no I/O paths
+  # Mark [CP] phases without I/O as always out-of-date to silence Xcode warnings
   ([pods_project] + user_projects).each do |proj|
     next unless proj.respond_to?(:targets)
 
@@ -146,27 +141,22 @@ post_integrate do |installer|
     proj.save
   end
 
-  # 4) Guard: fail CI if any Hermes "Replace Hermes" phase still exists after our cleanup
+  # --- Guard: fail if any Hermes replacement script remains
   if ENV['CI'] == 'true'
     offending = []
-    pods_project.targets
-      .select { |t| t.name == 'hermes-engine' }
-      .each do |t|
-        t.shell_script_build_phases.each do |phase|
-          name = (phase.name || '').downcase
-          body = (phase.shell_script || '').downcase
-          if name.include?('replace hermes') || body.include?('replace hermes')
-            offending << "#{t.name} :: #{phase.name}"
-          end
-        end
+    pods_project.targets.each do |t|
+      next unless t.name == 'hermes-engine'
+      t.shell_script_build_phases.each do |phase|
+        name = (phase.name || '').downcase
+        body = (phase.shell_script || '').downcase
+        offending << "#{t.name} :: #{phase.name}" if name.include?('replace hermes') || body.include?('replace hermes')
       end
-
+    end
     unless offending.empty?
       raise <<~MSG
         Detected forbidden Hermes script phase(s):
           #{offending.join("\n  ")}
-        CI policy: the "[Hermes] Replace Hermes" script must not exist.
-        The phase was expected to be deleted in post_integrate. Investigate Pod integration.
+        CI policy: the "[Hermes] Replace Hermes" script must not exist after pod install.
       MSG
     end
   end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -117,7 +117,6 @@ post_integrate do |installer|
       next unless t.name == 'hermes-engine'
       t.shell_script_build_phases.each do |phase|
         if phase.name&.include?('Replace Hermes for the right configuration')
-          UI.puts "Removing Hermes script phase from #{t.name}"
           t.build_phases.delete(phase)
         end
       end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -100,27 +100,20 @@ end
 # Silences "will be run during every build" warnings for [CP] phases lacking I/O paths
 # and removes the Hermes "Replace Hermes..." phase on CI after CocoaPods has integrated.
 post_integrate do |installer|
-  pods_projects =
-    if installer.respond_to?(:generated_projects) && installer.generated_projects.any?
-      installer.generated_projects.select { |proj| proj.path.to_s.include?('/Pods/') }
-    else
-      [installer.pods_project].compact
-    end
+  pods_project = installer.pods_project
 
-  # --- Remove the forbidden Hermes script (from ALL Pods projects)
+  # --- Remove the forbidden Hermes script (only from Pods project)
   if ENV['CI'] == 'true'
-    pods_projects.each do |proj|
-      proj.targets.each do |t|
-        next unless t.name == 'hermes-engine'
-        t.shell_script_build_phases.each do |phase|
-          if phase.name&.include?('Replace Hermes for the right configuration')
-            UI.puts "🧹 Removing Hermes script phase from #{t.name}"
-            t.build_phases.delete(phase)
-          end
+    pods_project.targets.each do |t|
+      next unless t.name == 'hermes-engine'
+      t.shell_script_build_phases.each do |phase|
+        if phase.name&.include?('Replace Hermes for the right configuration')
+          UI.puts "🧹 Removing Hermes script phase from #{t.name}"
+          t.build_phases.delete(phase)
         end
       end
-      proj.save
     end
+    pods_project.save
   end
 
   # --- Collect real Xcode *projects* only (avoid Pod::PodTarget, etc.)
@@ -130,37 +123,26 @@ post_integrate do |installer|
     .uniq { |p| p.path.to_s }
 
   # Mark [CP] phases without I/O as always out-of-date to silence Xcode warnings
-  (pods_projects + user_projects).each do |proj|
-    next unless proj.respond_to?(:targets)
-
+  ([pods_project] + user_projects).each do |proj|
     proj.targets.each do |t|
       t.build_phases
-       .select { |p|
-         p.isa == 'PBXShellScriptBuildPhase' && p.name && p.name.start_with?('[CP]')
-       }
-       .each do |run|
-         if (run.input_paths || []).empty? && (run.output_paths || []).empty?
-           run.always_out_of_date = '1'
-         end
-       end
+        .select { |p| p.isa == 'PBXShellScriptBuildPhase' && p.name&.start_with?('[CP]') }
+        .each do |run|
+          run.always_out_of_date = '1' if (run.input_paths || []).empty? && (run.output_paths || []).empty?
+        end
     end
-
     proj.save
   end
 
   # --- Guard: fail if any Hermes replacement script remains
   if ENV['CI'] == 'true'
     offending = []
-    pods_projects.each do |proj|
-      proj.targets.each do |t|
-        next unless t.name == 'hermes-engine'
-        t.shell_script_build_phases.each do |phase|
-          name = (phase.name || '').downcase
-          body = (phase.shell_script || '').downcase
-          if name.include?('replace hermes') || body.include?('replace hermes')
-            offending << "#{proj.path.basename} :: #{t.name} :: #{phase.name}"
-          end
-        end
+    pods_project.targets.each do |t|
+      next unless t.name == 'hermes-engine'
+      t.shell_script_build_phases.each do |phase|
+        name = (phase.name || '').downcase
+        body = (phase.shell_script || '').downcase
+        offending << "#{t.name} :: #{phase.name}" if name.include?('replace hermes') || body.include?('replace hermes')
       end
     end
     unless offending.empty?

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -129,7 +129,21 @@ end
 post_integrate do |installer|
   pods_project = installer.pods_project
 
-  # Collect real Xcode *projects* only (avoid Pod::PodTarget, etc.)
+  # --- Remove the forbidden Hermes script (only from Pods project)
+  if ENV['CI'] == 'true'
+    pods_project.targets.each do |t|
+      next unless t.name == 'hermes-engine'
+      t.shell_script_build_phases.each do |phase|
+        if phase.name&.include?('Replace Hermes for the right configuration')
+          UI.puts "🧹 Removing Hermes script phase from #{t.name}"
+          t.build_phases.delete(phase)
+        end
+      end
+    end
+    pods_project.save
+  end
+
+  # --- Collect real Xcode *projects* only (avoid Pod::PodTarget, etc.)
   user_projects = installer.aggregate_targets
     .select { |agg| agg.respond_to?(:user_project) && agg.user_project }
     .map(&:user_project)
@@ -145,5 +159,25 @@ post_integrate do |installer|
         end
     end
     proj.save
+  end
+
+  # --- Guard: fail if any Hermes replacement script remains
+  if ENV['CI'] == 'true'
+    offending = []
+    pods_project.targets.each do |t|
+      next unless t.name == 'hermes-engine'
+      t.shell_script_build_phases.each do |phase|
+        name = (phase.name || '').downcase
+        body = (phase.shell_script || '').downcase
+        offending << "#{t.name} :: #{phase.name}" if name.include?('replace hermes') || body.include?('replace hermes')
+      end
+    end
+    unless offending.empty?
+      raise <<~MSG
+        Detected forbidden Hermes script phase(s):
+          #{offending.join("\n  ")}
+        CI policy: the "[Hermes] Replace Hermes" script must not exist after pod install.
+      MSG
+    end
   end
 end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -95,6 +95,34 @@ post_install do |installer|
     end
     user_project.save
   end
+
+  # ---- Hermes Fix 2: Remove "Replace Hermes" script phases everywhere ----
+  forbidden_markers = [
+    'Replace Hermes for the right configuration, if needed',
+    'Replace Hermes'
+  ]
+
+  # 1) Scrub Pods project targets (e.g., hermes-engine, React-hermes, etc.)
+  installer.pods_project.targets.each do |t|
+    t.build_phases
+      .select { |p| p.respond_to?(:name) && forbidden_markers.any? { |m| p.name.to_s.include?(m) } }
+      .each { |p| t.build_phases.delete(p) }
+  end
+
+  # 2) Scrub the user projects (your app/workspace targets) that CocoaPods touches
+  installer.aggregate_targets.each do |agg|
+    agg.user_project.native_targets.each do |nt|
+      nt.build_phases
+        .select { |p| p.respond_to?(:name) && forbidden_markers.any? { |m| p.name.to_s.include?(m) } }
+        .each { |p| nt.build_phases.delete(p) }
+    end
+
+    # Save the user project after mutation
+    agg.user_project.save
+  end
+
+  # Save the Pods project after mutation
+  installer.pods_project.save
 end
 
 # Silences "will be run during every build" warnings for [CP] phases lacking I/O paths

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -98,57 +98,75 @@ post_install do |installer|
 end
 
 # Silences "will be run during every build" warnings for [CP] phases lacking I/O paths
+# and removes the Hermes "Replace Hermes..." phase on CI after CocoaPods has integrated.
 post_integrate do |installer|
   pods_project = installer.pods_project
 
-  # --- Remove the forbidden Hermes script (only from Pods project)
+  # 1) On CI, remove the Hermes "[Hermes] Replace Hermes..." phase from the Pods project
   if ENV['CI'] == 'true'
-    pods_project.targets.each do |t|
-      next unless t.name == 'hermes-engine'
-      t.shell_script_build_phases.each do |phase|
-        if phase.name&.include?('Replace Hermes for the right configuration')
-          UI.puts "🧹 Removing Hermes script phase from #{t.name}"
-          t.build_phases.delete(phase)
+    begin
+      pods_project.targets
+        .select { |t| t.name == 'hermes-engine' }
+        .each do |t|
+          t.shell_script_build_phases.each do |phase|
+            if (phase.name || '').include?('Replace Hermes for the right configuration')
+              UI.puts "🧹 Removing Hermes script phase from #{t.name}"
+              t.build_phases.delete(phase)
+            end
+          end
         end
-      end
+      pods_project.save
+    rescue => e
+      UI.puts "[warn] post_integrate Hermes cleanup failed: #{e}"
     end
-    pods_project.save
   end
 
-  # --- Collect real Xcode *projects* only (avoid Pod::PodTarget, etc.)
+  # 2) Collect user Xcode projects safely
   user_projects = installer.aggregate_targets
-    .select { |agg| agg.respond_to?(:user_project) && agg.user_project }
-    .map(&:user_project)
-    .uniq { |p| p.path.to_s }
+                    .map { |agg| agg.user_project }
+                    .compact
+                    .uniq
 
-  # Mark [CP] phases without I/O as always out-of-date to silence Xcode warnings
+  # 3) For Pods project + each user project, silence [CP] “always out of date” warnings if no I/O paths
   ([pods_project] + user_projects).each do |proj|
+    next unless proj.respond_to?(:targets)
+
     proj.targets.each do |t|
       t.build_phases
-        .select { |p| p.isa == 'PBXShellScriptBuildPhase' && p.name&.start_with?('[CP]') }
-        .each do |run|
-          run.always_out_of_date = '1' if (run.input_paths || []).empty? && (run.output_paths || []).empty?
-        end
+       .select { |p|
+         p.isa == 'PBXShellScriptBuildPhase' && p.name && p.name.start_with?('[CP]')
+       }
+       .each do |run|
+         if (run.input_paths || []).empty? && (run.output_paths || []).empty?
+           run.always_out_of_date = '1'
+         end
+       end
     end
+
     proj.save
   end
 
-  # --- Guard: fail if any Hermes replacement script remains
+  # 4) Guard: fail CI if any Hermes "Replace Hermes" phase still exists after our cleanup
   if ENV['CI'] == 'true'
     offending = []
-    pods_project.targets.each do |t|
-      next unless t.name == 'hermes-engine'
-      t.shell_script_build_phases.each do |phase|
-        name = (phase.name || '').downcase
-        body = (phase.shell_script || '').downcase
-        offending << "#{t.name} :: #{phase.name}" if name.include?('replace hermes') || body.include?('replace hermes')
+    pods_project.targets
+      .select { |t| t.name == 'hermes-engine' }
+      .each do |t|
+        t.shell_script_build_phases.each do |phase|
+          name = (phase.name || '').downcase
+          body = (phase.shell_script || '').downcase
+          if name.include?('replace hermes') || body.include?('replace hermes')
+            offending << "#{t.name} :: #{phase.name}"
+          end
+        end
       end
-    end
+
     unless offending.empty?
       raise <<~MSG
         Detected forbidden Hermes script phase(s):
           #{offending.join("\n  ")}
-        CI policy: the "[Hermes] Replace Hermes" script must not exist after pod install.
+        CI policy: the "[Hermes] Replace Hermes" script must not exist.
+        The phase was expected to be deleted in post_integrate. Investigate Pod integration.
       MSG
     end
   end

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -66,5 +66,18 @@ targets:
         product: MLX
       - package: MLXLibraries
         product: MLXLLM
+    scripts:
+      - name: Create Symlinks to Header Folders
+        script: echo "Symlinks handled by CocoaPods"
+        outputFiles:
+          - "${DERIVED_FILE_DIR}/create_symlinks_to_header_folders.stamp"
+      - name: "[CP-User] [Hermes] Replace Hermes for the right configuration, if needed"
+        script: echo "Hermes script neutralized in post_integrate"
+        outputFiles:
+          - "${DERIVED_FILE_DIR}/replace_hermes.stamp"
+      - name: "[CP] Copy XCFrameworks"
+        script: echo "Copy XCFrameworks handled by CocoaPods"
+        outputFiles:
+          - "${DERIVED_FILE_DIR}/copy_xcframeworks.stamp"
     scheme:
       testTargets: []

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -71,10 +71,6 @@ targets:
         script: echo "Symlinks handled by CocoaPods"
         outputFiles:
           - "${DERIVED_FILE_DIR}/create_symlinks_to_header_folders.stamp"
-      - name: "[CP-User] [Hermes] Replace Hermes for the right configuration, if needed"
-        script: echo "Hermes script neutralized in post_integrate"
-        outputFiles:
-          - "${DERIVED_FILE_DIR}/replace_hermes.stamp"
       - name: "[CP] Copy XCFrameworks"
         script: echo "Copy XCFrameworks handled by CocoaPods"
         outputFiles:

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,6 @@ module.exports = {
   },
   testEnvironment: "node",
   coverageThreshold: {
-    global: { lines: 40 }
+    global: { lines: 40 },
   },
 };

--- a/scripts/strip_hermes_phase.rb
+++ b/scripts/strip_hermes_phase.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+# Usage: ruby scripts/strip_hermes_phase.rb ios/Pods/Pods.xcodeproj ios/MyOfflineLLMApp.xcodeproj
+
+require 'xcodeproj'
+
+markers = [
+  'Replace Hermes for the right configuration, if needed',
+  'Replace Hermes'
+]
+
+def scrub_project(path, markers)
+  project = Xcodeproj::Project.open(path)
+  changed = false
+
+  project.targets.each do |t|
+    phases_to_delete = t.build_phases.select do |p|
+      p.respond_to?(:name) && markers.any? { |m| p.name.to_s.include?(m) }
+    end
+    phases_to_delete.each do |p|
+      t.build_phases.delete(p)
+      changed = true
+    end
+  end
+
+  project.save if changed
+  changed
+end
+
+ARGV.each do |proj_path|
+  if File.exist?(proj_path)
+    changed = scrub_project(proj_path, markers)
+    puts "[strip_hermes_phase] #{proj_path}: #{changed ? 'removed phases' : 'nothing to remove'}"
+  else
+    warn "[strip_hermes_phase] not found: #{proj_path}"
+  end
+end

--- a/src/App.js
+++ b/src/App.js
@@ -52,7 +52,7 @@ function App() {
   const { send } = useChat();
   const { messages } = useLLMStore();
   const { isRecording, start } = useSpeechRecognition(send, (err) =>
-    console.warn("Speech recognition error", err)
+    console.warn("Speech recognition error", err),
   );
 
   useEffect(() => {

--- a/src/architecture/diSetup.js
+++ b/src/architecture/diSetup.js
@@ -1,5 +1,5 @@
 export function setupLLMDI(di, { deviceProfile, performanceMetrics, kvCache }) {
-  di.register('deviceProfile', deviceProfile);
-  di.register('performanceMetrics', performanceMetrics);
-  di.register('kvCache', kvCache);
+  di.register("deviceProfile", deviceProfile);
+  di.register("performanceMetrics", performanceMetrics);
+  di.register("kvCache", kvCache);
 }

--- a/src/architecture/pluginSetup.js
+++ b/src/architecture/pluginSetup.js
@@ -1,10 +1,11 @@
 export function registerLLMPlugins(pluginManager, context) {
-  pluginManager.registerPlugin('sparseAttention', {
-    initialize: async () => console.log('Sparse attention plugin initialized'),
+  pluginManager.registerPlugin("sparseAttention", {
+    initialize: async () => console.log("Sparse attention plugin initialized"),
     replace: {
       generate: async function (prompt, maxTokens, temperature, options = {}) {
-        const useSparseAttention = options.useSparseAttention ||
-          context.deviceProfile.tier === 'low' ||
+        const useSparseAttention =
+          options.useSparseAttention ||
+          context.deviceProfile.tier === "low" ||
           context.kvCache.size > context.kvCache.maxSize * 0.8;
         if (context.isWeb) {
           return context.generateWeb(prompt, maxTokens, temperature);
@@ -12,15 +13,16 @@ export function registerLLMPlugins(pluginManager, context) {
         const generateOptions = {
           maxTokens,
           temperature,
-          useSparseAttention
+          useSparseAttention,
         };
         return context.nativeModule.generate(prompt, generateOptions);
-      }
-    }
+      },
+    },
   });
 
-  pluginManager.registerPlugin('adaptiveQuantization', {
-    initialize: async () => console.log('Adaptive quantization plugin initialized'),
+  pluginManager.registerPlugin("adaptiveQuantization", {
+    initialize: async () =>
+      console.log("Adaptive quantization plugin initialized"),
     // The actual quantization adjustment logic now lives on the LLMService
     // instance. See src/services/llmService.js. No need to extend the global
     // LLMService prototype. Enabling this plugin simply allows

--- a/src/architecture/toolSystem.js
+++ b/src/architecture/toolSystem.js
@@ -78,7 +78,7 @@ export class ToolRegistry {
 
   getToolsByCategory(category) {
     return Array.from(this.toolCategories.get(category) || []).map((toolName) =>
-      this.tools.get(toolName)
+      this.tools.get(toolName),
     );
   }
 
@@ -318,7 +318,7 @@ export const builtInTools = {
       try {
         // Safe evaluation of mathematical expressions
         const result = eval(
-          parameters.expression.replace(/[^0-9+\-*/().]/g, "")
+          parameters.expression.replace(/[^0-9+\-*/().]/g, ""),
         );
         return { result, success: true };
       } catch (error) {

--- a/src/components/ExtractedContent.js
+++ b/src/components/ExtractedContent.js
@@ -21,7 +21,7 @@ const ExtractedContent = ({ content, onLinkPress }) => {
         onLinkPress(href);
       } else {
         Linking.openURL(href).catch((err) =>
-          console.error("Failed to open URL:", err)
+          console.error("Failed to open URL:", err),
         );
       }
     } catch (e) {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -8,7 +8,7 @@ if (isReactNative) {
     Config = {};
     console.warn(
       "[Config] Failed to load react-native-config. Falling back to empty config. This may indicate a misconfiguration.",
-      _e
+      _e,
     );
   }
 }

--- a/src/core/tools/ToolHandler.js
+++ b/src/core/tools/ToolHandler.js
@@ -50,7 +50,11 @@ export default class ToolHandler {
         const res = await tool.execute(args);
         results.push({ role: "tool", name, content: JSON.stringify(res) });
       } catch (error) {
-        results.push({ role: "tool", name, content: `Error: ${error.message}` });
+        results.push({
+          role: "tool",
+          name,
+          content: `Error: ${error.message}`,
+        });
       }
     }
     return results;

--- a/src/core/tools/ToolRegistry.js
+++ b/src/core/tools/ToolRegistry.js
@@ -1,13 +1,13 @@
-import * as iosTools from '../../tools/iosTools';
-import * as androidTools from '../../tools/androidTools';
-import { Platform } from 'react-native';
+import * as iosTools from "../../tools/iosTools";
+import * as androidTools from "../../tools/androidTools";
+import { Platform } from "react-native";
 
 const createToolRegistry = () => {
   const tools = new Map();
 
   return {
     register(name, tool) {
-      if (!tool || typeof tool.execute !== 'function') {
+      if (!tool || typeof tool.execute !== "function") {
         throw new Error(`Invalid tool ${name}: missing execute()`);
       }
       tools.set(name, tool);
@@ -23,7 +23,7 @@ const createToolRegistry = () => {
     },
     autoRegister(module) {
       Object.values(module).forEach((tool) => {
-        if (tool && typeof tool.execute === 'function') {
+        if (tool && typeof tool.execute === "function") {
           this.register(tool.name, tool);
         }
       });
@@ -33,7 +33,7 @@ const createToolRegistry = () => {
 
 export const toolRegistry = createToolRegistry();
 
-const moduleToUse = Platform.OS === 'android' ? androidTools : iosTools;
+const moduleToUse = Platform.OS === "android" ? androidTools : iosTools;
 toolRegistry.autoRegister(moduleToUse);
 
 export default toolRegistry;

--- a/src/emotion/ProsodyDetector.ts
+++ b/src/emotion/ProsodyDetector.ts
@@ -1,4 +1,4 @@
-import { getEnv } from '../config';
+import { getEnv } from "../config";
 
 export interface ProsodyResult {
   emotion: string | null;
@@ -8,7 +8,7 @@ export interface ProsodyResult {
 export default class ProsodyDetector {
   enabled: boolean;
   constructor() {
-    this.enabled = getEnv('EMOTION_AUDIO_ENABLED') === 'true';
+    this.enabled = getEnv("EMOTION_AUDIO_ENABLED") === "true";
   }
 
   async analyze(_audio: Float32Array): Promise<ProsodyResult> {
@@ -16,7 +16,7 @@ export default class ProsodyDetector {
     // placeholder tiny model: compute simple energy
     const energy = _audio.reduce((s, v) => s + Math.abs(v), 0) / _audio.length;
     if (energy > 0.5) {
-      return { emotion: 'excited', confidence: 0.6 };
+      return { emotion: "excited", confidence: 0.6 };
     }
     return { emotion: null, confidence: 0.3 };
   }

--- a/src/hooks/useEmotion.ts
+++ b/src/hooks/useEmotion.ts
@@ -14,7 +14,7 @@ export function useEmotion() {
     };
     const lower = text.toLowerCase();
     const found = Object.entries(checks).find(([, words]) =>
-      words.some((w) => lower.includes(w))
+      words.some((w) => lower.includes(w)),
     );
     return found ? found[0] : null;
   };

--- a/src/hooks/useSpeechRecognition.js
+++ b/src/hooks/useSpeechRecognition.js
@@ -1,15 +1,15 @@
-import { useState, useEffect, useCallback } from 'react';
-import Voice from '@react-native-voice/voice';
+import { useState, useEffect, useCallback } from "react";
+import Voice from "@react-native-voice/voice";
 
 export function useSpeechRecognition(onResult, onError) {
   const [isRecording, setIsRecording] = useState(false);
 
   useEffect(() => {
-    Voice.onSpeechResults = event => {
+    Voice.onSpeechResults = (event) => {
       setIsRecording(false);
-      onResult(event.value?.[0] ?? '');
+      onResult(event.value?.[0] ?? "");
     };
-    Voice.onSpeechError = event => {
+    Voice.onSpeechError = (event) => {
       setIsRecording(false);
       if (onError) {
         onError(event.error);
@@ -23,7 +23,7 @@ export function useSpeechRecognition(onResult, onError) {
   const start = useCallback(async () => {
     setIsRecording(true);
     try {
-      await Voice.start('en-US');
+      await Voice.start("en-US");
     } catch (e) {
       setIsRecording(false);
       if (onError) {

--- a/src/memory/migrations/index.ts
+++ b/src/memory/migrations/index.ts
@@ -1,4 +1,4 @@
-import { up as init } from './0001_initial';
+import { up as init } from "./0001_initial";
 
 export const CURRENT_VERSION = 1;
 

--- a/src/native/mlx.ts
+++ b/src/native/mlx.ts
@@ -5,7 +5,7 @@ type MLXNative = {
   generate(
     _prompt: string,
     _maxTokens: number,
-    _temperature: number
+    _temperature: number,
   ): Promise<string>;
 };
 

--- a/src/privacy/consents.ts
+++ b/src/privacy/consents.ts
@@ -1,7 +1,13 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Logger } from '../utils/logger';
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { Logger } from "../utils/logger";
 
-const VALID_CONSENTS = ['camera', 'location', 'contacts', 'photos', 'microphone'] as const;
+const VALID_CONSENTS = [
+  "camera",
+  "location",
+  "contacts",
+  "photos",
+  "microphone",
+] as const;
 type ConsentKey = (typeof VALID_CONSENTS)[number];
 
 interface ConsentRecord {
@@ -10,12 +16,12 @@ interface ConsentRecord {
   timestamp: number;
 }
 
-const CONSENT_PREFIX = 'consent_';
+const CONSENT_PREFIX = "consent_";
 
 class ConsentError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = 'ConsentError';
+    this.name = "ConsentError";
   }
 }
 
@@ -23,12 +29,19 @@ export async function setConsent(key: string, value: boolean): Promise<void> {
   if (!VALID_CONSENTS.includes(key as ConsentKey)) {
     Logger.error(`Invalid consent key: ${key}`);
     throw new ConsentError(
-      `Invalid consent key: ${key}. Allowed: ${VALID_CONSENTS.join(', ')}`,
+      `Invalid consent key: ${key}. Allowed: ${VALID_CONSENTS.join(", ")}`,
     );
   }
-  const record: ConsentRecord = { key: key as ConsentKey, value, timestamp: Date.now() };
+  const record: ConsentRecord = {
+    key: key as ConsentKey,
+    value,
+    timestamp: Date.now(),
+  };
   try {
-    await AsyncStorage.setItem(`${CONSENT_PREFIX}${key}`, JSON.stringify(record));
+    await AsyncStorage.setItem(
+      `${CONSENT_PREFIX}${key}`,
+      JSON.stringify(record),
+    );
     Logger.info(`Consent set: ${key} = ${value}`);
   } catch (error: any) {
     Logger.error(`Failed to set consent for ${key}: ${error.message}`);
@@ -64,7 +77,9 @@ export async function revokeConsent(key: string): Promise<void> {
   }
 }
 
-export async function listConsents(): Promise<Record<ConsentKey, ConsentRecord>> {
+export async function listConsents(): Promise<
+  Record<ConsentKey, ConsentRecord>
+> {
   try {
     const keys = await AsyncStorage.getAllKeys();
     const consentKeys = keys.filter((k) => k.startsWith(CONSENT_PREFIX));
@@ -72,7 +87,7 @@ export async function listConsents(): Promise<Record<ConsentKey, ConsentRecord>>
     const result: Partial<Record<ConsentKey, ConsentRecord>> = {};
     for (const [key, value] of entries) {
       if (value) {
-        const consentKey = key.replace(CONSENT_PREFIX, '') as ConsentKey;
+        const consentKey = key.replace(CONSENT_PREFIX, "") as ConsentKey;
         if (VALID_CONSENTS.includes(consentKey)) {
           result[consentKey] = JSON.parse(value) as ConsentRecord;
         }

--- a/src/registerTurboModules.ts
+++ b/src/registerTurboModules.ts
@@ -1,14 +1,14 @@
 // Ensures RN codegen treats these NativeModule specs as "used".
 // Safe at runtime: we swallow the error if the native module isn't present.
 
-import { TurboModuleRegistry } from 'react-native';
-import type { Spec } from './specs/NativeLLM';
+import { TurboModuleRegistry } from "react-native";
+import type { Spec } from "./specs/NativeLLM";
 
 // Mark LLM as used for codegen. Do not export anything.
 (() => {
   try {
     // IMPORTANT: codegen looks specifically for `get<Spec>('Name')` calls.
-    TurboModuleRegistry.get<Spec>('LLM');
+    TurboModuleRegistry.get<Spec>("LLM");
   } catch {
     // No-op at runtime if Turbo module isn't registered yet.
   }

--- a/src/services/contextEngineer.js
+++ b/src/services/contextEngineer.js
@@ -26,7 +26,7 @@ export class ContextEvaluator {
     }
 
     const relevantContext = contextItems.filter(
-      (item) => item.similarity >= this.relevanceThreshold
+      (item) => item.similarity >= this.relevanceThreshold,
     );
 
     const topContext = relevantContext
@@ -54,7 +54,7 @@ export class ContextEvaluator {
     const selectedContext = await applySparseAttention(
       queryEmbedding,
       clusteredContext,
-      { numClusters: 3, topK: 2 }
+      { numClusters: 3, topK: 2 },
     );
 
     return await this._assessContextQuality(query, selectedContext);
@@ -69,7 +69,7 @@ export class ContextEvaluator {
       for (const cluster of clusters) {
         const clusterSimilarity = cosineSimilarity(
           item.embedding,
-          cluster.center
+          cluster.center,
         );
 
         if (clusterSimilarity > 0.7) {
@@ -190,14 +190,14 @@ export class ContextEngineer {
       return this._hierarchicalContextProcessing(
         query,
         conversationHistory,
-        tokenBudget
+        tokenBudget,
       );
     }
 
     return this._standardContextProcessing(
       query,
       conversationHistory,
-      tokenBudget
+      tokenBudget,
     );
   }
 
@@ -238,18 +238,18 @@ export class ContextEngineer {
   async _hierarchicalContextProcessing(
     query,
     conversationHistory,
-    tokenBudget
+    tokenBudget,
   ) {
     const queryEmbedding = await LLMService.embed(query);
 
     const relevantChunks = await this._retrieveRelevantChunksSparse(
       queryEmbedding,
-      Math.floor(tokenBudget.contextTokens / 100)
+      Math.floor(tokenBudget.contextTokens / 100),
     );
 
     const conversationSummary = await this._summarizeConversationHierarchically(
       conversationHistory,
-      tokenBudget.historyTokens
+      tokenBudget.historyTokens,
     );
 
     const availableContextTokens =
@@ -259,14 +259,14 @@ export class ContextEngineer {
 
     const selectedContext = await this._selectContextWithinBudgetSparse(
       relevantChunks,
-      availableContextTokens
+      availableContextTokens,
     );
 
     return {
       contextPrompt: this._assembleHierarchicalContext(
         query,
         selectedContext,
-        conversationSummary
+        conversationSummary,
       ),
       tokenUsage: {
         total: tokenBudget.maxContextTokens,
@@ -283,13 +283,13 @@ export class ContextEngineer {
       const results = await vectorStore.searchVectorsSparse(
         queryEmbedding,
         limit,
-        { useHierarchical: true, numClusters: 3 }
+        { useHierarchical: true, numClusters: 3 },
       );
       return results;
     } catch (error) {
       console.error(
         "Sparse retrieval failed, falling back to standard:",
-        error
+        error,
       );
       return await vectorStore.searchVectors(queryEmbedding, limit);
     }
@@ -306,7 +306,7 @@ export class ContextEngineer {
       const summaryResult = await LLMService.generate(
         summaryPrompt,
         maxTokens,
-        0.3
+        0.3,
       );
 
       return {
@@ -324,7 +324,7 @@ export class ContextEngineer {
           conversationHistory
             .slice(-2)
             .map((m) => m.content)
-            .join("\n")
+            .join("\n"),
         ),
       };
     }

--- a/src/services/providers/bing.js
+++ b/src/services/providers/bing.js
@@ -1,5 +1,5 @@
-import { getApiKeys } from '../utils/apiKeys';
-import { bing as mapTime } from '../utils/timeRange';
+import { getApiKeys } from "../utils/apiKeys";
+import { bing as mapTime } from "../utils/timeRange";
 
 export async function validateKey() {
   const { BING_API_KEY } = await getApiKeys();
@@ -9,20 +9,23 @@ export async function validateKey() {
 export async function search(query, { maxResults, timeRange, safeSearch }) {
   const { BING_API_KEY } = await getApiKeys();
   if (!BING_API_KEY) {
-    throw new Error('Missing Bing key');
+    throw new Error("Missing Bing key");
   }
-  const freshness = mapTime[timeRange] || '';
-  const url = `https://api.bing.microsoft.com/v7.0/search?q=${encodeURIComponent(query)}` +
-    `&count=${maxResults}&freshness=${freshness}&safeSearch=${safeSearch ? 'Moderate' : 'Off'}`;
+  const freshness = mapTime[timeRange] || "";
+  const url =
+    `https://api.bing.microsoft.com/v7.0/search?q=${encodeURIComponent(query)}` +
+    `&count=${maxResults}&freshness=${freshness}&safeSearch=${safeSearch ? "Moderate" : "Off"}`;
   const res = await fetch(url, {
-    headers: { 'Ocp-Apim-Subscription-Key': BING_API_KEY }
+    headers: { "Ocp-Apim-Subscription-Key": BING_API_KEY },
   });
   if (!res.ok) throw new Error(`Bing Error: ${res.statusText}`);
   const data = await res.json();
-  return data.webPages?.value?.map(item => ({
-    title: item.name,
-    url: item.url,
-    snippet: item.snippet,
-    date: item.dateLastCrawled || null
-  })) || [];
+  return (
+    data.webPages?.value?.map((item) => ({
+      title: item.name,
+      url: item.url,
+      snippet: item.snippet,
+      date: item.dateLastCrawled || null,
+    })) || []
+  );
 }

--- a/src/services/providers/brave.js
+++ b/src/services/providers/brave.js
@@ -1,5 +1,5 @@
-import { getApiKeys } from '../utils/apiKeys';
-import { brave as mapTime } from '../utils/timeRange';
+import { getApiKeys } from "../utils/apiKeys";
+import { brave as mapTime } from "../utils/timeRange";
 
 export async function validateKey() {
   const { BRAVE_API_KEY } = await getApiKeys();
@@ -9,24 +9,27 @@ export async function validateKey() {
 export async function search(query, { maxResults, timeRange, safeSearch }) {
   const { BRAVE_API_KEY } = await getApiKeys();
   if (!BRAVE_API_KEY) {
-    throw new Error('Missing Brave key');
+    throw new Error("Missing Brave key");
   }
-  const freshness = mapTime[timeRange] || '';
-  const url = `https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(query)}` +
-    `&count=${maxResults}&freshness=${freshness}&safesearch=${safeSearch ? 'moderate' : 'off'}`;
+  const freshness = mapTime[timeRange] || "";
+  const url =
+    `https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(query)}` +
+    `&count=${maxResults}&freshness=${freshness}&safesearch=${safeSearch ? "moderate" : "off"}`;
   const res = await fetch(url, {
     headers: {
-      Accept: 'application/json',
-      'Accept-Encoding': 'gzip',
-      'X-Subscription-Token': BRAVE_API_KEY
-    }
+      Accept: "application/json",
+      "Accept-Encoding": "gzip",
+      "X-Subscription-Token": BRAVE_API_KEY,
+    },
   });
   if (!res.ok) throw new Error(`Brave Error: ${res.statusText}`);
   const data = await res.json();
-  return data.web?.results?.map(item => ({
-    title: item.title,
-    url: item.url,
-    snippet: item.description,
-    date: item.age || null
-  })) || [];
+  return (
+    data.web?.results?.map((item) => ({
+      title: item.title,
+      url: item.url,
+      snippet: item.description,
+      date: item.age || null,
+    })) || []
+  );
 }

--- a/src/services/providers/duckduckgo.js
+++ b/src/services/providers/duckduckgo.js
@@ -4,16 +4,17 @@ export async function validateKey() {
 
 function parseResults(html, maxResults) {
   const results = [];
-  const regex = /<a class="result__a".*?href="([^"]+)".*?>(.*?)<\/a>.*?<a class="result__snippet".*?>(.*?)<\/a>/gs;
+  const regex =
+    /<a class="result__a".*?href="([^"]+)".*?>(.*?)<\/a>.*?<a class="result__snippet".*?>(.*?)<\/a>/gs;
   let match;
   while ((match = regex.exec(html)) !== null && results.length < maxResults) {
-    if (match[1].startsWith('//ad.')) continue;
-    const url = match[1].startsWith('//') ? 'https:' + match[1] : match[1];
+    if (match[1].startsWith("//ad.")) continue;
+    const url = match[1].startsWith("//") ? "https:" + match[1] : match[1];
     results.push({
-      title: match[2].replace(/<[^>]*>/g, ''),
+      title: match[2].replace(/<[^>]*>/g, ""),
       url,
-      snippet: match[3].replace(/<[^>]*>/g, ''),
-      date: null
+      snippet: match[3].replace(/<[^>]*>/g, ""),
+      date: null,
     });
   }
   return results;

--- a/src/services/providers/google.js
+++ b/src/services/providers/google.js
@@ -1,5 +1,5 @@
-import { getApiKeys } from '../utils/apiKeys';
-import { google as mapTime } from '../utils/timeRange';
+import { getApiKeys } from "../utils/apiKeys";
+import { google as mapTime } from "../utils/timeRange";
 
 export async function validateKey() {
   const { GOOGLE_API_KEY, GOOGLE_SEARCH_ENGINE_ID } = await getApiKeys();
@@ -9,20 +9,21 @@ export async function validateKey() {
 export async function search(query, { maxResults, timeRange, safeSearch }) {
   const { GOOGLE_API_KEY, GOOGLE_SEARCH_ENGINE_ID } = await getApiKeys();
   if (!GOOGLE_API_KEY || !GOOGLE_SEARCH_ENGINE_ID) {
-    throw new Error('Missing Google key/config');
+    throw new Error("Missing Google key/config");
   }
-  const dateRestrict = mapTime[timeRange] || '';
-  const safe = safeSearch ? 'medium' : 'off';
-  const url = `https://www.googleapis.com/customsearch/v1?key=${GOOGLE_API_KEY}&cx=${GOOGLE_SEARCH_ENGINE_ID}` +
+  const dateRestrict = mapTime[timeRange] || "";
+  const safe = safeSearch ? "medium" : "off";
+  const url =
+    `https://www.googleapis.com/customsearch/v1?key=${GOOGLE_API_KEY}&cx=${GOOGLE_SEARCH_ENGINE_ID}` +
     `&q=${encodeURIComponent(query)}&num=${Math.min(maxResults, 10)}&safe=${safe}` +
-    (dateRestrict ? `&dateRestrict=${dateRestrict}` : '');
+    (dateRestrict ? `&dateRestrict=${dateRestrict}` : "");
   const res = await fetch(url);
   if (!res.ok) throw new Error(`Google Error: ${res.statusText}`);
   const { items = [] } = await res.json();
-  return items.map(i => ({
+  return items.map((i) => ({
     title: i.title,
     url: i.link,
     snippet: i.snippet,
-    date: i.pagemap?.metatags?.[0]?.['article:published_time'] || null
+    date: i.pagemap?.metatags?.[0]?.["article:published_time"] || null,
   }));
 }

--- a/src/services/readabilityService.js
+++ b/src/services/readabilityService.js
@@ -64,7 +64,7 @@ class ReadabilityService {
 
       if (!response.ok) {
         throw new Error(
-          `HTTP error ${response.status}: ${response.statusText}`
+          `HTTP error ${response.status}: ${response.statusText}`,
         );
       }
 

--- a/src/services/treeOfThought.js
+++ b/src/services/treeOfThought.js
@@ -44,7 +44,7 @@ export class TreeOfThoughtReasoner {
     // Generate candidate thoughts
     const candidateThoughts = await this.generateCandidateThoughts(
       node.thought,
-      maxBranches
+      maxBranches,
     );
 
     // Evaluate each candidate
@@ -67,7 +67,7 @@ export class TreeOfThoughtReasoner {
           childNode,
           maxBranches,
           maxDepth,
-          evaluationThreshold
+          evaluationThreshold,
         );
       }
     }
@@ -172,7 +172,7 @@ Provide only the numerical rating:`;
         this.solveComplexProblem(problem, {
           maxBranches: Math.floor(this.maxBranches / numTrees),
           maxDepth: this.maxDepth,
-        })
+        }),
       );
     }
 

--- a/src/services/utils/apiKeys.js
+++ b/src/services/utils/apiKeys.js
@@ -1,24 +1,24 @@
-import { getEnv } from '../../config';
+import { getEnv } from "../../config";
 
 export async function getApiKeys() {
   return {
-    GOOGLE_API_KEY: getEnv('GOOGLE_API_KEY'),
-    GOOGLE_SEARCH_ENGINE_ID: getEnv('GOOGLE_SEARCH_ENGINE_ID'),
-    BING_API_KEY: getEnv('BING_API_KEY'),
-    BRAVE_API_KEY: getEnv('BRAVE_API_KEY')
+    GOOGLE_API_KEY: getEnv("GOOGLE_API_KEY"),
+    GOOGLE_SEARCH_ENGINE_ID: getEnv("GOOGLE_SEARCH_ENGINE_ID"),
+    BING_API_KEY: getEnv("BING_API_KEY"),
+    BRAVE_API_KEY: getEnv("BRAVE_API_KEY"),
   };
 }
 
 export async function validate(provider) {
   const keys = await getApiKeys();
   switch (provider) {
-    case 'google':
+    case "google":
       return !!(keys.GOOGLE_API_KEY && keys.GOOGLE_SEARCH_ENGINE_ID);
-    case 'bing':
+    case "bing":
       return !!keys.BING_API_KEY;
-    case 'brave':
+    case "brave":
       return !!keys.BRAVE_API_KEY;
-    case 'duckduckgo':
+    case "duckduckgo":
       return true;
     default:
       return false;

--- a/src/services/utils/cacheAndRate.js
+++ b/src/services/utils/cacheAndRate.js
@@ -18,7 +18,7 @@ export function rateLimiter(provider, fn, delay = 1000) {
   const last = lastRequestTimes.get(provider) || 0;
   const remaining = delay - (now - last);
   if (remaining > 0) {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       setTimeout(async () => {
         lastRequestTimes.set(provider, Date.now());
         resolve(await fn());

--- a/src/services/utils/timeRange.js
+++ b/src/services/utils/timeRange.js
@@ -1,19 +1,19 @@
 export const google = {
-  day: 'd1',
-  week: 'w1',
-  month: 'm1',
-  year: 'y1'
+  day: "d1",
+  week: "w1",
+  month: "m1",
+  year: "y1",
 };
 
 export const bing = {
-  day: 'Day',
-  week: 'Week',
-  month: 'Month'
+  day: "Day",
+  week: "Week",
+  month: "Month",
 };
 
 export const brave = {
-  day: 'pd',
-  week: 'pw',
-  month: 'pm',
-  year: 'py'
+  day: "pd",
+  week: "pw",
+  month: "pm",
+  year: "py",
 };

--- a/src/services/webSearchService.js
+++ b/src/services/webSearchService.js
@@ -1,10 +1,10 @@
-import * as google from './providers/google';
-import * as bing from './providers/bing';
-import * as brave from './providers/brave';
-import * as duckduckgo from './providers/duckduckgo';
-import { validate } from './utils/apiKeys';
-import { simpleCache, rateLimiter } from './utils/cacheAndRate';
-import ReadabilityService from './readabilityService';
+import * as google from "./providers/google";
+import * as bing from "./providers/bing";
+import * as brave from "./providers/brave";
+import * as duckduckgo from "./providers/duckduckgo";
+import { validate } from "./utils/apiKeys";
+import { simpleCache, rateLimiter } from "./utils/cacheAndRate";
+import ReadabilityService from "./readabilityService";
 
 const PROVIDERS = { google, bing, brave, duckduckgo };
 
@@ -15,13 +15,30 @@ export class SearchService {
     if (!(await validate(providerName))) {
       throw new Error(`No API key for ${providerName}`);
     }
-    const run = () => provider.search(query, { maxResults, timeRange, safeSearch });
+    const run = () =>
+      provider.search(query, { maxResults, timeRange, safeSearch });
     const limited = () => rateLimiter(providerName, run);
-    return simpleCache(`${providerName}:${query}:${maxResults}:${timeRange}:${safeSearch}`, limited);
+    return simpleCache(
+      `${providerName}:${query}:${maxResults}:${timeRange}:${safeSearch}`,
+      limited,
+    );
   }
 
-  async performSearchWithContentExtraction(provider, query, maxResults, timeRange, safeSearch, extractContent = true) {
-    const results = await this.performSearch(provider, query, maxResults, timeRange, safeSearch);
+  async performSearchWithContentExtraction(
+    provider,
+    query,
+    maxResults,
+    timeRange,
+    safeSearch,
+    extractContent = true,
+  ) {
+    const results = await this.performSearch(
+      provider,
+      query,
+      maxResults,
+      timeRange,
+      safeSearch,
+    );
     if (!extractContent) return results;
     const readabilityService = new ReadabilityService();
     const enriched = [];
@@ -34,13 +51,13 @@ export class SearchService {
         enriched.push({
           ...r,
           content,
-          contentExtracted: true
+          contentExtracted: true,
         });
       } catch (e) {
         enriched.push({
           ...r,
           contentExtracted: false,
-          contentExtractionError: e?.message || 'Content extraction failed'
+          contentExtractionError: e?.message || "Content extraction failed",
         });
       }
     }

--- a/src/specs/NativeLLM.ts
+++ b/src/specs/NativeLLM.ts
@@ -1,9 +1,21 @@
-import type {TurboModule} from 'react-native';
-import {TurboModuleRegistry} from 'react-native';
+import type { TurboModule } from "react-native";
+import { TurboModuleRegistry } from "react-native";
 
-export interface GenerateOptions { maxTokens?: number; temperature?: number; topK?: number; topP?: number; stop?: string[] | null; }
-export interface LoadOptions { quantization?: string | null; contextLength?: number | null; }
-export interface PerfMetrics { memoryUsage?: number; cpuUsage?: number; }
+export interface GenerateOptions {
+  maxTokens?: number;
+  temperature?: number;
+  topK?: number;
+  topP?: number;
+  stop?: string[] | null;
+}
+export interface LoadOptions {
+  quantization?: string | null;
+  contextLength?: number | null;
+}
+export interface PerfMetrics {
+  memoryUsage?: number;
+  cpuUsage?: number;
+}
 
 export interface Spec extends TurboModule {
   loadModel(_path: string, _options?: LoadOptions | null): Promise<boolean>;
@@ -21,11 +33,10 @@ export interface Spec extends TurboModule {
 // Probe for codegen so the spec is marked as used.
 try {
   // IMPORTANT: codegen looks specifically for `get<Spec>('Name')` calls.
-  TurboModuleRegistry.get<Spec>('LLM');
+  TurboModuleRegistry.get<Spec>("LLM");
 } catch {
   // Ignore missing native module during runtime.
 }
 
 // Expose the TurboModule; returns `null` when the native implementation is missing.
-export default TurboModuleRegistry.getOptional<Spec>('LLM');
-
+export default TurboModuleRegistry.getOptional<Spec>("LLM");

--- a/src/specs/registerTurboModules.ts
+++ b/src/specs/registerTurboModules.ts
@@ -1,1 +1,1 @@
-import '../registerTurboModules';
+import "../registerTurboModules";

--- a/src/tools/androidTools.js
+++ b/src/tools/androidTools.js
@@ -1,15 +1,15 @@
-export const unsupported = name => ({
+export const unsupported = (name) => ({
   name,
   execute: async () => {
     throw new Error(`${name} is unsupported on Android`);
   },
 });
 
-export const getBatteryInfoTool = unsupported('get_battery_info');
-export const getCurrentLocationTool = unsupported('get_current_location');
-export const createCalendarEventTool = unsupported('create_calendar_event');
-export const showMapTool = unsupported('show_map');
-export const setClipboardTool = unsupported('set_clipboard');
-export const getClipboardTool = unsupported('get_clipboard');
-export const openRecentFileTool = unsupported('open_recent_file');
-export const openSettingsTool = unsupported('open_settings');
+export const getBatteryInfoTool = unsupported("get_battery_info");
+export const getCurrentLocationTool = unsupported("get_current_location");
+export const createCalendarEventTool = unsupported("create_calendar_event");
+export const showMapTool = unsupported("show_map");
+export const setClipboardTool = unsupported("set_clipboard");
+export const getClipboardTool = unsupported("get_clipboard");
+export const openRecentFileTool = unsupported("open_recent_file");
+export const openSettingsTool = unsupported("open_settings");

--- a/src/tools/iosTools.js
+++ b/src/tools/iosTools.js
@@ -1,4 +1,4 @@
-import { NativeModules, Linking, Vibration, Clipboard } from 'react-native';
+import { NativeModules, Linking, Vibration, Clipboard } from "react-native";
 
 const {
   CalendarTurboModule,
@@ -15,317 +15,388 @@ const {
   SensorsTurboModule,
   FlashlightTurboModule,
   DeviceInfoTurboModule,
-  BrightnessTurboModule
+  BrightnessTurboModule,
 } = NativeModules;
 
 // Calendar
 export const createCalendarEventTool = {
-  name: 'create_calendar_event',
-  description: 'Create a new calendar event with title, date, location, notes',
+  name: "create_calendar_event",
+  description: "Create a new calendar event with title, date, location, notes",
   parameters: {
-    title: { type: 'string', required: true },
-    startDate: { type: 'string', required: true, description: 'ISO 8601 format' },
-    endDate: { type: 'string', required: false, description: 'ISO 8601 format' },
-    location: { type: 'string', required: false },
-    notes: { type: 'string', required: false }
+    title: { type: "string", required: true },
+    startDate: {
+      type: "string",
+      required: true,
+      description: "ISO 8601 format",
+    },
+    endDate: {
+      type: "string",
+      required: false,
+      description: "ISO 8601 format",
+    },
+    location: { type: "string", required: false },
+    notes: { type: "string", required: false },
   },
-  execute: async params => {
+  execute: async (params) => {
     const endDate =
-      params.endDate || new Date(new Date(params.startDate).getTime() + 3600000).toISOString();
+      params.endDate ||
+      new Date(new Date(params.startDate).getTime() + 3600000).toISOString();
     return await CalendarTurboModule.createEvent(
       params.title,
       params.startDate,
       endDate,
       params.location,
-      params.notes
+      params.notes,
     );
-  }
+  },
 };
 
 // Messages
 export const sendMessageTool = {
-  name: 'send_message',
-  description: 'Compose and send SMS/iMessage (user confirmation required)',
+  name: "send_message",
+  description: "Compose and send SMS/iMessage (user confirmation required)",
   parameters: {
-    recipient: { type: 'string', required: true, description: 'Phone number or email' },
-    body: { type: 'string', required: true }
+    recipient: {
+      type: "string",
+      required: true,
+      description: "Phone number or email",
+    },
+    body: { type: "string", required: true },
   },
-  execute: async params =>
-    await MessagesTurboModule.sendMessage(params.recipient, params.body)
+  execute: async (params) =>
+    await MessagesTurboModule.sendMessage(params.recipient, params.body),
 };
 
 // Phone calls
 export const makePhoneCallTool = {
-  name: 'make_phone_call',
-  description: 'Initiate a phone call (user confirmation required)',
+  name: "make_phone_call",
+  description: "Initiate a phone call (user confirmation required)",
   parameters: {
-    phoneNumber: { type: 'string', required: true }
+    phoneNumber: { type: "string", required: true },
   },
-  execute: async params => {
+  execute: async (params) => {
     const url = `tel:${params.phoneNumber}`;
     if (await Linking.canOpenURL(url)) {
       await Linking.openURL(url);
       return { success: true };
     }
-    throw new Error('Cannot make call');
-  }
+    throw new Error("Cannot make call");
+  },
 };
 
 export const getCallHistoryTool = {
-  name: 'get_call_history',
-  description: 'Get recent call history (limited access)',
+  name: "get_call_history",
+  description: "Get recent call history (limited access)",
   parameters: {
-    limit: { type: 'number', required: false, default: 10 }
+    limit: { type: "number", required: false, default: 10 },
   },
-  execute: async params => await CallTurboModule.getRecentCalls(params.limit || 10)
+  execute: async (params) =>
+    await CallTurboModule.getRecentCalls(params.limit || 10),
 };
 
 // Location
 export const getCurrentLocationTool = {
-  name: 'get_current_location',
-  description: 'Get current GPS location',
+  name: "get_current_location",
+  description: "Get current GPS location",
   parameters: {
-    accuracy: { type: 'string', required: false, default: 'high', enum: ['low', 'medium', 'high'] }
+    accuracy: {
+      type: "string",
+      required: false,
+      default: "high",
+      enum: ["low", "medium", "high"],
+    },
   },
-  execute: async params => await LocationTurboModule.getCurrentLocation(params.accuracy || 'high')
+  execute: async (params) =>
+    await LocationTurboModule.getCurrentLocation(params.accuracy || "high"),
 };
 
 export const startLocationUpdatesTool = {
-  name: 'start_location_updates',
-  description: 'Start continuous location updates',
+  name: "start_location_updates",
+  description: "Start continuous location updates",
   parameters: {
-    interval: { type: 'number', required: false, default: 10000 }
+    interval: { type: "number", required: false, default: 10000 },
   },
-  execute: async params => await LocationTurboModule.startUpdates(params.interval || 10000)
+  execute: async (params) =>
+    await LocationTurboModule.startUpdates(params.interval || 10000),
 };
 
 export const stopLocationUpdatesTool = {
-  name: 'stop_location_updates',
-  description: 'Stop location updates',
+  name: "stop_location_updates",
+  description: "Stop location updates",
   parameters: {},
-  execute: async () => await LocationTurboModule.stopUpdates()
+  execute: async () => await LocationTurboModule.stopUpdates(),
 };
 
 // Maps
 export const showMapTool = {
-  name: 'show_map',
-  description: 'Display map at location',
+  name: "show_map",
+  description: "Display map at location",
   parameters: {
-    latitude: { type: 'number', required: true },
-    longitude: { type: 'number', required: true },
-    title: { type: 'string', required: false }
+    latitude: { type: "number", required: true },
+    longitude: { type: "number", required: true },
+    title: { type: "string", required: false },
   },
-  execute: async params =>
-    await MapsTurboModule.showMap(params.latitude, params.longitude, params.title)
+  execute: async (params) =>
+    await MapsTurboModule.showMap(
+      params.latitude,
+      params.longitude,
+      params.title,
+    ),
 };
 
 export const getDirectionsTool = {
-  name: 'get_directions',
-  description: 'Get directions between points',
+  name: "get_directions",
+  description: "Get directions between points",
   parameters: {
-    from: { type: 'string', required: true, description: 'Address or lat,long' },
-    to: { type: 'string', required: true, description: 'Address or lat,long' },
-    mode: { type: 'string', required: false, default: 'driving', enum: ['driving', 'walking', 'transit'] }
+    from: {
+      type: "string",
+      required: true,
+      description: "Address or lat,long",
+    },
+    to: { type: "string", required: true, description: "Address or lat,long" },
+    mode: {
+      type: "string",
+      required: false,
+      default: "driving",
+      enum: ["driving", "walking", "transit"],
+    },
   },
-  execute: async params =>
-    await MapsTurboModule.getDirections(params.from, params.to, params.mode || 'driving')
+  execute: async (params) =>
+    await MapsTurboModule.getDirections(
+      params.from,
+      params.to,
+      params.mode || "driving",
+    ),
 };
 
 export const searchPlacesTool = {
-  name: 'search_places',
-  description: 'Search for places on map',
+  name: "search_places",
+  description: "Search for places on map",
   parameters: {
-    query: { type: 'string', required: true },
-    near: { type: 'string', required: false, description: 'lat,long or address' }
+    query: { type: "string", required: true },
+    near: {
+      type: "string",
+      required: false,
+      description: "lat,long or address",
+    },
   },
-  execute: async params => await MapsTurboModule.searchPlaces(params.query, params.near)
+  execute: async (params) =>
+    await MapsTurboModule.searchPlaces(params.query, params.near),
 };
 
 // Contacts
 export const findContactTool = {
-  name: 'find_contact',
-  description: 'Find contact by name or number',
+  name: "find_contact",
+  description: "Find contact by name or number",
   parameters: {
-    query: { type: 'string', required: true }
+    query: { type: "string", required: true },
   },
-  execute: async params => await ContactsTurboModule.findContact(params.query)
+  execute: async (params) =>
+    await ContactsTurboModule.findContact(params.query),
 };
 
 export const addContactTool = {
-  name: 'add_contact',
-  description: 'Add new contact',
+  name: "add_contact",
+  description: "Add new contact",
   parameters: {
-    name: { type: 'string', required: true },
-    phone: { type: 'string', required: false },
-    email: { type: 'string', required: false }
+    name: { type: "string", required: true },
+    phone: { type: "string", required: false },
+    email: { type: "string", required: false },
   },
-  execute: async params => await ContactsTurboModule.addContact(params.name, params.phone, params.email)
+  execute: async (params) =>
+    await ContactsTurboModule.addContact(
+      params.name,
+      params.phone,
+      params.email,
+    ),
 };
 
 // Music
 export const playMusicTool = {
-  name: 'play_music',
-  description: 'Play music from library',
+  name: "play_music",
+  description: "Play music from library",
   parameters: {
-    query: { type: 'string', required: true, description: 'Song, artist, or playlist' }
+    query: {
+      type: "string",
+      required: true,
+      description: "Song, artist, or playlist",
+    },
   },
-  execute: async params => await MusicTurboModule.playMusic(params.query)
+  execute: async (params) => await MusicTurboModule.playMusic(params.query),
 };
 
 export const getMusicLibraryTool = {
-  name: 'get_music_library',
-  description: 'Search music library',
+  name: "get_music_library",
+  description: "Search music library",
   parameters: {
-    query: { type: 'string', required: true },
-    type: { type: 'string', required: false, default: 'songs', enum: ['songs', 'artists', 'playlists'] }
+    query: { type: "string", required: true },
+    type: {
+      type: "string",
+      required: false,
+      default: "songs",
+      enum: ["songs", "artists", "playlists"],
+    },
   },
-  execute: async params => await MusicTurboModule.searchLibrary(params.query, params.type || 'songs')
+  execute: async (params) =>
+    await MusicTurboModule.searchLibrary(params.query, params.type || "songs"),
 };
 
 // Battery
 export const getBatteryInfoTool = {
-  name: 'get_battery_info',
-  description: 'Get battery level and state',
+  name: "get_battery_info",
+  description: "Get battery level and state",
   parameters: {},
-  execute: async () => await BatteryTurboModule.getBatteryInfo()
+  execute: async () => await BatteryTurboModule.getBatteryInfo(),
 };
 
 // Sensors
 export const getSensorDataTool = {
-  name: 'get_sensor_data',
-  description: 'Get accelerometer/gyro/magnetometer data',
+  name: "get_sensor_data",
+  description: "Get accelerometer/gyro/magnetometer data",
   parameters: {
-    type: { type: 'string', required: true, enum: ['accelerometer', 'gyroscope', 'magnetometer'] },
-    duration: { type: 'number', required: false, default: 1000 }
+    type: {
+      type: "string",
+      required: true,
+      enum: ["accelerometer", "gyroscope", "magnetometer"],
+    },
+    duration: { type: "number", required: false, default: 1000 },
   },
-  execute: async params =>
-    await SensorsTurboModule.getSensorData(params.type, params.duration || 1000)
+  execute: async (params) =>
+    await SensorsTurboModule.getSensorData(
+      params.type,
+      params.duration || 1000,
+    ),
 };
 
 // Clipboard
 export const setClipboardTool = {
-  name: 'set_clipboard',
-  description: 'Set text to clipboard',
+  name: "set_clipboard",
+  description: "Set text to clipboard",
   parameters: {
-    text: { type: 'string', required: true }
+    text: { type: "string", required: true },
   },
-  execute: async params => {
+  execute: async (params) => {
     Clipboard.setString(params.text);
     return { success: true };
-  }
+  },
 };
 
 export const getClipboardTool = {
-  name: 'get_clipboard',
-  description: 'Get text from clipboard',
+  name: "get_clipboard",
+  description: "Get text from clipboard",
   parameters: {},
-  execute: async () => ({ text: await Clipboard.getString() })
+  execute: async () => ({ text: await Clipboard.getString() }),
 };
 
 // Vibration
 export const vibrateTool = {
-  name: 'vibrate',
-  description: 'Vibrate device',
+  name: "vibrate",
+  description: "Vibrate device",
   parameters: {
-    pattern: { type: 'array', required: false, default: [1000] }
+    pattern: { type: "array", required: false, default: [1000] },
   },
-  execute: async params => {
+  execute: async (params) => {
     Vibration.vibrate(params.pattern || [1000]);
     return { success: true };
-  }
+  },
 };
 
 // Flashlight
 export const toggleFlashlightTool = {
-  name: 'toggle_flashlight',
-  description: 'Toggle flashlight on/off',
+  name: "toggle_flashlight",
+  description: "Toggle flashlight on/off",
   parameters: {
-    on: { type: 'boolean', required: true }
+    on: { type: "boolean", required: true },
   },
-  execute: async params => await FlashlightTurboModule.setTorchMode(params.on)
+  execute: async (params) =>
+    await FlashlightTurboModule.setTorchMode(params.on),
 };
 
 // Device info
 export const getDeviceInfoTool = {
-  name: 'get_device_info',
-  description: 'Get device information',
+  name: "get_device_info",
+  description: "Get device information",
   parameters: {},
-  execute: async () => await DeviceInfoTurboModule.getDeviceInfo()
+  execute: async () => await DeviceInfoTurboModule.getDeviceInfo(),
 };
 
 // Brightness
 export const setBrightnessTool = {
-  name: 'set_brightness',
-  description: 'Set screen brightness (0-1)',
+  name: "set_brightness",
+  description: "Set screen brightness (0-1)",
   parameters: {
-    level: { type: 'number', required: true }
+    level: { type: "number", required: true },
   },
-  execute: async params => await BrightnessTurboModule.setBrightness(params.level)
+  execute: async (params) =>
+    await BrightnessTurboModule.setBrightness(params.level),
 };
 
 // Photos
 export const pickPhotoTool = {
-  name: 'pick_photo',
-  description: 'Pick photo from library',
+  name: "pick_photo",
+  description: "Pick photo from library",
   parameters: {},
-  execute: async () => await PhotosTurboModule.pickPhoto()
+  execute: async () => await PhotosTurboModule.pickPhoto(),
 };
 
 export const takePhotoTool = {
-  name: 'take_photo',
-  description: 'Take photo with camera',
+  name: "take_photo",
+  description: "Take photo with camera",
   parameters: {
-    quality: { type: 'number', required: false, default: 0.8 }
+    quality: { type: "number", required: false, default: 0.8 },
   },
-  execute: async params => await CameraTurboModule.takePhoto(params.quality || 0.8)
+  execute: async (params) =>
+    await CameraTurboModule.takePhoto(params.quality || 0.8),
 };
 
 // Files
 export const pickFileTool = {
-  name: 'pick_file',
-  description: 'Pick file from device',
+  name: "pick_file",
+  description: "Pick file from device",
   parameters: {
-    type: { type: 'string', required: false, default: 'any' }
+    type: { type: "string", required: false, default: "any" },
   },
-  execute: async params => await FilesTurboModule.pickFile(params.type || 'any')
+  execute: async (params) =>
+    await FilesTurboModule.pickFile(params.type || "any"),
 };
 
 export const openRecentFileTool = {
-  name: 'open_recent_file',
-  description: 'Open the most recently used file',
+  name: "open_recent_file",
+  description: "Open the most recently used file",
   parameters: {},
-  execute: async () => await FilesTurboModule.openRecent()
+  execute: async () => await FilesTurboModule.openRecent(),
 };
 
 // URL
 export const openUrlTool = {
-  name: 'open_url',
-  description: 'Open URL in default browser',
+  name: "open_url",
+  description: "Open URL in default browser",
   parameters: {
-    url: { type: 'string', required: true }
+    url: { type: "string", required: true },
   },
-  execute: async params => {
+  execute: async (params) => {
     if (await Linking.canOpenURL(params.url)) {
       await Linking.openURL(params.url);
       return { success: true };
     }
-    throw new Error('Cannot open URL');
-  }
+    throw new Error("Cannot open URL");
+  },
 };
 
 export const openSettingsTool = {
-  name: 'open_settings',
-  description: 'Open device settings',
+  name: "open_settings",
+  description: "Open device settings",
   parameters: {
-    section: { type: 'string', required: false }
+    section: { type: "string", required: false },
   },
-  execute: async params => {
-    const url = params.section ? `app-settings:${params.section}` : 'app-settings:';
+  execute: async (params) => {
+    const url = params.section
+      ? `app-settings:${params.section}`
+      : "app-settings:";
     if (await Linking.canOpenURL(url)) {
       await Linking.openURL(url);
       return { success: true };
     }
-    throw new Error('Cannot open settings');
-  }
+    throw new Error("Cannot open settings");
+  },
 };
-

--- a/src/tools/webSearchTool.js
+++ b/src/tools/webSearchTool.js
@@ -64,7 +64,7 @@ export const webSearchTool = {
         maxResults,
         timeRange,
         safeSearch,
-        extractContent
+        extractContent,
       );
 
       return {

--- a/src/utils/deviceUtils.js
+++ b/src/utils/deviceUtils.js
@@ -12,13 +12,13 @@ export function getDeviceProfile() {
 
       if (!totalMemory) {
         console.warn(
-          "[DeviceProfile] getTotalMemory unavailable, using fallback value 4000MB"
+          "[DeviceProfile] getTotalMemory unavailable, using fallback value 4000MB",
         );
         totalMemory = 4000;
       }
       if (!processorCores) {
         console.warn(
-          "[DeviceProfile] getProcessorCount unavailable, using fallback value 4 cores"
+          "[DeviceProfile] getProcessorCount unavailable, using fallback value 4 cores",
         );
         processorCores = 4;
       }
@@ -28,13 +28,13 @@ export function getDeviceProfile() {
 
       if (!totalMemory) {
         console.warn(
-          "[DeviceProfile] totalMemory unavailable, using fallback value 4000MB"
+          "[DeviceProfile] totalMemory unavailable, using fallback value 4000MB",
         );
         totalMemory = 4000;
       }
       if (!processorCores) {
         console.warn(
-          "[DeviceProfile] processorCores unavailable, using fallback value 4 cores"
+          "[DeviceProfile] processorCores unavailable, using fallback value 4 cores",
         );
         processorCores = 4;
       }
@@ -77,7 +77,7 @@ export function getDeviceProfile() {
 export function getPerformanceMode(
   deviceProfile,
   batteryLevel = 1.0,
-  thermalState = "nominal"
+  thermalState = "nominal",
 ) {
   const { tier, isLowEndDevice } = deviceProfile;
 

--- a/src/utils/hnswVectorStore.js
+++ b/src/utils/hnswVectorStore.js
@@ -1,54 +1,54 @@
-import SQLite from 'react-native-sqlite-storage';
-import { cosineSimilarity, quantizeVector } from './vectorUtils';
+import SQLite from "react-native-sqlite-storage";
+import { cosineSimilarity, quantizeVector } from "./vectorUtils";
 
 const HNSW_DEFAULTS = {
-    m: 16,
-    efConstruction: 100,
-    efSearch: 50,
-    maxLayer: null,
-    quantization: 'scalar'
+  m: 16,
+  efConstruction: 100,
+  efSearch: 50,
+  maxLayer: null,
+  quantization: "scalar",
 };
 
 export class HNSWVectorStore {
-    constructor() {
-        this.db = null;
-        this.initialized = false;
-        this.index = {
-            layers: [],
-            entryPoint: null,
-            maxLayer: 0
-        };
-        this.config = { ...HNSW_DEFAULTS };
-        this.nodeMap = new Map();
-    }
+  constructor() {
+    this.db = null;
+    this.initialized = false;
+    this.index = {
+      layers: [],
+      entryPoint: null,
+      maxLayer: 0,
+    };
+    this.config = { ...HNSW_DEFAULTS };
+    this.nodeMap = new Map();
+  }
 
-    async initialize(config = {}) {
-        if (this.initialized) return;
-        
-        this.config = { ...this.config, ...config };
-        
-        try {
-            this.db = await SQLite.openDatabase({
-                name: 'hnsw_vectorstore.db',
-                location: 'default',
-                createFromLocation: 1
-            });
-            
-            await this.db.executeSql('PRAGMA foreign_keys = ON;');
-            
-            await this._createTables();
-            await this._loadIndex();
-            
-            this.initialized = true;
-            console.log('HNSW Vector Store initialized');
-        } catch (error) {
-            console.error('Failed to initialize HNSW Vector Store:', error);
-            throw error;
-        }
-    }
+  async initialize(config = {}) {
+    if (this.initialized) return;
 
-    async _createTables() {
-        await this.db.executeSql(`
+    this.config = { ...this.config, ...config };
+
+    try {
+      this.db = await SQLite.openDatabase({
+        name: "hnsw_vectorstore.db",
+        location: "default",
+        createFromLocation: 1,
+      });
+
+      await this.db.executeSql("PRAGMA foreign_keys = ON;");
+
+      await this._createTables();
+      await this._loadIndex();
+
+      this.initialized = true;
+      console.log("HNSW Vector Store initialized");
+    } catch (error) {
+      console.error("Failed to initialize HNSW Vector Store:", error);
+      throw error;
+    }
+  }
+
+  async _createTables() {
+    await this.db.executeSql(`
             CREATE TABLE IF NOT EXISTS vectors (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 content TEXT NOT NULL,
@@ -56,8 +56,8 @@ export class HNSWVectorStore {
                 created_at DATETIME DEFAULT CURRENT_TIMESTAMP
             )
         `);
-        
-        await this.db.executeSql(`
+
+    await this.db.executeSql(`
             CREATE TABLE IF NOT EXISTS vector_data (
                 id INTEGER PRIMARY KEY,
                 vector BLOB NOT NULL,
@@ -65,8 +65,8 @@ export class HNSWVectorStore {
                 FOREIGN KEY (id) REFERENCES vectors (id) ON DELETE CASCADE
             )
         `);
-        
-        await this.db.executeSql(`
+
+    await this.db.executeSql(`
             CREATE TABLE IF NOT EXISTS hnsw_layers (
                 layer INTEGER NOT NULL,
                 node_id INTEGER NOT NULL,
@@ -74,471 +74,489 @@ export class HNSWVectorStore {
                 PRIMARY KEY (layer, node_id)
             )
         `);
-        
-        await this.db.executeSql(`
+
+    await this.db.executeSql(`
             CREATE TABLE IF NOT EXISTS hnsw_config (
                 key TEXT PRIMARY KEY,
                 value TEXT NOT NULL
             )
         `);
-        
-        await this.db.executeSql(`
+
+    await this.db.executeSql(`
             CREATE INDEX IF NOT EXISTS idx_hnsw_layers_node 
             ON hnsw_layers (node_id)
         `);
-    }
+  }
 
-    async _loadIndex() {
-        const [configResults] = await this.db.executeSql(
-            'SELECT * FROM hnsw_config'
-        );
-        
-        const configRows = configResults.rows.raw();
-        configRows.forEach(row => {
-            if (row.key === 'entryPoint') {
-                this.index.entryPoint = parseInt(row.value);
-            } else if (row.key === 'maxLayer') {
-                this.index.maxLayer = parseInt(row.value);
-                this.config.maxLayer = this.index.maxLayer;
-            } else {
-                this.config[row.key] = JSON.parse(row.value);
-            }
-        });
-        
-        this.index.layers = new Array(this.index.maxLayer + 1).fill().map(() => new Map());
-        
-        const [layerResults] = await this.db.executeSql(
-            'SELECT * FROM hnsw_layers ORDER BY layer'
-        );
-        
-        layerResults.rows.raw().forEach(row => {
-            const layer = parseInt(row.layer);
-            const node_id = parseInt(row.node_id);
-            const connections = JSON.parse(row.connections);
-            
-            if (!this.index.layers[layer]) {
-                this.index.layers[layer] = new Map();
-            }
-            
-            this.index.layers[layer].set(node_id, connections);
-        });
-        
-        if (this.nodeMap.size === 0) {
-            await this._loadNodeMap();
-        }
-    }
+  async _loadIndex() {
+    const [configResults] = await this.db.executeSql(
+      "SELECT * FROM hnsw_config",
+    );
 
-    async _loadNodeMap() {
-        const [vectorResults] = await this.db.executeSql(`
+    const configRows = configResults.rows.raw();
+    configRows.forEach((row) => {
+      if (row.key === "entryPoint") {
+        this.index.entryPoint = parseInt(row.value);
+      } else if (row.key === "maxLayer") {
+        this.index.maxLayer = parseInt(row.value);
+        this.config.maxLayer = this.index.maxLayer;
+      } else {
+        this.config[row.key] = JSON.parse(row.value);
+      }
+    });
+
+    this.index.layers = new Array(this.index.maxLayer + 1)
+      .fill()
+      .map(() => new Map());
+
+    const [layerResults] = await this.db.executeSql(
+      "SELECT * FROM hnsw_layers ORDER BY layer",
+    );
+
+    layerResults.rows.raw().forEach((row) => {
+      const layer = parseInt(row.layer);
+      const node_id = parseInt(row.node_id);
+      const connections = JSON.parse(row.connections);
+
+      if (!this.index.layers[layer]) {
+        this.index.layers[layer] = new Map();
+      }
+
+      this.index.layers[layer].set(node_id, connections);
+    });
+
+    if (this.nodeMap.size === 0) {
+      await this._loadNodeMap();
+    }
+  }
+
+  async _loadNodeMap() {
+    const [vectorResults] = await this.db.executeSql(`
             SELECT v.id, v.content, v.metadata, vd.vector 
             FROM vectors v 
             JOIN vector_data vd ON v.id = vd.id
         `);
-        
-        vectorResults.rows.raw().forEach(row => {
-            const blob = new Uint8Array(row.vector);
-            const vector = new Float32Array(blob.buffer);
-            this.nodeMap.set(row.id, {
-                content: row.content,
-                metadata: JSON.parse(row.metadata || '{}'),
-                vector: Array.from(vector)
-            });
-        });
+
+    vectorResults.rows.raw().forEach((row) => {
+      const blob = new Uint8Array(row.vector);
+      const vector = new Float32Array(blob.buffer);
+      this.nodeMap.set(row.id, {
+        content: row.content,
+        metadata: JSON.parse(row.metadata || "{}"),
+        vector: Array.from(vector),
+      });
+    });
+  }
+
+  async addVector(content, vector, metadata = {}) {
+    if (!this.initialized) await this.initialize();
+
+    try {
+      const [result] = await this.db.executeSql(
+        "INSERT INTO vectors (content, metadata) VALUES (?, ?)",
+        [content, JSON.stringify(metadata)],
+      );
+      const id = result.insertId;
+
+      const quantizedVector = this._quantizeVector(vector);
+
+      const buffer = new ArrayBuffer(vector.length * 4);
+      const view = new Float32Array(buffer);
+      vector.forEach((v, i) => (view[i] = v));
+
+      let quantizedBlob = null;
+      if (quantizedVector) {
+        const quantizedBuffer = new ArrayBuffer(quantizedVector.length);
+        const quantizedView = new Uint8Array(quantizedBuffer);
+        quantizedVector.forEach((v, i) => (quantizedView[i] = v));
+        quantizedBlob = quantizedView;
+      }
+
+      await this.db.executeSql(
+        "INSERT INTO vector_data (id, vector, quantized) VALUES (?, ?, ?)",
+        [id, new Uint8Array(buffer), quantizedBlob],
+      );
+
+      await this._addToIndex(id, vector);
+
+      return id;
+    } catch (error) {
+      console.error("Failed to add vector to HNSW:", error);
+      throw error;
+    }
+  }
+
+  _quantizeVector(vector) {
+    if (this.config.quantization === "none") return null;
+
+    if (this.config.quantization === "scalar") {
+      return quantizeVector(vector);
     }
 
-    async addVector(content, vector, metadata = {}) {
-        if (!this.initialized) await this.initialize();
-        
-        try {
-            const [result] = await this.db.executeSql(
-                'INSERT INTO vectors (content, metadata) VALUES (?, ?)',
-                [content, JSON.stringify(metadata)]
-            );
-            const id = result.insertId;
-            
-            const quantizedVector = this._quantizeVector(vector);
-            
-            const buffer = new ArrayBuffer(vector.length * 4);
-            const view = new Float32Array(buffer);
-            vector.forEach((v, i) => view[i] = v);
-            
-            let quantizedBlob = null;
-            if (quantizedVector) {
-                const quantizedBuffer = new ArrayBuffer(quantizedVector.length);
-                const quantizedView = new Uint8Array(quantizedBuffer);
-                quantizedVector.forEach((v, i) => quantizedView[i] = v);
-                quantizedBlob = quantizedView;
+    return null;
+  }
+
+  async _addToIndex(id, vector) {
+    const layer = this._getRandomLayer();
+
+    if (this.index.entryPoint === null) {
+      this.index.entryPoint = id;
+      this.index.maxLayer = layer;
+      this.config.maxLayer = this.index.maxLayer;
+
+      await this._saveConfig();
+      return;
+    }
+
+    let currNode = this.index.entryPoint;
+    let currLayer = Math.min(this.index.maxLayer, layer);
+
+    while (currLayer > layer) {
+      currNode = await this._searchLayer(vector, currNode, currLayer, 1);
+      currLayer--;
+    }
+
+    for (let l = Math.min(layer, this.index.maxLayer); l >= 0; l--) {
+      const neighbors = await this._searchLayer(
+        vector,
+        currNode,
+        l,
+        this.config.efConstruction,
+      );
+      await this._insertNodeAtLayer(id, vector, l, neighbors);
+
+      if (l === this.index.maxLayer && neighbors.length > 0) {
+        this.index.maxLayer = l + 1;
+        this.config.maxLayer = this.index.maxLayer;
+        await this._saveConfig();
+      }
+    }
+  }
+
+  _getRandomLayer() {
+    return Math.min(
+      Math.floor(-Math.log(Math.random()) * Math.log(this.config.m)),
+      this.config.maxLayer || 16,
+    );
+  }
+
+  async _searchLayer(queryVector, enterPoint, layer, ef) {
+    const visited = new Set();
+    const candidates = new PriorityQueue(
+      (a, b) =>
+        cosineSimilarity(queryVector, this.nodeMap.get(a).vector) >
+        cosineSimilarity(queryVector, this.nodeMap.get(b).vector),
+    );
+    const results = new PriorityQueue(
+      (a, b) =>
+        cosineSimilarity(queryVector, this.nodeMap.get(a).vector) >
+        cosineSimilarity(queryVector, this.nodeMap.get(b).vector),
+    );
+
+    visited.add(enterPoint);
+    candidates.add(enterPoint);
+    results.add(enterPoint);
+
+    while (candidates.size() > 0) {
+      const current = candidates.poll();
+      const currentVector = this.nodeMap.get(current).vector;
+      const currentSimilarity = cosineSimilarity(queryVector, currentVector);
+
+      if (results.size() >= ef && currentSimilarity < results.peekPriority()) {
+        break;
+      }
+
+      const connections = this.index.layers[layer].get(current) || [];
+
+      for (const neighborId of connections) {
+        if (!visited.has(neighborId)) {
+          visited.add(neighborId);
+          const neighborVector = this.nodeMap.get(neighborId).vector;
+          const neighborSimilarity = cosineSimilarity(
+            queryVector,
+            neighborVector,
+          );
+
+          candidates.add(neighborId, neighborSimilarity);
+
+          if (
+            results.size() < ef ||
+            neighborSimilarity > results.peekPriority()
+          ) {
+            results.add(neighborId, neighborSimilarity);
+            if (results.size() > ef) {
+              results.poll();
             }
-            
-            await this.db.executeSql(
-                'INSERT INTO vector_data (id, vector, quantized) VALUES (?, ?, ?)',
-                [id, new Uint8Array(buffer), quantizedBlob]
-            );
-            
-            await this._addToIndex(id, vector);
-            
-            return id;
-        } catch (error) {
-            console.error('Failed to add vector to HNSW:', error);
-            throw error;
+          }
         }
+      }
     }
 
-    _quantizeVector(vector) {
-        if (this.config.quantization === 'none') return null;
-        
-        if (this.config.quantization === 'scalar') {
-            return quantizeVector(vector);
-        }
-        
-        return null;
+    return results.toArray().map((item) => item.value);
+  }
+
+  async _insertNodeAtLayer(nodeId, vector, layer, neighbors) {
+    if (!this.index.layers[layer]) {
+      this.index.layers[layer] = new Map();
     }
 
-    async _addToIndex(id, vector) {
-        const layer = this._getRandomLayer();
-        
-        if (this.index.entryPoint === null) {
-            this.index.entryPoint = id;
-            this.index.maxLayer = layer;
-            this.config.maxLayer = this.index.maxLayer;
-            
-            await this._saveConfig();
-            return;
-        }
-        
-        let currNode = this.index.entryPoint;
-        let currLayer = Math.min(this.index.maxLayer, layer);
-        
-        while (currLayer > layer) {
-            currNode = await this._searchLayer(vector, currNode, currLayer, 1);
-            currLayer--;
-        }
-        
-        for (let l = Math.min(layer, this.index.maxLayer); l >= 0; l--) {
-            const neighbors = await this._searchLayer(vector, currNode, l, this.config.efConstruction);
-            await this._insertNodeAtLayer(id, vector, l, neighbors);
-            
-            if (l === this.index.maxLayer && neighbors.length > 0) {
-                this.index.maxLayer = l + 1;
-                this.config.maxLayer = this.index.maxLayer;
-                await this._saveConfig();
-            }
-        }
-    }
+    this.index.layers[layer].set(nodeId, [...neighbors]);
 
-    _getRandomLayer() {
-        return Math.min(
-            Math.floor(-Math.log(Math.random()) * Math.log(this.config.m)),
-            this.config.maxLayer || 16
+    for (const neighborId of neighbors) {
+      const neighborConnections =
+        this.index.layers[layer].get(neighborId) || [];
+      neighborConnections.push(nodeId);
+
+      if (neighborConnections.length > this.config.m) {
+        const trimmed = await this._searchLayer(
+          this.nodeMap.get(neighborId).vector,
+          neighborId,
+          layer,
+          this.config.m,
         );
+        this.index.layers[layer].set(neighborId, trimmed);
+      } else {
+        this.index.layers[layer].set(neighborId, neighborConnections);
+      }
     }
 
-    async _searchLayer(queryVector, enterPoint, layer, ef) {
-        const visited = new Set();
-        const candidates = new PriorityQueue((a, b) => 
-            cosineSimilarity(queryVector, this.nodeMap.get(a).vector) > 
-            cosineSimilarity(queryVector, this.nodeMap.get(b).vector)
-        );
-        const results = new PriorityQueue((a, b) => 
-            cosineSimilarity(queryVector, this.nodeMap.get(a).vector) > 
-            cosineSimilarity(queryVector, this.nodeMap.get(b).vector)
-        );
-        
-        visited.add(enterPoint);
-        candidates.add(enterPoint);
-        results.add(enterPoint);
-        
-        while (candidates.size() > 0) {
-            const current = candidates.poll();
-            const currentVector = this.nodeMap.get(current).vector;
-            const currentSimilarity = cosineSimilarity(queryVector, currentVector);
-            
-            if (results.size() >= ef && currentSimilarity < results.peekPriority()) {
-                break;
-            }
-            
-            const connections = this.index.layers[layer].get(current) || [];
-            
-            for (const neighborId of connections) {
-                if (!visited.has(neighborId)) {
-                    visited.add(neighborId);
-                    const neighborVector = this.nodeMap.get(neighborId).vector;
-                    const neighborSimilarity = cosineSimilarity(queryVector, neighborVector);
-                    
-                    candidates.add(neighborId, neighborSimilarity);
-                    
-                    if (results.size() < ef || neighborSimilarity > results.peekPriority()) {
-                        results.add(neighborId, neighborSimilarity);
-                        if (results.size() > ef) {
-                            results.poll();
-                        }
-                    }
-                }
-            }
-        }
-        
-        return results.toArray().map(item => item.value);
-    }
+    await this.db.executeSql(
+      "INSERT OR REPLACE INTO hnsw_layers (layer, node_id, connections) VALUES (?, ?, ?)",
+      [layer, nodeId, JSON.stringify(neighbors)],
+    );
+  }
 
-    async _insertNodeAtLayer(nodeId, vector, layer, neighbors) {
-        if (!this.index.layers[layer]) {
-            this.index.layers[layer] = new Map();
-        }
-        
-        this.index.layers[layer].set(nodeId, [...neighbors]);
-        
-        for (const neighborId of neighbors) {
-            const neighborConnections = this.index.layers[layer].get(neighborId) || [];
-            neighborConnections.push(nodeId);
-            
-            if (neighborConnections.length > this.config.m) {
-                const trimmed = await this._searchLayer(
-                    this.nodeMap.get(neighborId).vector,
-                    neighborId,
-                    layer,
-                    this.config.m
-                );
-                this.index.layers[layer].set(neighborId, trimmed);
-            } else {
-                this.index.layers[layer].set(neighborId, neighborConnections);
-            }
-        }
-        
-        await this.db.executeSql(
-            'INSERT OR REPLACE INTO hnsw_layers (layer, node_id, connections) VALUES (?, ?, ?)',
-            [layer, nodeId, JSON.stringify(neighbors)]
-        );
-    }
+  async searchVectors(queryVector, limit = 5) {
+    if (!this.initialized) await this.initialize();
 
-    async searchVectors(queryVector, limit = 5) {
-        if (!this.initialized) await this.initialize();
-        
-        try {
-            let currNode = this.index.entryPoint;
-            let currLayer = this.index.maxLayer;
-            
-            while (currLayer >= 0) {
-                currNode = await this._searchLayer(
-                    queryVector, 
-                    currNode, 
-                    currLayer, 
-                    this.config.efSearch
-                )[0] || currNode;
-                currLayer--;
-            }
-            
-            const results = await this._searchLayer(
-                queryVector, 
-                currNode, 
-                0, 
-                Math.max(this.config.efSearch, limit * 2)
-            );
-            
-            const detailedResults = [];
-            for (const id of results.slice(0, limit * 2)) {
-                const node = this.nodeMap.get(id);
-                if (node) {
-                    const similarity = cosineSimilarity(queryVector, node.vector);
-                    detailedResults.push({
-                        id,
-                        content: node.content,
-                        metadata: node.metadata,
-                        similarity
-                    });
-                }
-            }
-            
-            return detailedResults
-                .sort((a, b) => b.similarity - a.similarity)
-                .slice(0, limit);
-        } catch (error) {
-            console.error('HNSW search failed:', error);
-            return this._fallbackSearch(queryVector, limit);
-        }
-    }
+    try {
+      let currNode = this.index.entryPoint;
+      let currLayer = this.index.maxLayer;
 
-    async _fallbackSearch(queryVector, limit = 5) {
-        const [results] = await this.db.executeSql(`
+      while (currLayer >= 0) {
+        currNode =
+          (await this._searchLayer(
+            queryVector,
+            currNode,
+            currLayer,
+            this.config.efSearch,
+          )[0]) || currNode;
+        currLayer--;
+      }
+
+      const results = await this._searchLayer(
+        queryVector,
+        currNode,
+        0,
+        Math.max(this.config.efSearch, limit * 2),
+      );
+
+      const detailedResults = [];
+      for (const id of results.slice(0, limit * 2)) {
+        const node = this.nodeMap.get(id);
+        if (node) {
+          const similarity = cosineSimilarity(queryVector, node.vector);
+          detailedResults.push({
+            id,
+            content: node.content,
+            metadata: node.metadata,
+            similarity,
+          });
+        }
+      }
+
+      return detailedResults
+        .sort((a, b) => b.similarity - a.similarity)
+        .slice(0, limit);
+    } catch (error) {
+      console.error("HNSW search failed:", error);
+      return this._fallbackSearch(queryVector, limit);
+    }
+  }
+
+  async _fallbackSearch(queryVector, limit = 5) {
+    const [results] = await this.db.executeSql(`
             SELECT v.id, v.content, v.metadata, vd.vector 
             FROM vectors v 
             JOIN vector_data vd ON v.id = vd.id 
             ORDER BY v.created_at DESC 
             LIMIT 1000
         `);
-        
-        const rows = results.rows.raw();
-        const similarities = [];
-        
-        for (const row of rows) {
-            const blob = new Uint8Array(row.vector);
-            const storedVector = new Float32Array(blob.buffer);
-            const similarity = cosineSimilarity(
-                queryVector, 
-                Array.from(storedVector)
-            );
-            
-            similarities.push({
-                id: row.id,
-                content: row.content,
-                metadata: JSON.parse(row.metadata || '{}'),
-                similarity
-            });
-        }
-        
-        return similarities
-            .sort((a, b) => b.similarity - a.similarity)
-            .slice(0, limit);
+
+    const rows = results.rows.raw();
+    const similarities = [];
+
+    for (const row of rows) {
+      const blob = new Uint8Array(row.vector);
+      const storedVector = new Float32Array(blob.buffer);
+      const similarity = cosineSimilarity(
+        queryVector,
+        Array.from(storedVector),
+      );
+
+      similarities.push({
+        id: row.id,
+        content: row.content,
+        metadata: JSON.parse(row.metadata || "{}"),
+        similarity,
+      });
     }
 
-    async _saveConfig() {
-        const operations = [
-            this.db.executeSql(
-                'INSERT OR REPLACE INTO hnsw_config (key, value) VALUES (?, ?)',
-                ['entryPoint', this.index.entryPoint.toString()]
-            ),
-            this.db.executeSql(
-                'INSERT OR REPLACE INTO hnsw_config (key, value) VALUES (?, ?)',
-                ['maxLayer', this.index.maxLayer.toString()]
-            ),
-            this.db.executeSql(
-                'INSERT OR REPLACE INTO hnsw_config (key, value) VALUES (?, ?)',
-                ['m', JSON.stringify(this.config.m)]
-            ),
-            this.db.executeSql(
-                'INSERT OR REPLACE INTO hnsw_config (key, value) VALUES (?, ?)',
-                ['efConstruction', JSON.stringify(this.config.efConstruction)]
-            ),
-            this.db.executeSql(
-                'INSERT OR REPLACE INTO hnsw_config (key, value) VALUES (?, ?)',
-                ['efSearch', JSON.stringify(this.config.efSearch)]
-            )
-        ];
-        
-        await Promise.all(operations);
+    return similarities
+      .sort((a, b) => b.similarity - a.similarity)
+      .slice(0, limit);
+  }
+
+  async _saveConfig() {
+    const operations = [
+      this.db.executeSql(
+        "INSERT OR REPLACE INTO hnsw_config (key, value) VALUES (?, ?)",
+        ["entryPoint", this.index.entryPoint.toString()],
+      ),
+      this.db.executeSql(
+        "INSERT OR REPLACE INTO hnsw_config (key, value) VALUES (?, ?)",
+        ["maxLayer", this.index.maxLayer.toString()],
+      ),
+      this.db.executeSql(
+        "INSERT OR REPLACE INTO hnsw_config (key, value) VALUES (?, ?)",
+        ["m", JSON.stringify(this.config.m)],
+      ),
+      this.db.executeSql(
+        "INSERT OR REPLACE INTO hnsw_config (key, value) VALUES (?, ?)",
+        ["efConstruction", JSON.stringify(this.config.efConstruction)],
+      ),
+      this.db.executeSql(
+        "INSERT OR REPLACE INTO hnsw_config (key, value) VALUES (?, ?)",
+        ["efSearch", JSON.stringify(this.config.efSearch)],
+      ),
+    ];
+
+    await Promise.all(operations);
+  }
+
+  async clearVectors() {
+    if (!this.initialized) await this.initialize();
+
+    try {
+      await this.db.executeSql("DELETE FROM vectors");
+      await this.db.executeSql("DELETE FROM vector_data");
+      await this.db.executeSql("DELETE FROM hnsw_layers");
+      await this.db.executeSql("DELETE FROM hnsw_config");
+
+      this.index = {
+        layers: [],
+        entryPoint: null,
+        maxLayer: 0,
+      };
+      this.nodeMap.clear();
+
+      return true;
+    } catch (error) {
+      console.error("Failed to clear vectors:", error);
+      return false;
     }
-    
-    async clearVectors() {
-        if (!this.initialized) await this.initialize();
-        
-        try {
-            await this.db.executeSql('DELETE FROM vectors');
-            await this.db.executeSql('DELETE FROM vector_data');
-            await this.db.executeSql('DELETE FROM hnsw_layers');
-            await this.db.executeSql('DELETE FROM hnsw_config');
-            
-            this.index = {
-                layers: [],
-                entryPoint: null,
-                maxLayer: 0
-            };
-            this.nodeMap.clear();
-            
-            return true;
-        } catch (error) {
-            console.error('Failed to clear vectors:', error);
-            return false;
-        }
+  }
+
+  async getVectorCount() {
+    if (!this.initialized) await this.initialize();
+
+    try {
+      const [results] = await this.db.executeSql(
+        "SELECT COUNT(*) as count FROM vectors",
+      );
+      return results.rows.raw()[0].count;
+    } catch (error) {
+      console.error("Failed to get vector count:", error);
+      return 0;
     }
-    
-    async getVectorCount() {
-        if (!this.initialized) await this.initialize();
-        
-        try {
-            const [results] = await this.db.executeSql('SELECT COUNT(*) as count FROM vectors');
-            return results.rows.raw()[0].count;
-        } catch (error) {
-            console.error('Failed to get vector count:', error);
-            return 0;
-        }
-    }
+  }
 }
 
 class PriorityQueue {
-    constructor(comparator = (a, b) => a > b) {
-        this._heap = [];
-        this._comparator = comparator;
+  constructor(comparator = (a, b) => a > b) {
+    this._heap = [];
+    this._comparator = comparator;
+  }
+
+  size() {
+    return this._heap.length;
+  }
+
+  isEmpty() {
+    return this.size() === 0;
+  }
+
+  peek() {
+    return this._heap[0];
+  }
+
+  peekPriority() {
+    return this._heap[0] ? this._heap[0].priority : -Infinity;
+  }
+
+  add(value, priority = 1) {
+    this._heap.push({ value, priority });
+    this._siftUp();
+    return this;
+  }
+
+  poll() {
+    const result = this.peek();
+    const last = this._heap.pop();
+    if (this.size() > 0) {
+      this._heap[0] = last;
+      this._siftDown();
     }
-    
-    size() {
-        return this._heap.length;
+    return result;
+  }
+
+  toArray() {
+    return [...this._heap];
+  }
+
+  _siftUp() {
+    let nodeIdx = this.size() - 1;
+    while (nodeIdx > 0 && this._compare(nodeIdx, this._parent(nodeIdx))) {
+      this._swap(nodeIdx, this._parent(nodeIdx));
+      nodeIdx = this._parent(nodeIdx);
     }
-    
-    isEmpty() {
-        return this.size() === 0;
+  }
+
+  _siftDown() {
+    let nodeIdx = 0;
+    while (
+      (this._left(nodeIdx) < this.size() &&
+        this._compare(this._left(nodeIdx), nodeIdx)) ||
+      (this._right(nodeIdx) < this.size() &&
+        this._compare(this._right(nodeIdx), nodeIdx))
+    ) {
+      const greaterChild =
+        this._right(nodeIdx) < this.size() &&
+        this._compare(this._right(nodeIdx), this._left(nodeIdx))
+          ? this._right(nodeIdx)
+          : this._left(nodeIdx);
+      this._swap(nodeIdx, greaterChild);
+      nodeIdx = greaterChild;
     }
-    
-    peek() {
-        return this._heap[0];
-    }
-    
-    peekPriority() {
-        return this._heap[0] ? this._heap[0].priority : -Infinity;
-    }
-    
-    add(value, priority = 1) {
-        this._heap.push({ value, priority });
-        this._siftUp();
-        return this;
-    }
-    
-    poll() {
-        const result = this.peek();
-        const last = this._heap.pop();
-        if (this.size() > 0) {
-            this._heap[0] = last;
-            this._siftDown();
-        }
-        return result;
-    }
-    
-    toArray() {
-        return [...this._heap];
-    }
-    
-    _siftUp() {
-        let nodeIdx = this.size() - 1;
-        while (nodeIdx > 0 && this._compare(nodeIdx, this._parent(nodeIdx))) {
-            this._swap(nodeIdx, this._parent(nodeIdx));
-            nodeIdx = this._parent(nodeIdx);
-        }
-    }
-    
-    _siftDown() {
-        let nodeIdx = 0;
-        while (
-            (this._left(nodeIdx) < this.size() && this._compare(this._left(nodeIdx), nodeIdx)) ||
-            (this._right(nodeIdx) < this.size() && this._compare(this._right(nodeIdx), nodeIdx))
-        ) {
-            const greaterChild = 
-                this._right(nodeIdx) < this.size() && 
-                this._compare(this._right(nodeIdx), this._left(nodeIdx)) 
-                    ? this._right(nodeIdx) 
-                    : this._left(nodeIdx);
-            this._swap(nodeIdx, greaterChild);
-            nodeIdx = greaterChild;
-        }
-    }
-    
-    _compare(i, j) {
-        return this._comparator(
-            this._heap[i].priority, 
-            this._heap[j].priority
-        );
-    }
-    
-    _swap(i, j) {
-        [this._heap[i], this._heap[j]] = [this._heap[j], this._heap[i]];
-    }
-    
-    _parent(i) {
-        return (i - 1) >> 1;
-    }
-    
-    _left(i) {
-        return (i << 1) + 1;
-    }
-    
-    _right(i) {
-        return (i + 1) << 1;
-    }
+  }
+
+  _compare(i, j) {
+    return this._comparator(this._heap[i].priority, this._heap[j].priority);
+  }
+
+  _swap(i, j) {
+    [this._heap[i], this._heap[j]] = [this._heap[j], this._heap[i]];
+  }
+
+  _parent(i) {
+    return (i - 1) >> 1;
+  }
+
+  _left(i) {
+    return (i << 1) + 1;
+  }
+
+  _right(i) {
+    return (i + 1) << 1;
+  }
 }

--- a/src/utils/quantumSafeCrypto.js
+++ b/src/utils/quantumSafeCrypto.js
@@ -1,213 +1,223 @@
-import CryptoJS from 'crypto-js';
-import { kyber } from 'noble-post-quantum';
+import CryptoJS from "crypto-js";
+import { kyber } from "noble-post-quantum";
 
 let sharedSecret;
 let keyPair;
 
 export async function initCrypto() {
-    try {
-        keyPair = await kyber.keypair();
-        const capsule = await kyber.encapsulate(keyPair.publicKey);
-        sharedSecret = await kyber.decapsulate(capsule, keyPair.privateKey);
-        
-        return true;
-    } catch (error) {
-        console.error('Failed to initialize quantum-safe cryptography:', error);
-        
-        // Fallback to traditional encryption
-        sharedSecret = CryptoJS.lib.WordArray.random(32);
-        return false;
-    }
+  try {
+    keyPair = await kyber.keypair();
+    const capsule = await kyber.encapsulate(keyPair.publicKey);
+    sharedSecret = await kyber.decapsulate(capsule, keyPair.privateKey);
+
+    return true;
+  } catch (error) {
+    console.error("Failed to initialize quantum-safe cryptography:", error);
+
+    // Fallback to traditional encryption
+    sharedSecret = CryptoJS.lib.WordArray.random(32);
+    return false;
+  }
 }
 
 export async function encrypt(plaintext) {
-    if (!sharedSecret) {
-        await initCrypto();
+  if (!sharedSecret) {
+    await initCrypto();
+  }
+
+  try {
+    // Use Kyber for quantum-safe encryption if available
+    if (keyPair && sharedSecret) {
+      const capsule = await kyber.encapsulate(keyPair.publicKey);
+      const encrypted = await _encryptWithKyber(plaintext, sharedSecret);
+
+      return JSON.stringify({
+        capsule: Array.from(capsule),
+        encrypted: Array.from(encrypted),
+        algorithm: "kyber",
+      });
+    } else {
+      // Fallback to AES encryption
+      const encrypted = CryptoJS.AES.encrypt(
+        plaintext,
+        sharedSecret.toString(),
+      ).toString();
+
+      return JSON.stringify({
+        encrypted,
+        algorithm: "aes",
+      });
     }
-    
-    try {
-        // Use Kyber for quantum-safe encryption if available
-        if (keyPair && sharedSecret) {
-            const capsule = await kyber.encapsulate(keyPair.publicKey);
-            const encrypted = await _encryptWithKyber(plaintext, sharedSecret);
-            
-            return JSON.stringify({
-                capsule: Array.from(capsule),
-                encrypted: Array.from(encrypted),
-                algorithm: 'kyber'
-            });
-        } else {
-            // Fallback to AES encryption
-            const encrypted = CryptoJS.AES.encrypt(plaintext, sharedSecret.toString()).toString();
-            
-            return JSON.stringify({
-                encrypted,
-                algorithm: 'aes'
-            });
-        }
-    } catch (error) {
-        console.error('Encryption failed:', error);
-        throw new Error('Failed to encrypt data');
-    }
+  } catch (error) {
+    console.error("Encryption failed:", error);
+    throw new Error("Failed to encrypt data");
+  }
 }
 
 export async function decrypt(ciphertext) {
-    if (!sharedSecret) {
-        await initCrypto();
+  if (!sharedSecret) {
+    await initCrypto();
+  }
+
+  try {
+    const data = JSON.parse(ciphertext);
+
+    if (data.algorithm === "kyber") {
+      const capsule = new Uint8Array(data.capsule);
+      const encrypted = new Uint8Array(data.encrypted);
+
+      const secret = await kyber.decapsulate(capsule, keyPair.privateKey);
+      return await _decryptWithKyber(encrypted, secret);
+    } else {
+      // AES decryption
+      const bytes = CryptoJS.AES.decrypt(
+        data.encrypted,
+        sharedSecret.toString(),
+      );
+      return bytes.toString(CryptoJS.enc.Utf8);
     }
-    
-    try {
-        const data = JSON.parse(ciphertext);
-        
-        if (data.algorithm === 'kyber') {
-            const capsule = new Uint8Array(data.capsule);
-            const encrypted = new Uint8Array(data.encrypted);
-            
-            const secret = await kyber.decapsulate(capsule, keyPair.privateKey);
-            return await _decryptWithKyber(encrypted, secret);
-        } else {
-            // AES decryption
-            const bytes = CryptoJS.AES.decrypt(data.encrypted, sharedSecret.toString());
-            return bytes.toString(CryptoJS.enc.Utf8);
-        }
-    } catch (error) {
-        console.error('Decryption failed:', error);
-        throw new Error('Failed to decrypt data');
-    }
+  } catch (error) {
+    console.error("Decryption failed:", error);
+    throw new Error("Failed to decrypt data");
+  }
 }
 
 async function _encryptWithKyber(plaintext, secret) {
-    // Convert plaintext to bytes
-    const encoder = new TextEncoder();
-    const plaintextBytes = encoder.encode(plaintext);
+  // Convert plaintext to bytes
+  const encoder = new TextEncoder();
+  const plaintextBytes = encoder.encode(plaintext);
 
+  if (!(secret instanceof Uint8Array)) {
+    secret = new Uint8Array(secret);
+  }
+
+  // Use the first 32 bytes of the secret as AES key
+  const aesKey = secret.slice(0, 32);
+  const aesKeyWordArray = _uint8ArrayToWordArray(aesKey);
+
+  // Generate a random IV
+  const iv = CryptoJS.lib.WordArray.random(16);
+
+  // Encrypt with AES-CBC (CryptoJS doesn't support GCM natively)
+  const encrypted = CryptoJS.AES.encrypt(
+    _uint8ArrayToWordArray(plaintextBytes),
+    aesKeyWordArray,
+    { iv, mode: CryptoJS.mode.CBC, padding: CryptoJS.pad.Pkcs7 },
+  );
+
+  // Combine IV and ciphertext safely
+  const ivBytes = _wordArrayToUint8Array(iv);
+  const cipherBytes = _wordArrayToUint8Array(encrypted.ciphertext);
+  const result = new Uint8Array(ivBytes.length + cipherBytes.length);
+  result.set(ivBytes, 0);
+  result.set(cipherBytes, ivBytes.length);
+
+  return result;
+}
+
+async function _decryptWithKyber(encrypted, secret) {
+  try {
     if (!(secret instanceof Uint8Array)) {
-        secret = new Uint8Array(secret);
+      secret = new Uint8Array(secret);
     }
 
     // Use the first 32 bytes of the secret as AES key
     const aesKey = secret.slice(0, 32);
     const aesKeyWordArray = _uint8ArrayToWordArray(aesKey);
 
-    // Generate a random IV
-    const iv = CryptoJS.lib.WordArray.random(16);
+    // Extract IV and ciphertext
+    const iv = encrypted.slice(0, 16);
+    const ciphertext = encrypted.slice(16);
 
-    // Encrypt with AES-CBC (CryptoJS doesn't support GCM natively)
-    const encrypted = CryptoJS.AES.encrypt(
-        _uint8ArrayToWordArray(plaintextBytes),
-        aesKeyWordArray,
-        { iv, mode: CryptoJS.mode.CBC, padding: CryptoJS.pad.Pkcs7 }
+    // Decrypt with AES-CBC
+    const decrypted = CryptoJS.AES.decrypt(
+      { ciphertext: _uint8ArrayToWordArray(ciphertext) },
+      aesKeyWordArray,
+      {
+        iv: _uint8ArrayToWordArray(iv),
+        mode: CryptoJS.mode.CBC,
+        padding: CryptoJS.pad.Pkcs7,
+      },
     );
 
-    // Combine IV and ciphertext safely
-    const ivBytes = _wordArrayToUint8Array(iv);
-    const cipherBytes = _wordArrayToUint8Array(encrypted.ciphertext);
-    const result = new Uint8Array(ivBytes.length + cipherBytes.length);
-    result.set(ivBytes, 0);
-    result.set(cipherBytes, ivBytes.length);
-
-    return result;
-}
-
-async function _decryptWithKyber(encrypted, secret) {
-    try {
-        if (!(secret instanceof Uint8Array)) {
-            secret = new Uint8Array(secret);
-        }
-
-        // Use the first 32 bytes of the secret as AES key
-        const aesKey = secret.slice(0, 32);
-        const aesKeyWordArray = _uint8ArrayToWordArray(aesKey);
-
-        // Extract IV and ciphertext
-        const iv = encrypted.slice(0, 16);
-        const ciphertext = encrypted.slice(16);
-
-        // Decrypt with AES-CBC
-        const decrypted = CryptoJS.AES.decrypt(
-            { ciphertext: _uint8ArrayToWordArray(ciphertext) },
-            aesKeyWordArray,
-            { iv: _uint8ArrayToWordArray(iv), mode: CryptoJS.mode.CBC, padding: CryptoJS.pad.Pkcs7 }
-        );
-
-        // Convert back to string
-        return decrypted.toString(CryptoJS.enc.Utf8);
-    } catch (error) {
-        console.error('Kyber decryption failed:', error);
-        throw new Error('Failed to decrypt with Kyber');
-    }
+    // Convert back to string
+    return decrypted.toString(CryptoJS.enc.Utf8);
+  } catch (error) {
+    console.error("Kyber decryption failed:", error);
+    throw new Error("Failed to decrypt with Kyber");
+  }
 }
 
 function _wordArrayToUint8Array(wordArray) {
-    const { words, sigBytes } = wordArray;
-    const result = new Uint8Array(sigBytes);
-    // CryptoJS stores words in big-endian format; extract bytes explicitly to
-    // avoid host endianness issues.
-    for (let i = 0; i < sigBytes; i++) {
-        result[i] = (words[i >>> 2] >>> (24 - (i & 3) * 8)) & 0xff;
-    }
-    return result;
+  const { words, sigBytes } = wordArray;
+  const result = new Uint8Array(sigBytes);
+  // CryptoJS stores words in big-endian format; extract bytes explicitly to
+  // avoid host endianness issues.
+  for (let i = 0; i < sigBytes; i++) {
+    result[i] = (words[i >>> 2] >>> (24 - (i & 3) * 8)) & 0xff;
+  }
+  return result;
 }
 
 function _uint8ArrayToWordArray(u8Array) {
-    const words = new Array(Math.ceil(u8Array.length / 4)).fill(0);
-    for (let i = 0; i < u8Array.length; i++) {
-        words[i >>> 2] |= u8Array[i] << (24 - (i & 3) * 8);
-    }
-    return CryptoJS.lib.WordArray.create(words, u8Array.length);
+  const words = new Array(Math.ceil(u8Array.length / 4)).fill(0);
+  for (let i = 0; i < u8Array.length; i++) {
+    words[i >>> 2] |= u8Array[i] << (24 - (i & 3) * 8);
+  }
+  return CryptoJS.lib.WordArray.create(words, u8Array.length);
 }
 
 export async function rotateKeys() {
-    try {
-        const newKeyPair = await kyber.keypair();
-        const capsule = await kyber.encapsulate(newKeyPair.publicKey);
-        sharedSecret = await kyber.decapsulate(capsule, newKeyPair.privateKey);
-        keyPair = newKeyPair;
-        
-        return true;
-    } catch (error) {
-        console.error('Failed to rotate keys:', error);
-        return false;
-    }
+  try {
+    const newKeyPair = await kyber.keypair();
+    const capsule = await kyber.encapsulate(newKeyPair.publicKey);
+    sharedSecret = await kyber.decapsulate(capsule, newKeyPair.privateKey);
+    keyPair = newKeyPair;
+
+    return true;
+  } catch (error) {
+    console.error("Failed to rotate keys:", error);
+    return false;
+  }
 }
 
-export async function generateHash(data, algorithm = 'SHA3-256') {
-    try {
-        switch (algorithm) {
-            case 'SHA3-256':
-                return CryptoJS.SHA3(data, { outputLength: 256 }).toString();
-            case 'SHA3-512':
-                return CryptoJS.SHA3(data, { outputLength: 512 }).toString();
-            case 'SHA256':
-                return CryptoJS.SHA256(data).toString();
-            default:
-                return CryptoJS.SHA3(data, { outputLength: 256 }).toString();
-        }
-    } catch (error) {
-        console.error('Hash generation failed:', error);
-        throw new Error('Failed to generate hash');
+export async function generateHash(data, algorithm = "SHA3-256") {
+  try {
+    switch (algorithm) {
+      case "SHA3-256":
+        return CryptoJS.SHA3(data, { outputLength: 256 }).toString();
+      case "SHA3-512":
+        return CryptoJS.SHA3(data, { outputLength: 512 }).toString();
+      case "SHA256":
+        return CryptoJS.SHA256(data).toString();
+      default:
+        return CryptoJS.SHA3(data, { outputLength: 256 }).toString();
     }
+  } catch (error) {
+    console.error("Hash generation failed:", error);
+    throw new Error("Failed to generate hash");
+  }
 }
 
 export async function generateSignature(data, privateKey) {
-    try {
-        // In a real implementation, this would use a quantum-safe signature algorithm
-        // For now, we use HMAC with SHA3 as a placeholder
-        return CryptoJS.HmacSHA3(data, privateKey).toString();
-    } catch (error) {
-        console.error('Signature generation failed:', error);
-        throw new Error('Failed to generate signature');
-    }
+  try {
+    // In a real implementation, this would use a quantum-safe signature algorithm
+    // For now, we use HMAC with SHA3 as a placeholder
+    return CryptoJS.HmacSHA3(data, privateKey).toString();
+  } catch (error) {
+    console.error("Signature generation failed:", error);
+    throw new Error("Failed to generate signature");
+  }
 }
 
 export async function verifySignature(data, signature, publicKey) {
-    try {
-        // In a real implementation, this would verify a quantum-safe signature
-        // For now, we use HMAC with SHA3 as a placeholder
-        const expectedSignature = CryptoJS.HmacSHA3(data, publicKey).toString();
-        return expectedSignature === signature;
-    } catch (error) {
-        console.error('Signature verification failed:', error);
-        return false;
-    }
+  try {
+    // In a real implementation, this would verify a quantum-safe signature
+    // For now, we use HMAC with SHA3 as a placeholder
+    const expectedSignature = CryptoJS.HmacSHA3(data, publicKey).toString();
+    return expectedSignature === signature;
+  } catch (error) {
+    console.error("Signature verification failed:", error);
+    return false;
+  }
 }

--- a/src/utils/sparseAttention.js
+++ b/src/utils/sparseAttention.js
@@ -3,7 +3,7 @@ import { cosineSimilarity, dotProduct } from "./vectorUtils";
 export function applySparseAttention(
   queryVector,
   contextVectors,
-  options = {}
+  options = {},
 ) {
   const { topK = 5, threshold = 0.5, useCosine = true } = options;
 
@@ -36,7 +36,7 @@ export function applySparseAttention(
 export function applyBlockSparseAttention(
   queryVector,
   contextVectors,
-  blockSize = 64
+  blockSize = 64,
 ) {
   if (!contextVectors || contextVectors.length === 0) {
     return [];
@@ -75,7 +75,7 @@ export function applyBlockSparseAttention(
 export function applyHierarchicalSparseAttention(
   queryVector,
   contextVectors,
-  options = {}
+  options = {},
 ) {
   const { numClusters = 3, topKPerCluster = 2 } = options;
 
@@ -99,7 +99,7 @@ export function applyHierarchicalSparseAttention(
 
     // Add top K vectors from this cluster
     selectedIndices.push(
-      ...clusterScores.slice(0, topKPerCluster).map((item) => item.index)
+      ...clusterScores.slice(0, topKPerCluster).map((item) => item.index),
     );
   }
 
@@ -125,7 +125,7 @@ function clusterVectors(vectors, numClusters) {
       for (const centroid of centroids) {
         const dist = vector.reduce(
           (sum, val, idx) => sum + Math.pow(val - centroid[idx], 2),
-          0
+          0,
         );
         if (dist < minDist) minDist = dist;
       }
@@ -178,7 +178,7 @@ function clusterVectors(vectors, numClusters) {
     for (let j = 0; j < numClusters; j++) {
       if (clusters[j].indices.length > 0) {
         const newCentroid = averageVectors(
-          clusters[j].indices.map((index) => vectors[index])
+          clusters[j].indices.map((index) => vectors[index]),
         );
 
         if (euclideanDistance(newCentroid, centroids[j]) > 0.001) {
@@ -221,6 +221,6 @@ function euclideanDistance(vecA, vecB) {
   }
 
   return Math.sqrt(
-    vecA.reduce((sum, a, i) => sum + Math.pow(a - vecB[i], 2), 0)
+    vecA.reduce((sum, a, i) => sum + Math.pow(a - vecB[i], 2), 0),
   );
 }

--- a/src/utils/vectorUtils.js
+++ b/src/utils/vectorUtils.js
@@ -1,129 +1,129 @@
 export function cosineSimilarity(vecA, vecB) {
-    if (!vecA || !vecB || vecA.length !== vecB.length) {
-        return 0;
-    }
-    
-    const dotProduct = vecA.reduce((sum, a, i) => sum + a * vecB[i], 0);
-    const magnitudeA = Math.sqrt(vecA.reduce((sum, a) => sum + a * a, 0));
-    const magnitudeB = Math.sqrt(vecB.reduce((sum, b) => sum + b * b, 0));
-    
-    if (magnitudeA === 0 || magnitudeB === 0) {
-        return 0;
-    }
-    
-    return dotProduct / (magnitudeA * magnitudeB);
+  if (!vecA || !vecB || vecA.length !== vecB.length) {
+    return 0;
+  }
+
+  const dotProduct = vecA.reduce((sum, a, i) => sum + a * vecB[i], 0);
+  const magnitudeA = Math.sqrt(vecA.reduce((sum, a) => sum + a * a, 0));
+  const magnitudeB = Math.sqrt(vecB.reduce((sum, b) => sum + b * b, 0));
+
+  if (magnitudeA === 0 || magnitudeB === 0) {
+    return 0;
+  }
+
+  return dotProduct / (magnitudeA * magnitudeB);
 }
 
 export function quantizeVector(vector, bits = 4) {
-    if (!vector || vector.length === 0) return [];
+  if (!vector || vector.length === 0) return [];
 
-    const maxVal = Math.max(...vector.map(Math.abs));
-    if (maxVal === 0) {
-        return new Array(vector.length).fill(0);
-    }
-    const scale = Math.pow(2, bits - 1) - 1;
+  const maxVal = Math.max(...vector.map(Math.abs));
+  if (maxVal === 0) {
+    return new Array(vector.length).fill(0);
+  }
+  const scale = Math.pow(2, bits - 1) - 1;
 
-    return vector.map(val => {
-        const normalized = val / maxVal;
-        return Math.round(normalized * scale);
-    });
+  return vector.map((val) => {
+    const normalized = val / maxVal;
+    return Math.round(normalized * scale);
+  });
 }
 
 export function dequantizeVector(quantized, maxVal, bits = 4) {
-    if (!quantized || quantized.length === 0) return [];
-    if (typeof maxVal !== 'number' || maxVal === 0) return [];
+  if (!quantized || quantized.length === 0) return [];
+  if (typeof maxVal !== "number" || maxVal === 0) return [];
 
-    const scale = Math.pow(2, bits - 1) - 1;
+  const scale = Math.pow(2, bits - 1) - 1;
 
-    return quantized.map(qVal => {
-        return (qVal / scale) * maxVal;
-    });
+  return quantized.map((qVal) => {
+    return (qVal / scale) * maxVal;
+  });
 }
 
 export function normalizeVector(vector) {
-    if (!vector || vector.length === 0) return [];
-    
-    const magnitude = Math.sqrt(vector.reduce((sum, val) => sum + val * val, 0));
-    
-    if (magnitude === 0) return vector;
-    
-    return vector.map(val => val / magnitude);
+  if (!vector || vector.length === 0) return [];
+
+  const magnitude = Math.sqrt(vector.reduce((sum, val) => sum + val * val, 0));
+
+  if (magnitude === 0) return vector;
+
+  return vector.map((val) => val / magnitude);
 }
 
 export function euclideanDistance(vecA, vecB) {
-    if (!vecA || !vecB || vecA.length !== vecB.length) {
-        return Infinity;
-    }
-    
-    return Math.sqrt(
-        vecA.reduce((sum, a, i) => sum + Math.pow(a - vecB[i], 2), 0)
-    );
+  if (!vecA || !vecB || vecA.length !== vecB.length) {
+    return Infinity;
+  }
+
+  return Math.sqrt(
+    vecA.reduce((sum, a, i) => sum + Math.pow(a - vecB[i], 2), 0),
+  );
 }
 
 export function manhattanDistance(vecA, vecB) {
-    if (!vecA || !vecB || vecA.length !== vecB.length) {
-        return Infinity;
-    }
-    
-    return vecA.reduce((sum, a, i) => sum + Math.abs(a - vecB[i]), 0);
+  if (!vecA || !vecB || vecA.length !== vecB.length) {
+    return Infinity;
+  }
+
+  return vecA.reduce((sum, a, i) => sum + Math.abs(a - vecB[i]), 0);
 }
 
 export function dotProduct(vecA, vecB) {
-    if (!vecA || !vecB || vecA.length !== vecB.length) {
-        return 0;
-    }
-    
-    return vecA.reduce((sum, a, i) => sum + a * vecB[i], 0);
+  if (!vecA || !vecB || vecA.length !== vecB.length) {
+    return 0;
+  }
+
+  return vecA.reduce((sum, a, i) => sum + a * vecB[i], 0);
 }
 
 export function vectorMagnitude(vector) {
-    if (!vector || vector.length === 0) {
-        return 0;
-    }
-    
-    return Math.sqrt(vector.reduce((sum, val) => sum + val * val, 0));
+  if (!vector || vector.length === 0) {
+    return 0;
+  }
+
+  return Math.sqrt(vector.reduce((sum, val) => sum + val * val, 0));
 }
 
 export function addVectors(vecA, vecB) {
-    if (!vecA || !vecB || vecA.length !== vecB.length) {
-        return [];
-    }
-    
-    return vecA.map((a, i) => a + vecB[i]);
+  if (!vecA || !vecB || vecA.length !== vecB.length) {
+    return [];
+  }
+
+  return vecA.map((a, i) => a + vecB[i]);
 }
 
 export function subtractVectors(vecA, vecB) {
-    if (!vecA || !vecB || vecA.length !== vecB.length) {
-        return [];
-    }
-    
-    return vecA.map((a, i) => a - vecB[i]);
+  if (!vecA || !vecB || vecA.length !== vecB.length) {
+    return [];
+  }
+
+  return vecA.map((a, i) => a - vecB[i]);
 }
 
 export function multiplyVectorByScalar(vector, scalar) {
-    if (!vector || vector.length === 0) {
-        return [];
-    }
-    
-    return vector.map(val => val * scalar);
+  if (!vector || vector.length === 0) {
+    return [];
+  }
+
+  return vector.map((val) => val * scalar);
 }
 
 export function averageVectors(vectors) {
-    if (!vectors || vectors.length === 0) {
-        return [];
-    }
+  if (!vectors || vectors.length === 0) {
+    return [];
+  }
 
-    const dimension = vectors[0].length;
-    if (!vectors.every(v => v.length === dimension)) {
-        return [];
-    }
-    const result = new Array(dimension).fill(0);
+  const dimension = vectors[0].length;
+  if (!vectors.every((v) => v.length === dimension)) {
+    return [];
+  }
+  const result = new Array(dimension).fill(0);
 
-    for (const vector of vectors) {
-        for (let i = 0; i < dimension; i++) {
-            result[i] += vector[i];
-        }
+  for (const vector of vectors) {
+    for (let i = 0; i < dimension; i++) {
+      result[i] += vector[i];
     }
+  }
 
-    return result.map(sum => sum / vectors.length);
+  return result.map((sum) => sum / vectors.length);
 }


### PR DESCRIPTION
### **User description**
## Summary
- avoid post_integrate crash on Pod::PodTarget objects
- remove Hermes script only from Pods project and guard it

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check` *(fails: Code style issues found in 50 files)*

------
https://chatgpt.com/codex/tasks/task_e_68b67e0f6f488333ab57f10d950e44da


___

### **PR Type**
Bug fix


___

### **Description**
- Fix crash when handling Pod::PodTarget objects in post_integrate

- Simplify Hermes script removal to only target Pods project

- Improve project collection logic to avoid non-project objects

- Enhance error messages and guard conditions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["post_integrate hook"] --> B["Filter real projects only"]
  B --> C["Remove Hermes scripts from Pods"]
  C --> D["Mark [CP] phases out-of-date"]
  D --> E["Guard against remaining scripts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Podfile</strong><dd><code>Harden post_integrate Hermes cleanup logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ios/Podfile

<ul><li>Simplified project collection to avoid Pod::PodTarget crashes<br> <li> Restricted Hermes script removal to Pods project only<br> <li> Enhanced user project filtering with proper type checking<br> <li> Improved error messages and guard condition logic</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/offLLM/pull/56/files#diff-281ded35b124f5160d0a57e47e521ee6f49f233933e091a0d33f3fd42a74abc8">+31/-45</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

## Summary by Sourcery

Harden the post_integrate hook in the iOS Podfile by restricting Hermes script removal to the Pods project, filtering valid Xcode project instances to prevent crashes, silencing empty [CP] phase warnings, and improving CI guard checks and error messages.

Bug Fixes:
- Prevent crashes by filtering for real user_project objects instead of Pod::PodTarget instances in post_integrate

Enhancements:
- Restrict Hermes replacement script removal to the pods_project only
- Simplify and unify marking of empty [CP] shell script phases as always out-of-date to silence Xcode warnings
- Refine CI guard logic to detect and fail on remaining Hermes scripts with clearer error messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iOS Simulator and unsigned IPA build workflows with archives, logs, and artifacts.
  * Persistent SQLite-backed vector store for durable embeddings.

* **Bug Fixes**
  * Reduced CI/build flakiness by safer removal/silencing of problematic Xcode/CocoaPods script phases.
  * Consent storage errors now propagate to callers.

* **Refactor**
  * Unified iOS post-install/post-integrate build-phase handling across projects.

* **Chores**
  * Hermes-scrub tooling, documentation updates, and broad style/formatting cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->