### PR TITLE
fix: include Pods configs and add iOS build diagnostics

### DIFF
--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -125,14 +125,6 @@ jobs:
             -UseModernBuildSystem=YES \
             CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | tee "${BUILD_DIR}/xcodebuild.log"
 
-      - name: Upload xcodebuild logs
-        uses: actions/upload-artifact@v4
-        with:
-          name: xcodebuild-logs
-          path: |
-            ${{ env.BUILD_DIR }}/xcodebuild.log
-            ${{ env.BUILD_DIR }}/MyOfflineLLMApp.xcresult
-
       - name: Summarize build log
         if: always()
         run: |
@@ -151,8 +143,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: build-diagnosis
-          path: ${{ env.BUILD_DIR }}/ci_diagnosis.md
+          name: ios-ci-diagnosis
+          path: |
+            ${{ env.BUILD_DIR }}/ci_diagnosis.md
+            ${{ env.BUILD_DIR }}/xcodebuild.log
+            ${{ env.BUILD_DIR }}/MyOfflineLLMApp.xcresult
           if-no-files-found: warn
 
       - name: Locate built .app and dSYMs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,3 +98,22 @@ You are a build doctor. Read the compact diagnosis report produced by CI and app
 ## Rollback Guidance
 
 - Revert doc-only changes with `git revert <commit>`.
+
+## iOS Build Doctor (CI Triage)
+
+**Inputs available as CI artifacts:**
+
+- `build/ci_diagnosis.md` (≤8K chars) — compact summary generated from the latest build.
+- `build/xcodebuild.log`, `build/*.xcresult` (full artifacts if you need detail).
+
+**Your task:**
+
+1. Read `ci_diagnosis.md` and identify the _most likely_ root cause in 1–3 bullets.
+2. Propose concrete repository changes to fix it. Prefer small, surgical edits:
+   - For missing `react/bridging/*` headers, ensure the app's Debug/Release xcconfig files `#include` the Pods-generated configs and (if needed) add `ReactCommon` / `React-Codegen` header search paths.
+3. Output your answer as:
+   - **Patches**: each with path and a minimal diff block.
+   - **Rationale**: 1–2 sentences per patch.
+4. Keep the total output under 300 lines. If uncertain, propose the smallest change that surfaces richer errors next run.
+
+**Don’ts:** Don’t paste the entire log. Don’t propose sweeping refactors. Aim for the next green build.

--- a/ios/Config/MyOfflineLLMApp.Debug.xcconfig
+++ b/ios/Config/MyOfflineLLMApp.Debug.xcconfig
@@ -1,14 +1,11 @@
-// Keep Pod settings optional at generate-time; pick them up after `pod install`
-#include? "../Pods/Target Support Files/Pods-MyOfflineLLMApp/Pods-MyOfflineLLMApp.debug.xcconfig"
+#include "Pods/Target Support Files/Pods-MyOfflineLLMApp/Pods-MyOfflineLLMApp.debug.xcconfig"
 #include? "Auto/MLXFlags.xcconfig"
 
-// Ensure React headers (and other public/private Pod headers) are discoverable
-HEADER_SEARCH_PATHS = $(inherited) \
-  "$(PODS_ROOT)/Headers/Public" \
-  "$(PODS_ROOT)/Headers/Public/React-Core" \
-  "$(PODS_ROOT)/Headers/Private" \
-  $(SRCROOT)/build/generated/ios \
-  $(PODS_ROOT)/Headers/Public/React-Codegen
-SWIFT_OBJC_BRIDGING_HEADER = $(SRCROOT)/MyOfflineLLMApp/MyOfflineLLMApp-Bridging-Header.h
-OTHER_SWIFT_FLAGS = $(inherited)
-SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited)
+/* Local additions (kept minimal — most comes from Pods) */
+HEADER_SEARCH_PATHS = $(inherited) $(SRCROOT)/build/generated/ios \
+  "$(PODS_CONFIGURATION_BUILD_DIR)/ReactCommon/ReactCommon.framework/Headers" \
+  "$(PODS_ROOT)/Headers/Public/ReactCommon" \
+  "$(PODS_ROOT)/Headers/Public/React-Codegen" \
+  "$(PODS_ROOT)/Headers/Private"
+
+SWIFT_INCLUDE_PATHS = $(inherited) $(SRCROOT)/build/generated/ios

--- a/ios/Config/MyOfflineLLMApp.Release.xcconfig
+++ b/ios/Config/MyOfflineLLMApp.Release.xcconfig
@@ -1,13 +1,10 @@
-#include? "../Pods/Target Support Files/Pods-MyOfflineLLMApp/Pods-MyOfflineLLMApp.release.xcconfig"
+#include "Pods/Target Support Files/Pods-MyOfflineLLMApp/Pods-MyOfflineLLMApp.release.xcconfig"
 #include? "Auto/MLXFlags.xcconfig"
 
-// Ensure React headers (and other public/private Pod headers) are discoverable
-HEADER_SEARCH_PATHS = $(inherited) \
-  "$(PODS_ROOT)/Headers/Public" \
-  "$(PODS_ROOT)/Headers/Public/React-Core" \
-  "$(PODS_ROOT)/Headers/Private" \
-  $(SRCROOT)/build/generated/ios \
-  $(PODS_ROOT)/Headers/Public/React-Codegen
-SWIFT_OBJC_BRIDGING_HEADER = $(SRCROOT)/MyOfflineLLMApp/MyOfflineLLMApp-Bridging-Header.h
-OTHER_SWIFT_FLAGS = $(inherited)
-SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited)
+HEADER_SEARCH_PATHS = $(inherited) $(SRCROOT)/build/generated/ios \
+  "$(PODS_CONFIGURATION_BUILD_DIR)/ReactCommon/ReactCommon.framework/Headers" \
+  "$(PODS_ROOT)/Headers/Public/ReactCommon" \
+  "$(PODS_ROOT)/Headers/Public/React-Codegen" \
+  "$(PODS_ROOT)/Headers/Private"
+
+SWIFT_INCLUDE_PATHS = $(inherited) $(SRCROOT)/build/generated/ios

--- a/scripts/ci/diagnose_build.sh
+++ b/scripts/ci/diagnose_build.sh
@@ -2,82 +2,46 @@
 set -euo pipefail
 
 BUILD_DIR="${1:-build}"
-REPORT="${BUILD_DIR}/ci_diagnosis.md"
-XCRESULT="${BUILD_DIR}/MyOfflineLLMApp.xcresult"
+XC="${BUILD_DIR}/MyOfflineLLMApp.xcresult"
 LOG="${BUILD_DIR}/xcodebuild.log"
+OUT_MD="${BUILD_DIR}/ci_diagnosis.md"
 
-mkdir -p "${BUILD_DIR}"
-echo "# Build Diagnosis (compact)" > "${REPORT}"
-echo "" >> "${REPORT}"
+shorten () {  # keep output tight for agents
+  local max=${1:-8000}
+  python3 - "$max" << 'PY'
+import sys, textwrap
+limit=int(sys.argv[1]); data=sys.stdin.read()
+print((data if len(data)<=limit else data[:limit-200]+"\n\n…(truncated)…"))
+PY
+}
 
-# Extract issues from .xcresult (if present) into markdown (uses Node from setup-node step)
-if [ -d "${XCRESULT}" ] || [ -f "${XCRESULT}" ]; then
-  JSON="${BUILD_DIR}/xcresult.json"
-  # note: may fail on older Xcode; continue
-  xcrun xcresulttool get --path "${XCRESULT}" --format json > "${JSON}" || true
-  node - <<'NODE' "${JSON}" "${BUILD_DIR}/xcresult.md" || true
-  const fs = require('fs');
-  const input = process.argv[2], out = process.argv[3];
-  try {
-    const j = JSON.parse(fs.readFileSync(input,'utf8'));
-    const val = x => (x && x._value) || (typeof x === 'string' ? x : '');
-    const arr = x => (x && x._values) || [];
-    const actions = arr(j.actions);
-    const issues = actions.flatMap(a => arr(a.actionResult && a.actionResult.issues));
-    const errors  = issues.flatMap(i => arr(i.errorSummaries)).map(e => ({msg: val(e.message), url: val(e.documentationURL)}));
-    const warns   = issues.flatMap(i => arr(i.warningSummaries)).map(w => val(w.message));
-
-    function uniq(xs){ return [...new Set(xs.filter(Boolean))]; }
-
-    let md = "## xcresult errors\n";
-    uniq(errors.map(e => `- ${e.msg}`)).slice(0, 50).forEach(line => md += line + "\n");
-    md += "\n## xcresult warnings\n";
-    uniq(warns.map(w => `- ${w}`)).slice(0, 50).forEach(line => md += line + "\n");
-    fs.writeFileSync(out, md);
-  } catch (e) {
-    // ignore parse errors, keep report generation going
-  }
-NODE
-  if [ -f "${BUILD_DIR}/xcresult.md" ]; then
-    echo "## xcresult summary" >> "${REPORT}"
-    cat "${BUILD_DIR}/xcresult.md" >> "${REPORT}"
-    echo "" >> "${REPORT}"
+{
+  echo "# iOS CI Diagnosis"
+  echo
+  echo "## Most likely root cause"
+  # Heuristic: pick 5 most frequent / representative error lines
+  if [ -f "$LOG" ]; then
+    echo '```'
+    grep -E '(^|: )error:|Internal inconsistency error' -n "$LOG" \
+      | sed 's#^.*Build/Intermediates[^:]*:##' \
+      | sed 's#^.*node_modules/[^:]*:##' \
+      | cut -c -240 \
+      | sort | uniq -c | sort -nr | head -n 5
+    echo '```'
+  else
+    echo "_log not found_"
   fi
-fi
+  echo
+  echo "## Top XCResult issues"
+  if [ -d "$XC" ] || [ -f "$XC" ]; then
+    python3 scripts/xcresult_top_issues.py "$XC" 2>/dev/null | shorten 4000 || echo "_xcresult parse failed_"
+  else
+    echo "_xcresult missing_"
+  fi
+  echo
+  echo "## Pointers"
+  echo "- Full log: \`$LOG\`"
+  echo "- Result bundle: \`$XC\`"
+} > "$OUT_MD"
 
-# Pull out error snippets from the xcodebuild log (3 lines of context, strip ANSI)
-if [ -f "${LOG}" ]; then
-  echo "## xcodebuild.log errors (with context)" >> "${REPORT}"
-  python3 - "${LOG}" >> "${REPORT}" <<'PY' || true
-import re, sys
-log = sys.argv[1]
-try:
-    with open(log, 'r', errors='ignore') as f:
-        lines = f.readlines()
-    pattern = re.compile(r'error:|fatal error:|Command PhaseScriptExecution failed|Internal inconsistency error|never received target ended message', re.IGNORECASE)
-    for idx, line in enumerate(lines):
-        if pattern.search(line):
-            print("```")
-            for ctx in lines[max(0, idx-3): min(len(lines), idx+4)]:
-                if '/clang' in ctx:
-                    continue
-                ctx = re.sub(r'\x1B\[[0-9;]*[A-Za-z]', '', ctx.rstrip("\n"))
-                if len(ctx) > 500:
-                    ctx = ctx[:500] + '…'
-                print(ctx)
-            print("```\n")
-except Exception:
-    pass
-PY
-fi
-
-# Cap size to ~180KB so the AGENT can ingest it in one go
-python3 - "$REPORT" <<'PY' || true
-import sys, os
-p=sys.argv[1]
-if os.path.exists(p) and os.path.getsize(p)>180*1024:
-    with open(p,'rb') as f: data=f.read(180*1024)
-    with open(p,'wb') as f: f.write(data+b"\n\n[truncated]")
-PY
-
-echo "✅ Wrote ${REPORT}"
+echo "Wrote $OUT_MD"


### PR DESCRIPTION
## Summary
- include CocoaPods configs and React headers in iOS xcconfig
- add compact iOS build diagnosis script and upload artifact
- document Build Doctor triage prompt for agents

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68b89a9d54b8833380bfaaa5acee256a

## Summary by Sourcery

Include missing CocoaPods and React header configurations in iOS xcconfig files, overhaul the CI build diagnosis script to produce a compact report, adjust the GitHub Actions workflow to upload the new artifacts, and enhance documentation with iOS Build Doctor triage guidance.

Bug Fixes:
- Include CocoaPods-generated configs and React header search paths in Debug and Release xcconfig files

Enhancements:
- Rewrite the iOS CI diagnose_build script to use shell heuristics and Python for compact, truncated build reports

CI:
- Update the GitHub Actions ios-unsigned workflow to upload the compact ci_diagnosis report along with xcodebuild.log and xcresult artifacts

Documentation:
- Add iOS Build Doctor (CI Triage) instructions to AGENTS.md for automated diagnosis agents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Documentation
  - Added an “iOS Build Doctor (CI Triage)” guide outlining inputs, triage workflow, and output format for faster CI troubleshooting.
- Chores
  - Consolidated iOS CI artifacts into a single diagnosis bundle, simplifying downloads and review.
  - Streamlined the diagnosis report with clearer sections and concise summaries of likely root causes and top issues.
- Build
  - Simplified iOS build configuration: updated header and Swift include paths and removed legacy Swift settings for a leaner setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->