### PR TITLE
fix(ci): remove invalid parallelizeTargets flag

### DIFF
--- a/.github/workflows/ios-simulator.yml
+++ b/.github/workflows/ios-simulator.yml
@@ -125,7 +125,6 @@ jobs:
             -sdk iphonesimulator \
             -destination "platform=iOS Simulator,name=${SIM_DEVICE}" \
             -UseModernBuildSystem=YES \
-            -parallelizeTargets 'NO' \
             -jobs 1 \
             -resultBundlePath "${BUILD_DIR}/MyOfflineLLMApp.xcresult" \
             CODE_SIGNING_ALLOWED=NO \

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -126,7 +126,6 @@ jobs:
             -archivePath "${BUILD_DIR}/MyOfflineLLMApp.xcarchive" \
             -resultBundlePath "${BUILD_DIR}/MyOfflineLLMApp.xcresult" \
             -UseModernBuildSystem=YES \
-            -parallelizeTargets 'NO' \
             -jobs 1 \
             CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
             clean archive | tee "${BUILD_DIR}/xcodebuild.log"


### PR DESCRIPTION
## Summary
- remove invalid `-parallelizeTargets NO` from iOS build workflows

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check` *(fails: Code style issues found in 2 files)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c9475db083338af51e193721de4c

## Summary by Sourcery

CI:
- Remove invalid '-parallelizeTargets NO' flag from ios-simulator and ios-unsigned workflows