### PR TITLE
fix(ios): strip Hermes script phases unconditionally

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -51,7 +51,19 @@ target app_target do
 end
 
 # ---- Hermes Fix 2: Remove "Replace Hermes" script phases everywhere ----
-forbidden_markers = ['Replace Hermes', 'Replace Hermes for the right configuration']
+FORBIDDEN_HERMES_MARKERS = ['Replace Hermes', 'Replace Hermes for the right configuration'].freeze
+
+def strip_hermes_replacement_scripts!(project)
+  project.targets.each do |t|
+    t.build_phases
+      .select do |p|
+        p.isa == 'PBXShellScriptBuildPhase' &&
+          FORBIDDEN_HERMES_MARKERS.any? { |m| (p.name || '').include?(m) || (p.shell_script || '').include?(m) }
+      end
+      .each { |p| t.build_phases.delete(p) }
+  end
+  project.save
+end
 
 post_install do |installer|
   react_native_post_install(installer) if defined?(react_native_post_install)
@@ -128,16 +140,10 @@ post_install do |installer|
   end
 
   # Remove Hermes "Replace Hermes" script phases from all projects
-  scrub = lambda { |proj|
-    proj.targets.each do |t|
-      t.build_phases.select { |p|
-        p.isa == 'PBXShellScriptBuildPhase' && p.name && forbidden_markers.any? { |m| p.name.include?(m) }
-      }.each { |p| t.build_phases.delete(p) }
-    end
-    proj.save
-  }
-  scrub.call(installer.pods_project)
-  installer.aggregate_targets.each { |agg| scrub.call(agg.user_project) if agg.user_project }
+  strip_hermes_replacement_scripts!(installer.pods_project)
+  installer.aggregate_targets.each do |agg|
+    strip_hermes_replacement_scripts!(agg.user_project) if agg.user_project
+  end
 
   # Mark [CP] phases without I/O as always out-of-date to silence warnings
   ([installer.pods_project] + installer.aggregate_targets.map(&:user_project).compact).each do |proj|
@@ -160,16 +166,10 @@ post_integrate do |installer|
   pods_project = installer.pods_project
 
   # --- Remove the forbidden Hermes script (all pods, all user targets)
-  scrub = lambda { |proj|
-    proj.targets.each do |t|
-      t.build_phases.select { |p|
-        p.isa == 'PBXShellScriptBuildPhase' && p.name && forbidden_markers.any? { |m| p.name.include?(m) }
-      }.each { |p| t.build_phases.delete(p) }
-    end
-    proj.save
-  }
-  scrub.call(pods_project)
-  installer.aggregate_targets.each { |agg| scrub.call(agg.user_project) }
+  strip_hermes_replacement_scripts!(pods_project)
+  installer.aggregate_targets.each do |agg|
+    strip_hermes_replacement_scripts!(agg.user_project) if agg.user_project
+  end
 
   # Collect real Xcode projects (user app)
   user_projects = installer.aggregate_targets


### PR DESCRIPTION
## Summary
- ensure Hermes replacement scripts are always stripped in post-install and post-integrate hooks

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68b8e9cc788c8333b8cfa767d8c8b4e5

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/offLLM/66)
<!-- GitContextEnd -->

## Summary by Sourcery

Unconditionally remove Hermes "Replace Hermes" script phases in both post_install and post_integrate hooks, and adjust the CI guard for detecting leftover scripts.

Bug Fixes:
- Always strip Hermes replacement shell script phases in post_install and post_integrate instead of only when CI is exactly 'true'
- Relax the CI environment check for the final guard to any truthy ENV['CI'] value