### PR TITLE
fix(ios): scrub Hermes scripts in all pod projects

### DIFF
--- a/ios/Config/MyOfflineLLMApp.Debug.xcconfig
+++ b/ios/Config/MyOfflineLLMApp.Debug.xcconfig
@@ -2,7 +2,7 @@
 #include? "Auto/MLXFlags.xcconfig"
 
 // Local additions (kept minimal — most comes from Pods)
-HEADER_SEARCH_PATHS = $(inherited) $(SRCROOT)/build/generated/ios \
+HEADER_SEARCH_PATHS = "$(inherited)" "$(SRCROOT)/build/generated/ios" \
   "$(PODS_CONFIGURATION_BUILD_DIR)/ReactCommon/ReactCommon.framework/Headers" \
   "$(PODS_ROOT)/Headers/Public/ReactCommon" \
   "$(PODS_ROOT)/Headers/Public/React-Codegen" \

--- a/ios/Config/MyOfflineLLMApp.Debug.xcconfig
+++ b/ios/Config/MyOfflineLLMApp.Debug.xcconfig
@@ -1,7 +1,7 @@
 #include "Pods/Target Support Files/Pods-MyOfflineLLMApp/Pods-MyOfflineLLMApp.debug.xcconfig"
 #include? "Auto/MLXFlags.xcconfig"
 
-/* Local additions (kept minimal — most comes from Pods) */
+// Local additions (kept minimal — most comes from Pods)
 HEADER_SEARCH_PATHS = $(inherited) $(SRCROOT)/build/generated/ios \
   "$(PODS_CONFIGURATION_BUILD_DIR)/ReactCommon/ReactCommon.framework/Headers" \
   "$(PODS_ROOT)/Headers/Public/ReactCommon" \

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -161,7 +161,7 @@ end
 # and scrubs any Hermes "Replace Hermes" phases that may be (re)introduced.
 post_integrate do |installer|
   pods_projects = [installer.pods_project]
-  pods_projects += installer.generated_projects if installer.respond_to?(:generated_projects)
+  pods_projects += Array(installer.generated_projects) if installer.respond_to?(:generated_projects)
 
   # --- Remove the forbidden Hermes script (all pods, all user targets)
   pods_projects = [installer.pods_project]

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -166,6 +166,8 @@ post_integrate do |installer|
   # --- Remove the forbidden Hermes script (all pods, all user targets)
   pods_projects = [installer.pods_project]
   pods_projects += Array(installer.generated_projects) if installer.respond_to?(:generated_projects)
+  pods_projects.each { |proj| strip_hermes_replacement_scripts!(proj) }
+  installer.aggregate_targets.each do |agg|
     strip_hermes_replacement_scripts!(agg.user_project) if agg.user_project
   end
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -86,7 +86,7 @@ post_install do |installer|
 
   # Pods project(s)
   pods_projects = [installer.pods_project]
-  pods_projects += installer.generated_projects if installer.respond_to?(:generated_projects)
+  pods_projects += Array(installer.generated_projects) if installer.respond_to?(:generated_projects)
   pods_projects.each do |proj|
     proj.targets.each do |t|
       scrub_cp_filelists_from_target(t)

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -92,10 +92,6 @@ post_install do |installer|
       scrub_cp_filelists_from_target(t)
       t.build_configurations.each do |cfg|
         cfg.build_settings['ENABLE_USER_SCRIPT_SANDBOXING'] = 'NO'
-        current = cfg.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] || '0'
-        if Gem::Version.new(current) < Gem::Version.new('18.0')
-          cfg.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '18.0'
-        end
         if cfg.name.include?('Debug')
           # SwiftUI previews expect no optimization in debug builds
           cfg.build_settings['SWIFT_OPTIMIZATION_LEVEL'] = '-Onone'

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -141,7 +141,8 @@ post_install do |installer|
   end
 
   # Remove Hermes "Replace Hermes" script phases from all projects
-  all_projects = pods_projects + installer.aggregate_targets.map(&:user_project).compact
+  all_projects = (pods_projects + installer.aggregate_targets.map(&:user_project).compact)
+    .uniq { |p| p.path.to_s }
   all_projects.each { |proj| strip_hermes_replacement_scripts!(proj) }
 
   # Mark [CP] phases without I/O as always out-of-date to silence warnings

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -164,8 +164,8 @@ post_integrate do |installer|
   pods_projects += installer.generated_projects if installer.respond_to?(:generated_projects)
 
   # --- Remove the forbidden Hermes script (all pods, all user targets)
-  pods_projects.each { |proj| strip_hermes_replacement_scripts!(proj) }
-  installer.aggregate_targets.each do |agg|
+  pods_projects = [installer.pods_project]
+  pods_projects += Array(installer.generated_projects) if installer.respond_to?(:generated_projects)
     strip_hermes_replacement_scripts!(agg.user_project) if agg.user_project
   end
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -84,47 +84,52 @@ post_install do |installer|
     end
   end
 
-  # Pods project
-  installer.pods_project.targets.each do |t|
-    scrub_cp_filelists_from_target(t)
-    t.build_configurations.each do |cfg|
-      cfg.build_settings['ENABLE_USER_SCRIPT_SANDBOXING'] = 'NO'
-      current = cfg.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] || '0'
-      if Gem::Version.new(current) < Gem::Version.new('18.0')
-        cfg.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '18.0'
-      end
-      if cfg.name.include?('Debug')
-        # SwiftUI previews expect no optimization in debug builds
-        cfg.build_settings['SWIFT_OPTIMIZATION_LEVEL'] = '-Onone'
-        cfg.build_settings['SWIFT_COMPILATION_MODE'] = 'singlefile'
-      else
-        cfg.build_settings['SWIFT_OPTIMIZATION_LEVEL'] ||= '-O'
-      end
+  # Pods project(s)
+  pods_projects = [installer.pods_project]
+  pods_projects += installer.generated_projects if installer.respond_to?(:generated_projects)
+  pods_projects.each do |proj|
+    proj.targets.each do |t|
+      scrub_cp_filelists_from_target(t)
+      t.build_configurations.each do |cfg|
+        cfg.build_settings['ENABLE_USER_SCRIPT_SANDBOXING'] = 'NO'
+        current = cfg.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] || '0'
+        if Gem::Version.new(current) < Gem::Version.new('18.0')
+          cfg.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '18.0'
+        end
+        if cfg.name.include?('Debug')
+          # SwiftUI previews expect no optimization in debug builds
+          cfg.build_settings['SWIFT_OPTIMIZATION_LEVEL'] = '-Onone'
+          cfg.build_settings['SWIFT_COMPILATION_MODE'] = 'singlefile'
+        else
+          cfg.build_settings['SWIFT_OPTIMIZATION_LEVEL'] ||= '-O'
+        end
 
-      # Ensure mixed C++ headers compile under gnu++17 and Swift 5
-      cfg.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] ||= 'gnu++17'
-      cfg.build_settings['SWIFT_VERSION'] ||= '5.0'
+        # Ensure mixed C++ headers compile under gnu++17 and Swift 5
+        cfg.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] ||= 'gnu++17'
+        cfg.build_settings['SWIFT_VERSION'] ||= '5.0'
 
-      # ReactCommon's TurboModule core needs bridging headers like <react/bridging/EventEmitter.h>
-      if t.name == 'ReactCommon'
-        # Allow <react/…> includes to resolve without header maps
-        paths = Array(cfg.build_settings['HEADER_SEARCH_PATHS'] || '$(inherited)')
-        paths += [
-          '$(PODS_ROOT)/Headers/Public/ReactCommon',
-          '$(PODS_ROOT)/Headers/Private/ReactCommon',
-          '$(PODS_TARGET_SRCROOT)',
-          '$(PODS_TARGET_SRCROOT)/react',
-          '$(PODS_TARGET_SRCROOT)/react/bridging',
-          # Reach into node_modules for bridging headers when not copied into the sandbox
-          # Node modules live one level above ios/, so we need ../../ to reach them
-          '$(PODS_ROOT)/../../node_modules/react-native/ReactCommon',
-          '$(PODS_ROOT)/../../node_modules/react-native/ReactCommon/react/bridging'
-        ]
-        cfg.build_settings['HEADER_SEARCH_PATHS'] = paths.uniq
-        # Disable header maps so the compiler consults our explicit search paths
-        cfg.build_settings['USE_HEADERMAP'] = 'NO'
+        # ReactCommon's TurboModule core needs bridging headers like <react/bridging/EventEmitter.h>
+        if t.name == 'ReactCommon'
+          # Allow <react/…> includes to resolve without header maps
+          paths = Array(cfg.build_settings['HEADER_SEARCH_PATHS'] || '$(inherited)')
+          paths += [
+            '$(PODS_ROOT)/Headers/Public/ReactCommon',
+            '$(PODS_ROOT)/Headers/Private/ReactCommon',
+            '$(PODS_TARGET_SRCROOT)',
+            '$(PODS_TARGET_SRCROOT)/react',
+            '$(PODS_TARGET_SRCROOT)/react/bridging',
+            # Reach into node_modules for bridging headers when not copied into the sandbox
+            # Node modules live one level above ios/, so we need ../../ to reach them
+            '$(PODS_ROOT)/../../node_modules/react-native/ReactCommon',
+            '$(PODS_ROOT)/../../node_modules/react-native/ReactCommon/react/bridging'
+          ]
+          cfg.build_settings['HEADER_SEARCH_PATHS'] = paths.uniq
+          # Disable header maps so the compiler consults our explicit search paths
+          cfg.build_settings['USE_HEADERMAP'] = 'NO'
+        end
       end
     end
+    proj.save
   end
 
   # User (app) project(s)
@@ -140,13 +145,11 @@ post_install do |installer|
   end
 
   # Remove Hermes "Replace Hermes" script phases from all projects
-  strip_hermes_replacement_scripts!(installer.pods_project)
-  installer.aggregate_targets.each do |agg|
-    strip_hermes_replacement_scripts!(agg.user_project) if agg.user_project
-  end
+  all_projects = pods_projects + installer.aggregate_targets.map(&:user_project).compact
+  all_projects.each { |proj| strip_hermes_replacement_scripts!(proj) }
 
   # Mark [CP] phases without I/O as always out-of-date to silence warnings
-  ([installer.pods_project] + installer.aggregate_targets.map(&:user_project).compact).each do |proj|
+  all_projects.each do |proj|
     proj.targets.each do |t|
       t.build_phases
         .select { |p| p.isa == 'PBXShellScriptBuildPhase' && p.name&.start_with?('[CP]') }
@@ -156,17 +159,16 @@ post_install do |installer|
     end
     proj.save
   end
-
-  installer.pods_project.save
 end
 
 # Silences "will be run during every build" warnings for shell phases with no I/O,
 # and scrubs any Hermes "Replace Hermes" phases that may be (re)introduced.
 post_integrate do |installer|
-  pods_project = installer.pods_project
+  pods_projects = [installer.pods_project]
+  pods_projects += installer.generated_projects if installer.respond_to?(:generated_projects)
 
   # --- Remove the forbidden Hermes script (all pods, all user targets)
-  strip_hermes_replacement_scripts!(pods_project)
+  pods_projects.each { |proj| strip_hermes_replacement_scripts!(proj) }
   installer.aggregate_targets.each do |agg|
     strip_hermes_replacement_scripts!(agg.user_project) if agg.user_project
   end
@@ -178,7 +180,7 @@ post_integrate do |installer|
     .uniq { |p| p.path.to_s }
 
   # Mark [CP] phases without I/O as always out-of-date to silence Xcode warnings
-  ([pods_project] + user_projects).each do |proj|
+  (pods_projects + user_projects).each do |proj|
     proj.targets.each do |t|
       t.build_phases
         .select { |p| p.isa == 'PBXShellScriptBuildPhase' && p.name&.start_with?('[CP]') }
@@ -192,7 +194,7 @@ post_integrate do |installer|
   # --- Guard: fail if any Hermes replacement script remains
   if ENV['CI']
     offending = []
-    ([pods_project] + user_projects).each do |proj|
+    (pods_projects + user_projects).each do |proj|
       proj.targets.each do |t|
         t.build_phases.select { |p| p.isa == 'PBXShellScriptBuildPhase' }.each do |phase|
           name = (phase.name || '').downcase


### PR DESCRIPTION
### **User description**
## Summary
- clean up Hermes "Replace Hermes" script phases across all CocoaPods projects
- mark [CP] phases without I/O as always out-of-date in generated pod projects

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68b8ed33105c833392edd2dd471b8f42


___

### **PR Type**
Bug fix


___

### **Description**
- Extend Hermes script cleanup to all pod projects

- Include generated projects in build configuration updates

- Consolidate project processing logic for consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Single pods_project"] --> B["All pods projects array"]
  B --> C["Include generated_projects"]
  C --> D["Apply scrub_cp_filelists_from_target"]
  C --> E["Apply strip_hermes_replacement_scripts"]
  C --> F["Mark CP phases as out-of-date"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Podfile</strong><dd><code>Extend CocoaPods processing to all projects</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ios/Podfile

<ul><li>Replace single <code>installer.pods_project</code> with array including generated <br>projects<br> <li> Consolidate project processing logic using <code>all_projects</code> variable<br> <li> Apply Hermes script cleanup and build settings to all pod projects<br> <li> Ensure consistent handling across <code>post_install</code> and <code>post_integrate</code> <br>hooks</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/offLLM/pull/67/files#diff-281ded35b124f5160d0a57e47e521ee6f49f233933e091a0d33f3fd42a74abc8">+51/-49</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

## Summary by Sourcery

Extend Podfile hooks to uniformly clean Hermes scripts and update build settings across all CocoaPods projects (including generated ones) and mark [CP] script phases without I/O as always out-of-date to suppress Xcode warnings.

Bug Fixes:
- Remove the Hermes "Replace Hermes" script phase from all core, generated, and user projects in post_install and post_integrate hooks
- Mark [CP] shell script build phases without I/O as always out-of-date across all projects to silence build warnings

Enhancements:
- Consolidate CocoaPods project iteration to handle installer.pods_project and installer.generated_projects together
- Apply uniform build setting adjustments to all pod targets, including disabling script sandboxing, enforcing iOS 18.0 deployment, setting Swift/C++ standards, and adding ReactCommon header search paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved iOS setup with full multi-project CocoaPods support.
  - Applies sensible default build settings (Swift/Clang) and ReactCommon header paths to reduce configuration friction.

- Bug Fixes
  - More reliable removal of Hermes replacement scripts and CocoaPods phase checks across all related projects, reducing unexpected build failures locally and in CI.

- Chores
  - Standardizes iOS deployment target to 18.0 where lower, ensuring consistent builds.
  - Refactors post-install/integrate flows to operate across all discovered projects and persist settings consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->