### PR TITLE
fix: raise pod deployment target and harden report snapshot

### DIFF
--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -84,8 +84,8 @@ jobs:
         run: |
           ts=$(date +%Y%m%d-%H%M%S)
           mkdir -p ci-reports/$ts
-          cp reports/REPORT.md ci-reports/$ts/
-          cp reports/report_agent.md ci-reports/$ts/
+          [ -f reports/REPORT.md ] && cp reports/REPORT.md ci-reports/$ts/
+          [ -f reports/report_agent.md ] && cp reports/report_agent.md ci-reports/$ts/
           [ -f build/xcodebuild.log ] && cp build/xcodebuild.log ci-reports/$ts/
           [ -d build/MyOfflineLLMApp.xcresult ] && ln -sf ../../build/MyOfflineLLMApp.xcresult ci-reports/$ts/MyOfflineLLMApp.xcresult
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
-# Ensure pods support iOS 12.0+; the app's deployment target lives in project.yml
-platform :ios, '12.0'
+# Ensure pods support iOS 18.0+; the app's deployment target lives in project.yml
+platform :ios, '18.0'
 ENV['RCT_NEW_ARCH_ENABLED'] = "1" # Enable Fabric/TurboModules
 
 # Include React Native's CocoaPods helpers
@@ -109,7 +109,7 @@ post_install do |installer|
         cfg.build_settings['SWIFT_VERSION'] ||= '5.0'
 
         # Bump any low deployment targets to avoid "IPHONEOS_DEPLOYMENT_TARGET" errors.
-        min_target = Gem::Version.new('12.0')
+        min_target = Gem::Version.new('18.0')
         current = Gem::Version.new(cfg.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] || '0')
         cfg.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = min_target.to_s if current < min_target
 


### PR DESCRIPTION
## Summary
- raise iOS pods deployment target to 18.0
- guard CI report snapshot step when reports are missing

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`
- `cd ios && bundle exec pod install --repo-update --allow-root` *(fails: No .xcodeproj found)*

------
https://chatgpt.com/codex/tasks/task_e_68b90fd076208333b7fd0e1732c66fbe

## Summary by Sourcery

Bump iOS Pod deployment target to 18.0 and harden the CI report snapshot step with file existence checks.

Bug Fixes:
- Increase CocoaPods platform iOS deployment target to 18.0 in Podfile and post_install script
- Guard copying of CI report files in ios-unsigned workflow by checking file existence before copying