### PR TITLE
fix(ios): scrub CP file list paths

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -162,8 +162,6 @@ post_integrate do |installer|
   pods_projects += Array(installer.generated_projects) if installer.respond_to?(:generated_projects)
 
   # --- Remove the forbidden Hermes script (all pods, all user targets)
-  pods_projects = [installer.pods_project]
-  pods_projects += Array(installer.generated_projects) if installer.respond_to?(:generated_projects)
   pods_projects.each { |proj| strip_hermes_replacement_scripts!(proj) }
   installer.aggregate_targets.each do |agg|
     strip_hermes_replacement_scripts!(agg.user_project) if agg.user_project

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -78,6 +78,8 @@ post_install do |installer|
       begin
         phase.input_paths = [] if phase.respond_to?(:input_paths=)
         phase.output_paths = [] if phase.respond_to?(:output_paths=)
+        phase.input_file_list_paths = [] if phase.respond_to?(:input_file_list_paths=)
+        phase.output_file_list_paths = [] if phase.respond_to?(:output_file_list_paths=)
       rescue => e
         puts "WARN: Skipping scrub for phase #{phase.name}: #{e}"
       end


### PR DESCRIPTION
## Summary
- clear input/output file list paths for all `[CP]` script phases
- reduce PhaseScriptExecution failures when using static CocoaPods

## Testing
- `npm test`
- `test -f eslint.config.js && npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68b91421ccd483339ca79f5cf1969774

## Summary by Sourcery

Scrub CocoaPods script phases in the iOS Podfile by clearing input and output file list paths to reduce PhaseScriptExecution failures when using static pods.

Bug Fixes:
- Clear input_file_list_paths for all [CP] script phases if available
- Clear output_file_list_paths for all [CP] script phases if available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved iOS build configuration to more thoroughly clean copy-phase file lists during installation, clearing stale input/output file-list entries where applicable.
  - Removed redundant project reinitialization during integration to streamline post-install steps and slightly speed up/clarify the cleanup of build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->