### PR TITLE
fix(ios): strip Hermes script phases from pod projects

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -69,7 +69,10 @@ def strip_hermes_replacement_scripts!(project)
               (p.shell_script || '').downcase.include?(m)
           end
       end
-      .each { |p| t.build_phases.delete(p) }
+      .each do |p|
+        t.build_phases.delete(p)
+        p.remove_from_project
+      end
   end
   project.save
 end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -74,6 +74,16 @@ def strip_hermes_replacement_scripts!(project)
   project.save
 end
 
+def pods_projects_for(installer)
+  pods = [installer.pods_project]
+  pods.concat(Array(installer.generated_projects)) if installer.respond_to?(:generated_projects)
+  pods.compact
+end
+
+def user_projects_for(installer)
+  installer.aggregate_targets.map(&:user_project).compact.uniq { |p| p.path.to_s }
+end
+
 post_install do |installer|
   react_native_post_install(installer) if defined?(react_native_post_install)
 
@@ -96,9 +106,8 @@ post_install do |installer|
   end
 
   # Collect all Pods and user projects
-  pod_project_paths = Dir.glob(File.join(installer.sandbox.root.to_s, '**/*.xcodeproj'))
-  pods_projects = pod_project_paths.map { |p| Xcodeproj::Project.open(p) }
-  user_projects = installer.aggregate_targets.map(&:user_project).compact
+  pods_projects = pods_projects_for(installer)
+  user_projects = user_projects_for(installer)
   all_projects = (pods_projects + user_projects).uniq { |p| p.path.to_s }
 
   # Scrub CI-unfriendly settings from every target
@@ -167,12 +176,8 @@ end
 # Silences "will be run during every build" warnings for shell phases with no I/O,
 # and scrubs any Hermes "Replace Hermes" phases that may be (re)introduced.
 post_integrate do |installer|
-  pod_project_paths = Dir.glob(File.join(installer.sandbox.root.to_s, '**/*.xcodeproj'))
-  pods_projects = pod_project_paths.map { |p| Xcodeproj::Project.open(p) }
-  user_projects = installer.aggregate_targets
-    .select { |agg| agg.respond_to?(:user_project) && agg.user_project }
-    .map(&:user_project)
-    .uniq { |p| p.path.to_s }
+  pods_projects = pods_projects_for(installer)
+  user_projects = user_projects_for(installer)
 
   # --- Remove the forbidden Hermes script (all pods, all user targets)
   (pods_projects + user_projects).each { |proj| strip_hermes_replacement_scripts!(proj) }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -51,14 +51,23 @@ target app_target do
 end
 
 # ---- Hermes Fix 2: Remove "Replace Hermes" script phases everywhere ----
-FORBIDDEN_HERMES_MARKERS = ['Replace Hermes', 'Replace Hermes for the right configuration'].freeze
+# Include both the explicit "Replace Hermes" scripts and any stray phases
+# named with bracketed [Hermes] tags.
+FORBIDDEN_HERMES_MARKERS = [
+  'replace hermes',
+  'replace hermes for the right configuration',
+  '[hermes]'
+].freeze
 
 def strip_hermes_replacement_scripts!(project)
   project.targets.each do |t|
     t.build_phases
       .select do |p|
         p.isa == 'PBXShellScriptBuildPhase' &&
-          FORBIDDEN_HERMES_MARKERS.any? { |m| (p.name || '').include?(m) || (p.shell_script || '').include?(m) }
+          FORBIDDEN_HERMES_MARKERS.any? do |m|
+            (p.name || '').downcase.include?(m) ||
+              (p.shell_script || '').downcase.include?(m)
+          end
       end
       .each { |p| t.build_phases.delete(p) }
   end
@@ -87,8 +96,8 @@ post_install do |installer|
   end
 
   # Collect all Pods and user projects
-  pods_projects = [installer.pods_project]
-  pods_projects += Array(installer.generated_projects) if installer.respond_to?(:generated_projects)
+  pod_project_paths = Dir.glob(File.join(installer.sandbox.root.to_s, '**/*.xcodeproj'))
+  pods_projects = pod_project_paths.map { |p| Xcodeproj::Project.open(p) }
   user_projects = installer.aggregate_targets.map(&:user_project).compact
   all_projects = (pods_projects + user_projects).uniq { |p| p.path.to_s }
 
@@ -158,20 +167,15 @@ end
 # Silences "will be run during every build" warnings for shell phases with no I/O,
 # and scrubs any Hermes "Replace Hermes" phases that may be (re)introduced.
 post_integrate do |installer|
-  pods_projects = [installer.pods_project]
-  pods_projects += Array(installer.generated_projects) if installer.respond_to?(:generated_projects)
-
-  # --- Remove the forbidden Hermes script (all pods, all user targets)
-  pods_projects.each { |proj| strip_hermes_replacement_scripts!(proj) }
-  installer.aggregate_targets.each do |agg|
-    strip_hermes_replacement_scripts!(agg.user_project) if agg.user_project
-  end
-
-  # Collect real Xcode projects (user app)
+  pod_project_paths = Dir.glob(File.join(installer.sandbox.root.to_s, '**/*.xcodeproj'))
+  pods_projects = pod_project_paths.map { |p| Xcodeproj::Project.open(p) }
   user_projects = installer.aggregate_targets
     .select { |agg| agg.respond_to?(:user_project) && agg.user_project }
     .map(&:user_project)
     .uniq { |p| p.path.to_s }
+
+  # --- Remove the forbidden Hermes script (all pods, all user targets)
+  (pods_projects + user_projects).each { |proj| strip_hermes_replacement_scripts!(proj) }
 
   # Mark [CP] phases without I/O as always out-of-date to silence Xcode warnings
   (pods_projects + user_projects).each do |proj|
@@ -193,7 +197,7 @@ post_integrate do |installer|
         t.build_phases.select { |p| p.isa == 'PBXShellScriptBuildPhase' }.each do |phase|
           name = (phase.name || '').downcase
           body = (phase.shell_script || '').downcase
-          offending << "#{proj.path.basename} :: #{t.name} :: #{phase.name}" if name.include?('replace hermes') || body.include?('replace hermes')
+          offending << "#{proj.path.basename} :: #{t.name} :: #{phase.name}" if FORBIDDEN_HERMES_MARKERS.any? { |m| name.include?(m) || body.include?(m) }
         end
       end
     end

--- a/scripts/strip_hermes_phase.rb
+++ b/scripts/strip_hermes_phase.rb
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
 require 'xcodeproj'
 
-MARKERS = ['replace hermes'].freeze
+# Match both the explicit "Replace Hermes" phase and any stray phases tagged
+# with bracketed [Hermes] names.
+MARKERS = ['replace hermes', '[hermes]'].freeze
 
 def scrub_project(path)
   project = Xcodeproj::Project.open(path)
@@ -19,7 +21,15 @@ def scrub_project(path)
   puts "[strip_hermes_phase] #{File.basename(path)}: #{changed ? 'removed phases' : 'nothing to remove'}"
 end
 
-ARGV.each do |proj|
+paths = ARGV.flat_map do |proj|
+  if File.directory?(proj)
+    Dir.glob(File.join(proj, '**/*.xcodeproj'))
+  else
+    proj
+  end
+end
+
+paths.each do |proj|
   if File.exist?(proj)
     scrub_project(proj)
   else

--- a/scripts/strip_hermes_phase.rb
+++ b/scripts/strip_hermes_phase.rb
@@ -14,6 +14,7 @@ def scrub_project(path)
         MARKERS.any? { |m| ((p.name || '') + (p.shell_script || '')).downcase.include?(m) }
     end.each do |p|
       t.build_phases.delete(p)
+      p.remove_from_project
       changed = true
     end
   end


### PR DESCRIPTION
## Summary
- ensure Podfile scrubs `[Hermes] Replace Hermes` phases from every pods project
- harden strip_hermes_phase.rb to catch bracketed Hermes phases and directories

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68b91e985fd08333aa13770a052f5893

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/offLLM/71)
<!-- GitContextEnd -->

## Summary by Sourcery

Harden Hermes script-phase stripping by improving marker detection, broadening project discovery in Podfile hooks, and extending the standalone strip_hermes_phase.rb script to handle directory inputs and nested projects.

Enhancements:
- Expand forbidden Hermes markers to include case-insensitive names and bracketed '[hermes]' tags
- Glob all .xcodeproj files in the CocoaPods sandbox for both post_install and post_integrate hooks
- Allow strip_hermes_phase.rb to accept directories and recursively locate and scrub nested Xcode projects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - New project discovery helpers and a scrubber to clean CP-related file lists across projects.

- Bug Fixes
  - More robust removal of Hermes-related build phases and warnings for leftover phases.
  - Cleans copy-phase file lists to reduce build issues.

- Refactor
  - Reworked project collection and post-install/post-integrate workflows.
  - Adjusted header search handling and disabled header maps.

- Chores
  - Raised minimum iOS deployment target to 18.0.
  - Standardized Swift/C++ build settings and disabled user script sandboxing.

- Documentation
  - Clarified supported Hermes markers (including lowercase and bracketed forms).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->