### PR TITLE
fix(ios): ensure workspace exists before build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,6 +44,19 @@ cd ios && bundle install && cd ..
 echo "📱 Generating Xcode project and installing CocoaPods..."
 cd ios && xcodegen generate && bundle exec pod install --repo-update && cd ..
 
+# Ensure the Xcode workspace exists before attempting to build.
+# If the initial pod install failed to produce it (e.g. due to a flaky
+# environment), retry once and bail out with a clear error message.
+if [ ! -d "$WORKSPACE" ]; then
+  echo "⚠️ Workspace not found at $WORKSPACE; rerunning CocoaPods install..."
+  (cd ios && bundle exec pod install --repo-update)
+fi
+
+if [ ! -d "$WORKSPACE" ]; then
+  echo "❌ Error: Xcode workspace still missing at $WORKSPACE"
+  exit 1
+fi
+
 # Step 4: Run the Xcode build (Simulator, unsigned)
 echo "📦 Building for iOS Simulator (unsigned)..."
 xcodebuild build \


### PR DESCRIPTION
## Summary
- retry CocoaPods install if the iOS workspace is missing

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68b975c66a9c8333837744475a429f98