### PR TITLE
fix(ci): use macOS base64 flag

### DIFF
--- a/.github/workflows/ios-signed.yml
+++ b/.github/workflows/ios-signed.yml
@@ -48,8 +48,8 @@ jobs:
           BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
-          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o "$RUNNER_TEMP/certificate.p12"
-          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o "$RUNNER_TEMP/profile.mobileprovision"
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 -D -o "$RUNNER_TEMP/certificate.p12"
+          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 -D -o "$RUNNER_TEMP/profile.mobileprovision"
 
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$RUNNER_TEMP/build.keychain"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$RUNNER_TEMP/build.keychain"
@@ -81,7 +81,7 @@ jobs:
         env:
           EXPORT_OPTIONS_PLIST: ${{ secrets.EXPORT_OPTIONS_PLIST }}
         run: |
-          echo -n "$EXPORT_OPTIONS_PLIST" | base64 --decode -o "$RUNNER_TEMP/ExportOptions.plist"
+          echo -n "$EXPORT_OPTIONS_PLIST" | base64 -D -o "$RUNNER_TEMP/ExportOptions.plist"
           xcodebuild -exportArchive \
                      -archivePath "$RUNNER_TEMP/Actions.xcarchive" \
                      -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist" \


### PR DESCRIPTION
## Summary
- use macOS-compatible `base64 -D` flag for certificate, profile, and export option decoding in iOS signed workflow

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68ba24b566f883338fb5ee9c8517fa75