### PR TITLE
feat(debug): add logging console & CI result bundle

### DIFF
--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -117,6 +117,7 @@ jobs:
             -sdk iphoneos \
             -arch arm64 \
             -derivedDataPath "$DERIVED_DATA" \
+            -resultBundlePath "$DERIVED_DATA/ResultBundle.xcresult" \
             CODE_SIGNING_ALLOWED=NO \
             build | xcpretty && exit ${PIPESTATUS[0]}
 
@@ -134,4 +135,12 @@ jobs:
         with:
           name: xcode-logs
           path: artifacts/xcode-log
+          if-no-files-found: ignore
+
+      - name: Upload result bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xcode-result-bundle
+          path: ${{ env.DERIVED_DATA }}/ResultBundle.xcresult
           if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,13 @@
 - `test -f eslint.config.mjs && npm run lint || echo "lint skipped: no eslint.config.mjs"`
 - Run `npm run format:check`.
 
+## Logging & Debugging
+
+- Enable file logging by setting `DEBUG_LOGGING=1` in the env (via `react-native-config`).
+- Logs are written under `logs/` in the app's document directory (`logs/app.log`).
+- Open the in-app Debug Console (dev builds or `DEBUG_PANEL=1`) to view, copy, share, or clear logs.
+- Attach `app.log` when filing issues to aid triage.
+
 ## CI Playbook
 
 - `ios-unsigned.yml` workflow: xcodegen → pod install → unsigned simulator build → uploads `offLLM-unsigned-ipa` artifact.

--- a/__mocks__/react-native-config.js
+++ b/__mocks__/react-native-config.js
@@ -1,0 +1,1 @@
+module.exports = { DEBUG_LOGGING: "0" };

--- a/__mocks__/react-native-fs.js
+++ b/__mocks__/react-native-fs.js
@@ -1,0 +1,9 @@
+module.exports = {
+  DocumentDirectoryPath: "/tmp",
+  mkdir: jest.fn(() => Promise.resolve()),
+  stat: jest.fn(() => Promise.reject(new Error("no file"))),
+  appendFile: jest.fn(() => Promise.resolve()),
+  unlink: jest.fn(() => Promise.resolve()),
+  moveFile: jest.fn(() => Promise.resolve()),
+  readFile: jest.fn(() => Promise.resolve("")),
+};

--- a/__tests__/logger.test.ts
+++ b/__tests__/logger.test.ts
@@ -1,0 +1,45 @@
+import RNFS from "react-native-fs";
+import Config from "react-native-config";
+import { Logger } from "../src/utils/logger";
+
+describe("Logger", () => {
+  beforeEach(() => {
+    Logger.setFileSink(false);
+    Logger.setLevel("debug");
+    Logger.clear();
+    jest.clearAllMocks();
+  });
+
+  it("filters debug when level info", async () => {
+    Logger.setLevel("info");
+    await Logger.debug("T", "hidden");
+    const tail = await Logger.tail();
+    expect(tail).toBe("");
+  });
+
+  it("maintains ring buffer cap", async () => {
+    for (let i = 0; i < 600; i++) {
+      await Logger.info("T", `msg${i}`);
+    }
+    const tail = await Logger.tail(600);
+    const lines = tail.split("\n").filter(Boolean);
+    expect(lines.length).toBe(500);
+    expect(lines[0]).toBe("[T] msg100");
+    expect(lines[lines.length - 1]).toBe("[T] msg599");
+  });
+
+  it("rotates file when size exceeds 1MB", async () => {
+    // enable file sink
+    (Config as any).DEBUG_LOGGING = "1";
+    Logger.setFileSink(true);
+    (RNFS.stat as any).mockResolvedValueOnce({ size: 1024 * 1024 + 1 });
+    await Logger.info("T", "rotate");
+    // allow async flush
+    await new Promise(setImmediate);
+    expect(RNFS.moveFile).toHaveBeenCalled();
+  });
+
+  it("native forward no-op when bridge missing", async () => {
+    await expect(Logger.error("T", "msg")).resolves.toBeUndefined();
+  });
+});

--- a/ios/MyOfflineLLMApp/Logging.swift
+++ b/ios/MyOfflineLLMApp/Logging.swift
@@ -1,0 +1,25 @@
+import Foundation
+import os
+import React
+
+@objc(Logging)
+class Logging: NSObject, RCTBridgeModule {
+  static func moduleName() -> String! { "Logging" }
+  static func requiresMainQueueSetup() -> Bool { false }
+
+  @objc func log(_ level: String, tag: String, message: String) {
+    let logger = os.Logger(subsystem: "com.27pm.monGARS", category: tag)
+    switch level {
+    case "debug":
+      logger.debug("\(message, privacy: .public)")
+    case "info":
+      logger.info("\(message, privacy: .public)")
+    case "warn":
+      logger.warning("\(message, privacy: .public)")
+    case "error":
+      logger.error("\(message, privacy: .public)")
+    default:
+      logger.log("\(message, privacy: .public)")
+    }
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,4 +6,5 @@ module.exports = {
   coverageThreshold: {
     global: { lines: 40 },
   },
+  setupFiles: ["<rootDir>/jest.setup.js"],
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,4 @@
+global.__DEV__ = false;
+jest.mock("react-native-fs");
+jest.mock("react-native-config");
+jest.mock("./src/utils/NativeLogger", () => ({}));

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
+/* global __DEV__ */
 import {
   View,
   Text,
   ActivityIndicator,
   StyleSheet,
   Platform,
+  Button,
 } from "react-native";
 import LLMService from "./services/llmService";
 import { ensureModelDownloaded } from "./utils/modelDownloader";
@@ -41,6 +43,7 @@ import {
 import { PluginManager } from "./architecture/pluginManager";
 import { DependencyInjector } from "./architecture/dependencyInjector";
 import ChatInterface from "./components/ChatInterface";
+import DebugConsole from "./debug/DebugConsole";
 import { useSpeechRecognition } from "./hooks/useSpeechRecognition";
 import { useChat } from "./hooks/useChat";
 import useLLMStore from "./store/llmStore";
@@ -49,6 +52,7 @@ function App() {
   const [initialized, setInitialized] = useState(false);
   const [error, setError] = useState(null);
   const [input, setInput] = useState("");
+  const [showDebug, setShowDebug] = useState(false);
   const { send } = useChat();
   const { messages } = useLLMStore();
   const { isRecording, start } = useSpeechRecognition(send, (err) =>
@@ -137,14 +141,27 @@ function App() {
   }
 
   return (
-    <ChatInterface
-      messages={messages}
-      input={input}
-      onInputChange={setInput}
-      onSend={() => handleSend()}
-      isRecording={isRecording}
-      onMicPress={start}
-    />
+    <>
+      <ChatInterface
+        messages={messages}
+        input={input}
+        onInputChange={setInput}
+        onSend={() => handleSend()}
+        isRecording={isRecording}
+        onMicPress={start}
+      />
+      {(__DEV__ || process.env.DEBUG_PANEL === "1") && (
+        <>
+          <DebugConsole
+            visible={showDebug}
+            onClose={() => setShowDebug(false)}
+          />
+          <View style={styles.debugButton}>
+            <Button title="Debug" onPress={() => setShowDebug(true)} />
+          </View>
+        </>
+      )}
+    </>
   );
 }
 
@@ -156,6 +173,11 @@ const styles = StyleSheet.create({
   },
   loading: { marginTop: 20 },
   errorText: { color: "red" },
+  debugButton: {
+    position: "absolute",
+    bottom: 20,
+    right: 20,
+  },
 });
 
 export default App;

--- a/src/debug/DebugConsole.tsx
+++ b/src/debug/DebugConsole.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useState } from "react";
+import {
+  Modal,
+  View,
+  Text,
+  Button,
+  ScrollView,
+  StyleSheet,
+  Share,
+} from "react-native";
+import Clipboard from "@react-native-clipboard/clipboard";
+import { Logger } from "../utils/logger";
+import { useDebugSettings } from "./useDebugSettings";
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export default function DebugConsole({ visible, onClose }: Props) {
+  const [logs, setLogs] = useState("");
+  const { verbose, file, toggleVerbose, toggleFile } = useDebugSettings();
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setInterval>;
+    if (visible) {
+      const refresh = async () => {
+        const text = await Logger.tail();
+        setLogs(text);
+      };
+      refresh();
+      timer = setInterval(refresh, 1000);
+    }
+    return () => {
+      if (timer) clearInterval(timer);
+    };
+  }, [visible]);
+
+  const copy = () => Clipboard.setString(logs);
+  const share = async () => {
+    try {
+      await Share.share({ message: logs });
+    } catch {
+      copy();
+    }
+  };
+  const clear = async () => {
+    await Logger.clear();
+    setLogs("");
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <View style={styles.container}>
+        <ScrollView style={styles.scroll}>
+          <Text style={styles.logText}>{logs}</Text>
+        </ScrollView>
+        <View style={styles.buttons}>
+          <Button title="Copy" onPress={copy} />
+          <Button title="Share" onPress={share} />
+          <Button title="Clear" onPress={clear} />
+          <Button
+            title={verbose ? "Verbose" : "Quiet"}
+            onPress={toggleVerbose}
+          />
+          <Button title={file ? "File On" : "File Off"} onPress={toggleFile} />
+        </View>
+        <Button title="Close" onPress={onClose} />
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 8, backgroundColor: "white" },
+  scroll: { flex: 1, marginBottom: 8 },
+  logText: { fontFamily: "Courier", fontSize: 12 },
+  buttons: {
+    flexDirection: "row",
+    justifyContent: "space-around",
+    marginBottom: 8,
+  },
+});

--- a/src/debug/useDebugSettings.ts
+++ b/src/debug/useDebugSettings.ts
@@ -1,0 +1,29 @@
+import create from "zustand";
+import Config from "react-native-config";
+import { Logger } from "../utils/logger";
+
+declare const __DEV__: boolean;
+
+const DEBUG_LOGGING = Config.DEBUG_LOGGING === "1";
+
+export const useDebugSettings = create<{
+  verbose: boolean;
+  file: boolean;
+  toggleVerbose: () => void;
+  toggleFile: () => void;
+}>((set) => ({
+  verbose: __DEV__,
+  file: DEBUG_LOGGING,
+  toggleVerbose: () =>
+    set((state) => {
+      const next = !state.verbose;
+      Logger.setLevel(next ? "debug" : "info");
+      return { verbose: next };
+    }),
+  toggleFile: () =>
+    set((state) => {
+      const next = !state.file;
+      Logger.setFileSink(next);
+      return { file: next };
+    }),
+}));

--- a/src/utils/NativeLogger.ts
+++ b/src/utils/NativeLogger.ts
@@ -1,0 +1,12 @@
+import { NativeModules, Platform } from "react-native";
+
+export function logToNative(level: string, tag: string, message: string) {
+  try {
+    const mod: any = (NativeModules as any).Logging;
+    if (Platform.OS === "ios" && mod && typeof mod.log === "function") {
+      mod.log(level, tag, message);
+    }
+  } catch {
+    // ignore native failures
+  }
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,13 +1,105 @@
+import RNFS from "react-native-fs";
+import Config from "react-native-config";
+import { logToNative } from "./NativeLogger";
+
+declare const __DEV__: boolean;
+/* eslint-disable no-unused-vars */
+export enum LogLevel {
+  debug = 10,
+  info = 20,
+  warn = 30,
+  error = 40,
+}
+/* eslint-enable no-unused-vars */
+
+const DEBUG_LOGGING = Config.DEBUG_LOGGING === "1";
+const RING_SIZE = 500;
+const MAX_SIZE = 1024 * 1024; // ~1MB
+const logsDir = `${RNFS.DocumentDirectoryPath}/logs`;
+const activeLog = `${logsDir}/app.log`;
+const rotatedLog = `${logsDir}/app.log.1`;
+
 export class Logger {
-  static info(message: string): void {
-    console.log(`[INFO] ${message}`);
+  private static level: LogLevel = __DEV__ ? LogLevel.debug : LogLevel.info;
+  private static buffer: string[] = [];
+  private static fileSinkEnabled = DEBUG_LOGGING;
+
+  static setLevel(level: keyof typeof LogLevel): void {
+    this.level = LogLevel[level];
   }
 
-  static warn(message: string): void {
-    console.warn(`[WARN] ${message}`);
+  static setFileSink(enabled: boolean): void {
+    this.fileSinkEnabled = enabled;
   }
 
-  static error(message: string): void {
-    console.error(`[ERROR] ${message}`);
+  static async log(
+    level: keyof typeof LogLevel,
+    tag: string,
+    ...args: any[]
+  ): Promise<void> {
+    if (LogLevel[level] < this.level) return;
+    const line = `[${tag}] ${args.map(String).join(" ")}`;
+    const fn = console[level] || console.log;
+    fn(line);
+    this.buffer.push(line);
+    if (this.buffer.length > RING_SIZE) this.buffer.shift();
+    if (this.fileSinkEnabled) {
+      await this.writeToFile(line);
+    }
+    if (level === "warn" || level === "error") {
+      try {
+        logToNative?.(level, tag, line);
+      } catch {
+        // no-op
+      }
+    }
+  }
+
+  static debug(tag: string, ...args: any[]): Promise<void> {
+    return this.log("debug", tag, ...args);
+  }
+  static info(tag: string, ...args: any[]): Promise<void> {
+    return this.log("info", tag, ...args);
+  }
+  static warn(tag: string, ...args: any[]): Promise<void> {
+    return this.log("warn", tag, ...args);
+  }
+  static error(tag: string, ...args: any[]): Promise<void> {
+    return this.log("error", tag, ...args);
+  }
+
+  private static async writeToFile(line: string): Promise<void> {
+    try {
+      await RNFS.mkdir(logsDir);
+      const info = await RNFS.stat(activeLog).catch(() => null);
+      if (info && info.size > MAX_SIZE) {
+        await RNFS.unlink(rotatedLog).catch(() => {});
+        await RNFS.moveFile(activeLog, rotatedLog).catch(() => {});
+      }
+      await RNFS.appendFile(activeLog, line + "\n", "utf8");
+    } catch {
+      // swallow file errors
+    }
+  }
+
+  static async tail(n = 200): Promise<string> {
+    if (this.fileSinkEnabled) {
+      try {
+        const content = await RNFS.readFile(activeLog, "utf8");
+        const lines = content.split("\n");
+        return lines.slice(-n).join("\n");
+      } catch {
+        // fall back to buffer
+      }
+    }
+    return this.buffer.slice(-n).join("\n");
+  }
+
+  static async clear(): Promise<void> {
+    this.buffer = [];
+    if (this.fileSinkEnabled) {
+      await RNFS.unlink(activeLog).catch(() => {});
+      await RNFS.unlink(rotatedLog).catch(() => {});
+    }
   }
 }


### PR DESCRIPTION
## Summary
- capture and upload Xcode result bundle in iOS unsigned workflow
- introduce leveled JS logger with optional file sink, rotation and native os_log bridge
- add Debug Console screen with log tail, copy/share/clear and verbose toggle
- document debug logging usage in AGENTS

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`

## Checklist
- [x] npm test passes, including logger tests
- [x] npm run lint passes
- [x] npm run format:check passes
- [x] CI uploads xcode-result-bundle artifact
- [x] No manual Slider pods in Podfile
- [x] Debug Console allows toggling verbosity, tailing, copying and clearing logs


------
https://chatgpt.com/codex/tasks/task_e_68be40f3ddc483339a1436074da06f00