### PR TITLE
fix(ci): build and package iOS unsigned app reliably

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Upload APKs/AABs
         uses: actions/upload-artifact@v4
         with:
-          name: offLLM-android-artifacts
+          name: monGARS-android-artifacts
           path: |
             android/app/build/outputs/apk/release/**/*.apk
             android/app/build/outputs/bundle/release/**/*.aab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,18 +364,18 @@ jobs:
           rm -rf Payload
           mkdir -p Payload
           cp -R "$APP_PATH" Payload/
-          /usr/bin/zip -qry offLLM-unsigned.ipa Payload
-          /usr/bin/zip -qry MyOfflineLLMApp.app.zip "$APP_PATH"
+          /usr/bin/zip -qry monGARS-unsigned.ipa Payload
+          /usr/bin/zip -qry monGARS.app.zip "$APP_PATH"
 
       - name: Upload unsigned IPA & logs
         uses: actions/upload-artifact@v4
         with:
           name: ios-unsigned-ipa
           path: |
-            build/offLLM-unsigned.ipa
-            build/MyOfflineLLMApp.app.zip
+            build/monGARS-unsigned.ipa
+            build/monGARS.app.zip
             build/xcodebuild_ipa.log
-            build/MyOfflineLLMApp.xcarchive
-            build/MyOfflineLLMApp_ipa.xcresult
+            build/monGARS.xcarchive
+            build/monGARS_ipa.xcresult
           if-no-files-found: error
           compression-level: 6

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -155,15 +155,10 @@ jobs:
             -arch arm64 \
             -derivedDataPath "$DERIVED_DATA" \
             -resultBundlePath "$DERIVED_DATA/ResultBundle.xcresult" \
-            CODE_SIGNING_ALLOWED=NO \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGN_IDENTITY="" \
-            PROVISIONING_PROFILE_SPECIFIER="" \
-            SKIP_INSTALL=NO \
-            BUILD_LIBRARY_FOR_DISTRIBUTION=NO \
+            CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' \
+            PROVISIONING_PROFILE_SPECIFIER='' SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=NO \
             "OTHER_CFLAGS=-DOBJC_OLD_DISPATCH_PROTOTYPES=0" \
-            clean build \
-          | xcbeautify
+            build | xcbeautify
 
       - name: Package unsigned IPA from Release-iphoneos
         run: |
@@ -176,12 +171,12 @@ jobs:
             echo "::error title=Products dir missing::No Build/Products directory at $PRODUCTS_DIR (build may have failed earlier)."
             exit 1
           fi
-          APP_PATH="$(/usr/bin/find "$PRODUCTS_DIR" -type d -name '*.app' -print -quit || true)"
-          if [ -z "$APP_PATH" ]; then
+          APP_PATH="$PRODUCTS_DIR/Release-iphoneos/${XCODE_SCHEME}.app"
+          if [ ! -d "$APP_PATH" ]; then
             echo "::group::Debug: list of Build/Products"
             /bin/ls -lahR "$PRODUCTS_DIR" || true
             echo "::endgroup::"
-            echo "::error title=App not found::No .app found under $PRODUCTS_DIR (build may have failed earlier)."
+            echo "::error title=App not found::No app at $APP_PATH (build may have failed earlier)."
             exit 1
           fi
           mkdir -p build

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -144,50 +144,59 @@ jobs:
             /usr/bin/grep -E 'PRODUCT_NAME|WRAPPER_NAME|PRODUCT_BUNDLE_IDENTIFIER|PRODUCT_TYPE|CONFIGURATION_BUILD_DIR' || true
           echo "::endgroup::"
 
-      - name: Archive (unsigned, Release, iphoneos)
+      - name: Resolve SwiftPM dependencies
         env:
           XCODE_WORKSPACE: ios/${{ env.XCODE_PROJECT_NAME }}.xcworkspace
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for authenticated SPM fetches
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          ARCHIVE_PATH="build/App.xcarchive"
-          # Resolve packages explicitly for clearer logs
-          xcodebuild -resolvePackageDependencies \
-            -workspace "$XCODE_WORKSPACE" \
-            -scheme "$XCODE_SCHEME" | xcbeautify
-          # Create an unsigned archive targeting a generic iOS device
-          xcodebuild archive \
+          xcodebuild \
+            -resolvePackageDependencies \
             -workspace "$XCODE_WORKSPACE" \
             -scheme "$XCODE_SCHEME" \
             -configuration Release \
             -sdk iphoneos \
             -destination 'generic/platform=iOS' \
-            -archivePath "$ARCHIVE_PATH" \
+            -derivedDataPath "$DERIVED_DATA" \
+            -resultBundlePath "$DERIVED_DATA/ResultBundle.xcresult"
+
+      - name: Build (Release, iphoneos)
+        env:
+          XCODE_WORKSPACE: ios/${{ env.XCODE_PROJECT_NAME }}.xcworkspace
+        run: |
+          set -euo pipefail
+          xcodebuild \
+            -workspace "$XCODE_WORKSPACE" \
+            -scheme "$XCODE_SCHEME" \
+            -configuration Release \
+            -sdk iphoneos \
+            -destination 'generic/platform=iOS' \
+            -arch arm64 \
             -derivedDataPath "$DERIVED_DATA" \
             -resultBundlePath "$DERIVED_DATA/ResultBundle.xcresult" \
             CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' \
             PROVISIONING_PROFILE_SPECIFIER='' SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=NO \
             "OTHER_CFLAGS=-DOBJC_OLD_DISPATCH_PROTOTYPES=0" \
-            | xcbeautify
-      - name: Package unsigned IPA from archive
+            clean build | xcbeautify
+
+      - name: Package unsigned IPA from Release-iphoneos
         run: |
           set -euo pipefail
-          APP_DIR="build/App.xcarchive/Products/Applications"
-          FOUND_APP="$(/usr/bin/find "$APP_DIR" -maxdepth 1 -type d -name '*.app' -print -quit || true)"
-          if [ -z "$FOUND_APP" ]; then
-            echo "::group::Debug: list archive contents"
-            /bin/ls -lahR "build/App.xcarchive" || true
+          APP_PATH="$DERIVED_DATA/Build/Products/Release-iphoneos/${XCODE_SCHEME}.app"
+          if [ ! -d "$APP_PATH" ]; then
+            echo "::group::Debug: list of Build/Products"
+            /bin/ls -lahR "$DERIVED_DATA/Build/Products" || true
             echo "::endgroup::"
-            echo "::error title=App not found::No .app inside $APP_DIR (archive may have failed)."
+            echo "::error title=App not found::No .app found at $APP_PATH (build may have failed earlier)."
             exit 1
           fi
           mkdir -p build
           cd build
           rm -rf Payload
           mkdir -p Payload
-          cp -R "$FOUND_APP" Payload/
+          cp -R "$APP_PATH" Payload/
           /usr/bin/zip -qry monGARS-unsigned.ipa Payload
-          /usr/bin/zip -qry "$(basename "$FOUND_APP").zip" "$FOUND_APP"
+          /usr/bin/zip -qry "$(basename "$APP_PATH").zip" "$APP_PATH"
 
       - name: Upload unsigned IPA, app & logs
         if: always()

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -145,7 +145,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for authenticated SPM fetches
         run: |
           set -euo pipefail
-          xcodebuild build \
+          xcodebuild \
             -resolvePackageDependencies \
             -workspace "$XCODE_WORKSPACE" \
             -scheme "$XCODE_SCHEME" \
@@ -162,15 +162,19 @@ jobs:
             SKIP_INSTALL=NO \
             BUILD_LIBRARY_FOR_DISTRIBUTION=NO \
             "OTHER_CFLAGS=-DOBJC_OLD_DISPATCH_PROTOTYPES=0" \
+            clean build \
           | xcbeautify
 
       - name: Package unsigned IPA from Release-iphoneos
         run: |
           set -euo pipefail
-          APP_DIR="$DERIVED_DATA/Build/Products/Release-iphoneos"
-          APP_PATH="$(/bin/ls -d "$APP_DIR"/*.app 2>/dev/null | head -n1 || true)"
+          PRODUCTS_DIR="$DERIVED_DATA/Build/Products"
+          APP_PATH="$(/usr/bin/find "$PRODUCTS_DIR" -type d -name '*.app' -print -quit || true)"
           if [ -z "$APP_PATH" ]; then
-            echo "::error title=App not found::No .app under $APP_DIR (build must have failed earlier)."
+            echo "::group::Debug: list of Build/Products"
+            /bin/ls -lahR "$PRODUCTS_DIR" || true
+            echo "::endgroup::"
+            echo "::error title=App not found::No .app found under $PRODUCTS_DIR (build may have failed earlier)."
             exit 1
           fi
           mkdir -p build

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -133,59 +133,61 @@ jobs:
           set -euo pipefail
           brew install xcbeautify || true
 
-      - name: Clean SwiftPM state (fresh resolve)
+      - name: Sanity check schemes & build settings
         run: |
           set -euo pipefail
-          rm -rf "$DERIVED_DATA/SourcePackages" || true
-          find . -name "Package.resolved" -maxdepth 3 -print -exec rm -f {} \; || true
+          xcodebuild -list -workspace "ios/${XCODE_PROJECT_NAME}.xcworkspace" | sed -n '1,200p' || true
+          echo "::group::Build settings for scheme ${XCODE_SCHEME}"
+          xcodebuild -showBuildSettings \
+            -workspace "ios/${XCODE_PROJECT_NAME}.xcworkspace" \
+            -scheme "${XCODE_SCHEME}" -configuration Release | \
+            /usr/bin/grep -E 'PRODUCT_NAME|WRAPPER_NAME|PRODUCT_BUNDLE_IDENTIFIER|PRODUCT_TYPE|CONFIGURATION_BUILD_DIR' || true
+          echo "::endgroup::"
 
-      - name: Build (Release, iphoneos, deterministic DerivedData)
+      - name: Archive (unsigned, Release, iphoneos)
         env:
           XCODE_WORKSPACE: ios/${{ env.XCODE_PROJECT_NAME }}.xcworkspace
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for authenticated SPM fetches
         run: |
           set -euo pipefail
-          xcodebuild \
-            -resolvePackageDependencies \
+          ARCHIVE_PATH="build/App.xcarchive"
+          # Resolve packages explicitly for clearer logs
+          xcodebuild -resolvePackageDependencies \
+            -workspace "$XCODE_WORKSPACE" \
+            -scheme "$XCODE_SCHEME" | xcbeautify
+          # Create an unsigned archive targeting a generic iOS device
+          xcodebuild archive \
             -workspace "$XCODE_WORKSPACE" \
             -scheme "$XCODE_SCHEME" \
             -configuration Release \
             -sdk iphoneos \
             -destination 'generic/platform=iOS' \
-            -arch arm64 \
+            -archivePath "$ARCHIVE_PATH" \
             -derivedDataPath "$DERIVED_DATA" \
             -resultBundlePath "$DERIVED_DATA/ResultBundle.xcresult" \
             CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' \
             PROVISIONING_PROFILE_SPECIFIER='' SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=NO \
             "OTHER_CFLAGS=-DOBJC_OLD_DISPATCH_PROTOTYPES=0" \
-            build | xcbeautify
-
-      - name: Package unsigned IPA from Release-iphoneos
+            | xcbeautify
+      - name: Package unsigned IPA from archive
         run: |
           set -euo pipefail
-          PRODUCTS_DIR="$DERIVED_DATA/Build/Products"
-          if [ ! -d "$PRODUCTS_DIR" ]; then
-            echo "::group::Debug: list of DerivedData"
-            /bin/ls -lahR "$DERIVED_DATA" || true
+          APP_DIR="build/App.xcarchive/Products/Applications"
+          FOUND_APP="$(/usr/bin/find "$APP_DIR" -maxdepth 1 -type d -name '*.app' -print -quit || true)"
+          if [ -z "$FOUND_APP" ]; then
+            echo "::group::Debug: list archive contents"
+            /bin/ls -lahR "build/App.xcarchive" || true
             echo "::endgroup::"
-            echo "::error title=Products dir missing::No Build/Products directory at $PRODUCTS_DIR (build may have failed earlier)."
-            exit 1
-          fi
-          APP_PATH="$PRODUCTS_DIR/Release-iphoneos/${XCODE_SCHEME}.app"
-          if [ ! -d "$APP_PATH" ]; then
-            echo "::group::Debug: list of Build/Products"
-            /bin/ls -lahR "$PRODUCTS_DIR" || true
-            echo "::endgroup::"
-            echo "::error title=App not found::No app at $APP_PATH (build may have failed earlier)."
+            echo "::error title=App not found::No .app inside $APP_DIR (archive may have failed)."
             exit 1
           fi
           mkdir -p build
           cd build
           rm -rf Payload
           mkdir -p Payload
-          cp -R "$APP_PATH" Payload/
+          cp -R "$FOUND_APP" Payload/
           /usr/bin/zip -qry monGARS-unsigned.ipa Payload
-          /usr/bin/zip -qry "$(basename "$APP_PATH").zip" "$APP_PATH"
+          /usr/bin/zip -qry "$(basename "$FOUND_APP").zip" "$FOUND_APP"
 
       - name: Upload unsigned IPA, app & logs
         if: always()

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -169,6 +169,13 @@ jobs:
         run: |
           set -euo pipefail
           PRODUCTS_DIR="$DERIVED_DATA/Build/Products"
+          if [ ! -d "$PRODUCTS_DIR" ]; then
+            echo "::group::Debug: list of DerivedData"
+            /bin/ls -lahR "$DERIVED_DATA" || true
+            echo "::endgroup::"
+            echo "::error title=Products dir missing::No Build/Products directory at $PRODUCTS_DIR (build may have failed earlier)."
+            exit 1
+          fi
           APP_PATH="$(/usr/bin/find "$PRODUCTS_DIR" -type d -name '*.app' -print -quit || true)"
           if [ -z "$APP_PATH" ]; then
             echo "::group::Debug: list of Build/Products"

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -133,39 +133,85 @@ jobs:
           set -euo pipefail
           brew install xcbeautify || true
 
-      - name: Sanity check schemes & build settings
-        run: |
-          set -euo pipefail
-          xcodebuild -list -workspace "ios/${XCODE_PROJECT_NAME}.xcworkspace" | sed -n '1,200p' || true
-          echo "::group::Build settings for scheme ${XCODE_SCHEME}"
-          xcodebuild -showBuildSettings \
-            -workspace "ios/${XCODE_PROJECT_NAME}.xcworkspace" \
-            -scheme "${XCODE_SCHEME}" -configuration Release | \
-            /usr/bin/grep -E 'PRODUCT_NAME|WRAPPER_NAME|PRODUCT_BUNDLE_IDENTIFIER|PRODUCT_TYPE|CONFIGURATION_BUILD_DIR' || true
-          echo "::endgroup::"
-
-      - name: Resolve SwiftPM dependencies
+      - name: Dump Xcode schemes (debug aid)
         env:
           XCODE_WORKSPACE: ios/${{ env.XCODE_PROJECT_NAME }}.xcworkspace
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p build
+          # List all schemes/targets in JSON (handy artifact when builds don’t produce an .app)
+          xcodebuild -list -json -workspace "$XCODE_WORKSPACE" > build/xcode-list.json || true
+          echo "Schemes:"
+          /usr/bin/plutil -p build/xcode-list.json 2>/dev/null | sed 's/^/  /' || cat build/xcode-list.json || true
+
+      - name: Clean SwiftPM state (fresh resolve)
+        run: |
+          set -euo pipefail
+          rm -rf "$DERIVED_DATA/SourcePackages" || true
+          find . -name "Package.resolved" -maxdepth 3 -print -exec rm -f {} \; || true
+
+      - name: Compute app output path from build settings (Release/iPhoneOS)
+        env:
+          XCODE_WORKSPACE: ios/${{ env.XCODE_PROJECT_NAME }}.xcworkspace
+        run: |
+          set -euo pipefail
+          mkdir -p build
+          # Try JSON first (available on modern Xcode), then fall back to text parsing.
+          brew install jq || true
+          # JSON (best): select the application product in this scheme, Release + iphoneos
+          ( xcodebuild -showBuildSettings \
+              -workspace "$XCODE_WORKSPACE" \
+              -scheme "$XCODE_SCHEME" \
+              -configuration Release \
+              -sdk iphoneos \
+              -json > build/showBuildSettings.json ) || true
+
+          APP_DIR=""
+          WRAPPER_NAME=""
+          if [ -s build/showBuildSettings.json ] && command -v jq >/dev/null; then
+            APP_DIR="$(jq -r '.[] | .buildSettings | select(.PRODUCT_TYPE=="com.apple.product-type.application") | .CONFIGURATION_BUILD_DIR' build/showBuildSettings.json | tail -n1)"
+            WRAPPER_NAME="$(jq -r '.[] | .buildSettings | select(.PRODUCT_TYPE=="com.apple.product-type.application") | .WRAPPER_NAME' build/showBuildSettings.json | tail -n1)"
+          fi
+
+          # Text fallback: narrow to the application target block and scrape the two lines we need.
+          if [ -z "$APP_DIR" ] || [ -z "$WRAPPER_NAME" ]; then
+            xcodebuild -showBuildSettings \
+              -workspace "$XCODE_WORKSPACE" \
+              -scheme "$XCODE_SCHEME" \
+              -configuration Release \
+              -sdk iphoneos \
+              > build/showBuildSettings.txt 2>&1 || true
+            # Grep the last 'PRODUCT_TYPE = application' block for Release|iphoneos
+            awk '
+              /PRODUCT_TYPE = com\.apple\.product-type\.application/ { inapp=1 }
+              inapp && /CONFIGURATION_BUILD_DIR =/ { gsub(/^[^=]*= /,"" ); gsub(/^ +| +$/,"" ); appdir=$0 }
+              inapp && /WRAPPER_NAME =/             { gsub(/^[^=]*= /,"" ); gsub(/^ +| +$/,"" ); wrapper=$0 }
+              inapp && appdir && wrapper { print appdir; print wrapper; exit }
+            ' build/showBuildSettings.txt > build/appPath.tmp || true
+            if [ -s build/appPath.tmp ]; then
+              APP_DIR="$(sed -n '1p' build/appPath.tmp)"
+              WRAPPER_NAME="$(sed -n '2p' build/appPath.tmp)"
+            fi
+          fi
+
+          # Persist for later steps; also emit for logs.
+          if [ -n "$APP_DIR" ] && [ -n "$WRAPPER_NAME" ]; then
+            echo "Derived app path:"
+            echo "  CONFIGURATION_BUILD_DIR: $APP_DIR"
+            echo "  WRAPPER_NAME:            $WRAPPER_NAME"
+            echo "APP_PATH=$APP_DIR/$WRAPPER_NAME" >> "$GITHUB_ENV"
+          else
+            echo "::warning title=Could not derive app path::The scheme may not include an application target. Packaging will fall back to scanning Build/Products."
+          fi
+
+      - name: Build (Release, iphoneos, deterministic DerivedData)
+        env:
+          XCODE_WORKSPACE: ios/${{ env.XCODE_PROJECT_NAME }}.xcworkspace
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for authenticated SPM fetches
         run: |
           set -euo pipefail
           xcodebuild \
             -resolvePackageDependencies \
-            -workspace "$XCODE_WORKSPACE" \
-            -scheme "$XCODE_SCHEME" \
-            -configuration Release \
-            -sdk iphoneos \
-            -destination 'generic/platform=iOS' \
-            -derivedDataPath "$DERIVED_DATA" \
-            -resultBundlePath "$DERIVED_DATA/ResultBundle.xcresult"
-
-      - name: Build (Release, iphoneos)
-        env:
-          XCODE_WORKSPACE: ios/${{ env.XCODE_PROJECT_NAME }}.xcworkspace
-        run: |
-          set -euo pipefail
-          xcodebuild \
             -workspace "$XCODE_WORKSPACE" \
             -scheme "$XCODE_SCHEME" \
             -configuration Release \
@@ -177,26 +223,39 @@ jobs:
             CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' \
             PROVISIONING_PROFILE_SPECIFIER='' SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=NO \
             "OTHER_CFLAGS=-DOBJC_OLD_DISPATCH_PROTOTYPES=0" \
-            clean build | xcbeautify
+            build | xcbeautify
 
       - name: Package unsigned IPA from Release-iphoneos
         run: |
           set -euo pipefail
-          APP_PATH="$DERIVED_DATA/Build/Products/Release-iphoneos/${XCODE_SCHEME}.app"
-          if [ ! -d "$APP_PATH" ]; then
-            echo "::group::Debug: list of Build/Products"
-            /bin/ls -lahR "$DERIVED_DATA/Build/Products" || true
+          PRODUCTS_DIR="$DERIVED_DATA/Build/Products"
+          if [ ! -d "$PRODUCTS_DIR" ]; then
+            echo "::group::Debug: list of DerivedData"
+            /bin/ls -lahR "$DERIVED_DATA" || true
             echo "::endgroup::"
-            echo "::error title=App not found::No .app found at $APP_PATH (build may have failed earlier)."
+            echo "::error title=Products dir missing::No Build/Products directory at $PRODUCTS_DIR (build may have failed earlier)."
+            exit 1
+          fi
+          # Prefer the APP_PATH we derived from build settings; else first *.app we can find.
+          if [ -n "${APP_PATH:-}" ] && [ -d "$APP_PATH" ]; then
+            SELECTED_APP="$APP_PATH"
+          else
+            SELECTED_APP="$(/usr/bin/find "$PRODUCTS_DIR" -type d -name '*.app' -print -quit || true)"
+          fi
+          if [ -z "$SELECTED_APP" ]; then
+            echo "::group::Debug: list of Build/Products"
+            /bin/ls -lahR "$PRODUCTS_DIR" || true
+            echo "::endgroup::"
+            echo "::error title=App not found::No .app found under $PRODUCTS_DIR. The selected scheme may not build an iOS application target."
             exit 1
           fi
           mkdir -p build
           cd build
           rm -rf Payload
           mkdir -p Payload
-          cp -R "$APP_PATH" Payload/
+          cp -R "$SELECTED_APP" Payload/
           /usr/bin/zip -qry monGARS-unsigned.ipa Payload
-          /usr/bin/zip -qry "$(basename "$APP_PATH").zip" "$APP_PATH"
+          /usr/bin/zip -qry "$(basename "$SELECTED_APP").zip" "$SELECTED_APP"
 
       - name: Upload unsigned IPA, app & logs
         if: always()
@@ -208,5 +267,8 @@ jobs:
             build/*.app.zip
             ${{ env.DERIVED_DATA }}/ResultBundle.xcresult
             ${{ env.DERIVED_DATA }}/Logs/Build
+            build/xcode-list.json
+            build/showBuildSettings.json
+            build/showBuildSettings.txt
           if-no-files-found: error
           compression-level: 6

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -184,7 +184,7 @@ jobs:
           rm -rf Payload
           mkdir -p Payload
           cp -R "$APP_PATH" Payload/
-          /usr/bin/zip -qry offLLM-unsigned.ipa Payload
+          /usr/bin/zip -qry monGARS-unsigned.ipa Payload
           /usr/bin/zip -qry "$(basename "$APP_PATH").zip" "$APP_PATH"
 
       - name: Upload unsigned IPA, app & logs
@@ -193,7 +193,7 @@ jobs:
         with:
           name: ios-unsigned-ipa
           path: |
-            build/offLLM-unsigned.ipa
+            build/monGARS-unsigned.ipa
             build/*.app.zip
             ${{ env.DERIVED_DATA }}/ResultBundle.xcresult
             ${{ env.DERIVED_DATA }}/Logs/Build

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@ node_modules/
 vector_memory.dat
 ios/Pods/
 ios/vendor/
-ios/MyOfflineLLMApp.xcodeproj/
-ios/MyOfflineLLMApp.xcworkspace/
+ios/monGARS.xcodeproj/
+ios/monGARS.xcworkspace/
 ios/.bundle/
 ios/.xcode.env.local
 /build/
@@ -12,7 +12,7 @@ android/app/build/
 .env
 *.xcfilelist
 ios/build/
-ios/MyOfflineLLMApp/*.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+ios/monGARS.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
 !ios/build/generated/
 !ios/build/generated/ios/**
-ios/MyOfflineLLMApp.xcresult
+ios/monGARS.xcresult

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@
 ## iOS Rules
 
 - Build with Xcode 16.x (command line tools installed).
-- Deployment target stays **18.0** in [`ios/project.yml`](ios/project.yml), [`ios/MyOfflineLLMApp/project.yml`](ios/MyOfflineLLMApp/project.yml), and `Podfile` post_install.
+- Deployment target stays **18.0** in [`ios/project.yml`](ios/project.yml) and `Podfile` post_install.
 - When editing these files, update comments and re-run `bundle exec pod update hermes-engine --no-repo-update && bundle exec pod install --repo-update`.
 - **Do not enable CocoaPods input/output file lists** with static pods (`:disable_input_output_paths => true` stays). Set `ENABLE_USER_SCRIPT_SANDBOXING` to `NO` in `post_install` for CI stability.
 - When editing project.yml or Podfile, ensure no legacy .xcfilelist references or invalid Podfile hooks are reintroduced.
@@ -70,7 +70,7 @@
 
 ## CI Playbook
 
-- `ios-unsigned.yml` workflow: xcodegen → pod install → unsigned simulator build → uploads `offLLM-unsigned-ipa` artifact.
+- `ios-unsigned.yml` workflow: xcodegen → pod install → unsigned simulator build → uploads `monGARS-unsigned-ipa` artifact.
 - If CI fails on pods or project generation, try `pod repo update`, `rm -rf ios/Pods`, and rerun xcodegen.
 
 ## PR Checklist

--- a/CI-REPORT.md
+++ b/CI-REPORT.md
@@ -10,4 +10,4 @@
 
 ## Pointers
 - Full log: `build/xcodebuild.log`
-- Result bundle: `/Users/runner/work/offLLM/offLLM/build/MyOfflineLLMApp.xcresult`
+- Result bundle: `/Users/runner/work/offLLM/offLLM/build/monGARS.xcresult`

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm run codegen
 ```bash
 npx react-native run-ios
 # unsigned
-(cd ios && xcodebuild -workspace MyOfflineLLMApp.xcworkspace -scheme MyOfflineLLMApp -configuration Release -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO)
+(cd ios && xcodebuild -workspace monGARS.xcworkspace -scheme monGARS -configuration Release -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO)
 ```
 
 ### Run tests
@@ -76,7 +76,7 @@ npm test
 - React Native 0.81.x with **New Architecture** enabled (TurboModules).
 - Swift-first TurboModule pattern: TS spec → Swift class → minimal `.mm` glue.
 - JS retrieves modules with `TurboModuleRegistry.getOptional` and falls back to `MLXModule` (iOS) or `LlamaTurboModule` (Android).
-- Specs live in [src/specs/](src/specs/); iOS Turbo sources in [ios/MyOfflineLLMApp/Turbo](ios/MyOfflineLLMApp/Turbo).
+- Specs live in [src/specs/](src/specs/); iOS Turbo sources for monGARS live in [ios/MyOfflineLLMApp/Turbo](ios/MyOfflineLLMApp/Turbo).
 
 ## Scripts Reference
 
@@ -93,10 +93,10 @@ npm test
 ## iOS Unsigned Build (Simulator)
 
 ```bash
-cd ios && xcodebuild -workspace MyOfflineLLMApp.xcworkspace -scheme MyOfflineLLMApp -configuration Release -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO
+cd ios && xcodebuild -workspace monGARS.xcworkspace -scheme monGARS -configuration Release -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO
 ```
 
-The `.github/workflows/ios-unsigned.yml` workflow automates these steps and uploads an `offLLM-unsigned-ipa.zip` artifact.
+The `.github/workflows/ios-unsigned.yml` workflow automates these steps and uploads a `monGARS-unsigned-ipa.zip` artifact.
 
 ## iOS Signed Build (GitHub Actions)
 

--- a/REPORT.md
+++ b/REPORT.md
@@ -10,4 +10,4 @@
 
 ## Pointers
 - Full log: `/Users/runner/work/offLLM/offLLM/build/xcodebuild.log`
-- Result bundle: `/Users/runner/work/offLLM/offLLM/build/MyOfflineLLMApp.xcresult`
+- Result bundle: `/Users/runner/work/offLLM/offLLM/build/monGARS.xcresult`

--- a/android/app/src/main/cpp/llama_jni.cpp
+++ b/android/app/src/main/cpp/llama_jni.cpp
@@ -239,7 +239,7 @@ private:
 };
 
 extern "C" JNIEXPORT jlong JNICALL
-Java_com_myofflinellmapp_LlamaTurboModule_loadModel(JNIEnv *env, jobject thiz,
+Java_com_mongars_LlamaTurboModule_loadModel(JNIEnv *env, jobject thiz,
                                                     jstring model_path,
                                                     jint context_size,
                                                     jint n_threads) {
@@ -284,7 +284,7 @@ Java_com_myofflinellmapp_LlamaTurboModule_loadModel(JNIEnv *env, jobject thiz,
 }
 
 extern "C" JNIEXPORT jstring JNICALL
-Java_com_myofflinellmapp_LlamaTurboModule_generate(
+Java_com_mongars_LlamaTurboModule_generate(
     JNIEnv *env, jobject thiz, jlong ctx_ptr, jstring prompt, jint max_tokens,
     jfloat temperature, jboolean use_sparse_attention) {
   return jniWithCtx<jstring>(
@@ -305,7 +305,7 @@ Java_com_myofflinellmapp_LlamaTurboModule_generate(
 }
 
 extern "C" JNIEXPORT jfloatArray JNICALL
-Java_com_myofflinellmapp_LlamaTurboModule_embed(JNIEnv *env, jobject thiz,
+Java_com_mongars_LlamaTurboModule_embed(JNIEnv *env, jobject thiz,
                                                 jlong ctx_ptr, jstring text) {
   return jniWithCtx<jfloatArray>(
       env, ctx_ptr, env->NewFloatArray(0), [&](LlamaContext *ctx) {
@@ -319,7 +319,7 @@ Java_com_myofflinellmapp_LlamaTurboModule_embed(JNIEnv *env, jobject thiz,
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_myofflinellmapp_LlamaTurboModule_clearKVCache(JNIEnv *env,
+Java_com_mongars_LlamaTurboModule_clearKVCache(JNIEnv *env,
                                                        jobject thiz,
                                                        jlong ctx_ptr) {
   LlamaContext *ctx = reinterpret_cast<LlamaContext *>(ctx_ptr);
@@ -329,7 +329,7 @@ Java_com_myofflinellmapp_LlamaTurboModule_clearKVCache(JNIEnv *env,
 }
 
 extern "C" JNIEXPORT jint JNICALL
-Java_com_myofflinellmapp_LlamaTurboModule_getKVCacheSize(JNIEnv *env,
+Java_com_mongars_LlamaTurboModule_getKVCacheSize(JNIEnv *env,
                                                          jobject thiz,
                                                          jlong ctx_ptr) {
   LlamaContext *ctx = reinterpret_cast<LlamaContext *>(ctx_ptr);
@@ -340,7 +340,7 @@ Java_com_myofflinellmapp_LlamaTurboModule_getKVCacheSize(JNIEnv *env,
 }
 
 extern "C" JNIEXPORT jint JNICALL
-Java_com_myofflinellmapp_LlamaTurboModule_getKVCacheMaxSize(JNIEnv *env,
+Java_com_mongars_LlamaTurboModule_getKVCacheMaxSize(JNIEnv *env,
                                                             jobject thiz,
                                                             jlong ctx_ptr) {
   LlamaContext *ctx = reinterpret_cast<LlamaContext *>(ctx_ptr);
@@ -351,7 +351,7 @@ Java_com_myofflinellmapp_LlamaTurboModule_getKVCacheMaxSize(JNIEnv *env,
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_myofflinellmapp_LlamaTurboModule_addMessageBoundary(JNIEnv *env,
+Java_com_mongars_LlamaTurboModule_addMessageBoundary(JNIEnv *env,
                                                              jobject thiz,
                                                              jlong ctx_ptr) {
   LlamaContext *ctx = reinterpret_cast<LlamaContext *>(ctx_ptr);
@@ -361,14 +361,14 @@ Java_com_myofflinellmapp_LlamaTurboModule_addMessageBoundary(JNIEnv *env,
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_myofflinellmapp_LlamaTurboModule_freeModel(JNIEnv *env, jobject thiz,
+Java_com_mongars_LlamaTurboModule_freeModel(JNIEnv *env, jobject thiz,
                                                     jlong ctx_ptr) {
   LlamaContext *ctx = reinterpret_cast<LlamaContext *>(ctx_ptr);
   delete ctx;
 }
 
 extern "C" JNIEXPORT jobject JNICALL
-Java_com_myofflinellmapp_LlamaTurboModule_getPerformanceMetrics(JNIEnv *env,
+Java_com_mongars_LlamaTurboModule_getPerformanceMetrics(JNIEnv *env,
                                                                 jobject thiz,
                                                                 jlong ctx_ptr) {
   if (ctx_ptr == 0) {
@@ -404,7 +404,7 @@ Java_com_myofflinellmapp_LlamaTurboModule_getPerformanceMetrics(JNIEnv *env,
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_myofflinellmapp_LlamaTurboModule_adjustPerformanceMode(JNIEnv *env,
+Java_com_mongars_LlamaTurboModule_adjustPerformanceMode(JNIEnv *env,
                                                                 jobject thiz,
                                                                 jlong ctx_ptr,
                                                                 jstring mode) {

--- a/android/app/src/main/java/com/mongars/BatteryTurboModule.java
+++ b/android/app/src/main/java/com/mongars/BatteryTurboModule.java
@@ -1,4 +1,4 @@
-package com.myofflinellmapp;
+package com.mongars;
 
 import android.content.Intent;
 import android.content.IntentFilter;

--- a/android/app/src/main/java/com/mongars/BrightnessTurboModule.java
+++ b/android/app/src/main/java/com/mongars/BrightnessTurboModule.java
@@ -1,4 +1,4 @@
-package com.myofflinellmapp;
+package com.mongars;
 
 import android.app.Activity;
 import android.view.Window;

--- a/android/app/src/main/java/com/mongars/CalendarTurboModule.java
+++ b/android/app/src/main/java/com/mongars/CalendarTurboModule.java
@@ -1,4 +1,4 @@
-package com.myofflinellmapp;
+package com.mongars;
 
 import android.content.ContentResolver;
 import android.content.ContentValues;

--- a/android/app/src/main/java/com/mongars/CallTurboModule.java
+++ b/android/app/src/main/java/com/mongars/CallTurboModule.java
@@ -1,4 +1,4 @@
-package com.myofflinellmapp;
+package com.mongars;
 
 import android.database.Cursor;
 import android.provider.CallLog;

--- a/android/app/src/main/java/com/mongars/CameraTurboModule.java
+++ b/android/app/src/main/java/com/mongars/CameraTurboModule.java
@@ -1,4 +1,4 @@
-package com.myofflinellmapp;
+package com.mongars;
 
 import androidx.annotation.NonNull;
 import com.facebook.react.bridge.Promise;

--- a/android/app/src/main/java/com/mongars/ContactsTurboModule.java
+++ b/android/app/src/main/java/com/mongars/ContactsTurboModule.java
@@ -1,4 +1,4 @@
-package com.myofflinellmapp;
+package com.mongars;
 
 import android.Manifest;
 import android.content.ContentProviderOperation;

--- a/android/app/src/main/java/com/mongars/DeviceInfoTurboModule.java
+++ b/android/app/src/main/java/com/mongars/DeviceInfoTurboModule.java
@@ -1,4 +1,4 @@
-package com.myofflinellmapp;
+package com.mongars;
 
 import android.content.Context;
 import android.os.Build;

--- a/android/app/src/main/java/com/mongars/FilesTurboModule.java
+++ b/android/app/src/main/java/com/mongars/FilesTurboModule.java
@@ -1,4 +1,4 @@
-package com.myofflinellmapp;
+package com.mongars;
 
 import androidx.annotation.NonNull;
 import com.facebook.react.bridge.Promise;

--- a/android/app/src/main/java/com/mongars/FlashlightTurboModule.java
+++ b/android/app/src/main/java/com/mongars/FlashlightTurboModule.java
@@ -1,4 +1,4 @@
-package com.myofflinellmapp;
+package com.mongars;
 
 import android.content.Context;
 import android.hardware.camera2.CameraAccessException;

--- a/android/app/src/main/java/com/mongars/LlamaTurboModule.java
+++ b/android/app/src/main/java/com/mongars/LlamaTurboModule.java
@@ -1,4 +1,4 @@
-package com.myofflinellmapp;
+package com.mongars;
 
 import androidx.annotation.NonNull;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -16,7 +16,7 @@ import com.facebook.react.module.annotations.ReactModule;
  * Native. This class replaces the previous LlamaRNModule name to align with
  * the C++ JNI symbols defined in {@code llama_jni.cpp}. The name constant and
  * React module annotation must match the JNI function prefixes
- * (e.g. Java_com_myofflinellmapp_LlamaTurboModule_...).
+ * (e.g. Java_com_mongars_LlamaTurboModule_...).
  */
 @ReactModule(name = LlamaTurboModule.NAME)
 public class LlamaTurboModule extends ReactContextBaseJavaModule {

--- a/android/app/src/main/java/com/mongars/LocationTurboModule.java
+++ b/android/app/src/main/java/com/mongars/LocationTurboModule.java
@@ -1,4 +1,4 @@
-package com.myofflinellmapp;
+package com.mongars;
 
 import android.Manifest;
 import android.annotation.SuppressLint;

--- a/android/app/src/main/java/com/mongars/MapsTurboModule.java
+++ b/android/app/src/main/java/com/mongars/MapsTurboModule.java
@@ -1,4 +1,4 @@
-package com.myofflinellmapp;
+package com.mongars;
 
 import android.content.Intent;
 import android.net.Uri;

--- a/android/app/src/main/java/com/mongars/MessagesTurboModule.java
+++ b/android/app/src/main/java/com/mongars/MessagesTurboModule.java
@@ -1,4 +1,4 @@
-package com.myofflinellmapp;
+package com.mongars;
 
 import android.content.Intent;
 import android.net.Uri;

--- a/android/app/src/main/java/com/mongars/ModuleUtils.java
+++ b/android/app/src/main/java/com/mongars/ModuleUtils.java
@@ -1,4 +1,4 @@
-package com.myofflinellmapp;
+package com.mongars;
 
 import android.content.Context;
 import android.content.pm.PackageManager;

--- a/android/app/src/main/java/com/mongars/MonGarsPackage.java
+++ b/android/app/src/main/java/com/mongars/MonGarsPackage.java
@@ -1,4 +1,4 @@
-package com.myofflinellmapp;
+package com.mongars;
 
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;
@@ -9,7 +9,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * MyOfflineLLMAppPackage registers the custom TurboModules implemented in this
+ * MonGarsPackage registers the custom TurboModules implemented in this
  * application with the React Native bridge. Older architectures rely on
  * explicit registration via a ReactPackage, whereas the new architecture
  * will auto-link modules annotated with @ReactModule. Including this
@@ -17,7 +17,7 @@ import java.util.List;
  * package to your MainApplication#getPackages() method to ensure modules
  * are available.
  */
-public class MyOfflineLLMAppPackage implements ReactPackage {
+public class MonGarsPackage implements ReactPackage {
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();

--- a/android/app/src/main/java/com/mongars/MusicTurboModule.java
+++ b/android/app/src/main/java/com/mongars/MusicTurboModule.java
@@ -1,4 +1,4 @@
-package com.myofflinellmapp;
+package com.mongars;
 
 import androidx.annotation.NonNull;
 import com.facebook.react.bridge.Promise;

--- a/android/app/src/main/java/com/mongars/PhotosTurboModule.java
+++ b/android/app/src/main/java/com/mongars/PhotosTurboModule.java
@@ -1,4 +1,4 @@
-package com.myofflinellmapp;
+package com.mongars;
 
 import androidx.annotation.NonNull;
 import com.facebook.react.bridge.Promise;

--- a/android/app/src/main/java/com/mongars/SensorsTurboModule.java
+++ b/android/app/src/main/java/com/mongars/SensorsTurboModule.java
@@ -1,4 +1,4 @@
-package com.myofflinellmapp;
+package com.mongars;
 
 import android.content.Context;
 import android.hardware.Sensor;

--- a/app.json
+++ b/app.json
@@ -1,12 +1,12 @@
 {
-  "name": "MyOfflineLLMApp",
-  "displayName": "MyOfflineLLMApp",
+  "name": "monGARS",
+  "displayName": "monGARS",
   "ios": {
-    "bundleIdentifier": "com.myofflinellmapp",
+    "bundleIdentifier": "com.offllm.mongars",
     "buildNumber": "1",
     "target": "18.0"
   },
   "android": {
-    "package": "com.myofflinellmapp"
+    "package": "com.mongars"
   }
 }

--- a/build.sh
+++ b/build.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 
 # Configuration
-: "${SCHEME:=MyOfflineLLMApp}"
+# Default to the monGARS scheme
+: "${SCHEME:=monGARS}"
 # Resolve the iOS project path to an absolute location to avoid
 # issues when the caller provides IOS_PROJECT_DIR as a relative path.
 IOS_PROJECT_DIR=$(cd "${IOS_PROJECT_DIR:-${PWD}/ios}" && pwd)
-: "${WORKSPACE:=${IOS_PROJECT_DIR}/MyOfflineLLMApp.xcworkspace}"
+: "${WORKSPACE:=${IOS_PROJECT_DIR}/monGARS.xcworkspace}"
 : "${BUILD_DIR:=build}"
 : "${REQUIRED_NODE_VERSION:=20.0.0}"
 
@@ -91,7 +92,7 @@ PAYLOAD_DIR="$BUILD_DIR/Payload"
 rm -rf "$PAYLOAD_DIR"
 mkdir -p "$PAYLOAD_DIR"
 cp -R "$APP_PATH" "$PAYLOAD_DIR/"
-(cd "$BUILD_DIR" && zip -qr offLLM-unsigned-ipa.zip Payload)
-echo "✅ Artifact created at $BUILD_DIR/offLLM-unsigned-ipa.zip"
+(cd "$BUILD_DIR" && zip -qr monGARS-unsigned-ipa.zip Payload)
+echo "✅ Artifact created at $BUILD_DIR/monGARS-unsigned-ipa.zip"
 
 echo "✅ Build script completed."

--- a/ios/MyOfflineLLMApp/AppDelegate.mm
+++ b/ios/MyOfflineLLMApp/AppDelegate.mm
@@ -9,7 +9,7 @@
   // Prepare the React Native environment.
   RCTAppSetupPrepareApp(application);
   // Name must match the "name" field in app.json.
-  self.moduleName = @"MyOfflineLLMApp";
+  self.moduleName = @"monGARS";
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 

--- a/ios/MyOfflineLLMApp/Info.plist
+++ b/ios/MyOfflineLLMApp/Info.plist
@@ -2,8 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDisplayName</key>
-	<string>MyOfflineLLMApp</string>
+        <key>CFBundleDisplayName</key>
+        <string>monGARS</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Bluetooth is used for device connectivity.</string>
 	<key>NSCalendarsUsageDescription</key>

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -29,7 +29,7 @@ targets:
 
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.offllm.monGARS
+        PRODUCT_BUNDLE_IDENTIFIER: com.offllm.mongars
         INFOPLIST_FILE: MyOfflineLLMApp/Info.plist
         SWIFT_VERSION: 5.0
 

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     "lint:ci": "eslint . --max-warnings=0",
     "format:check": "prettier --check .",
     "build:android": "cd android && ./gradlew assembleRelease",
-    "build:ios": "(cd ios && xcodegen generate && bundle install) && BUNDLE_GEMFILE=ios/Gemfile bundle exec pod install --deployment --project-directory=ios && xcodebuild -workspace ios/MyOfflineLLMApp.xcworkspace -scheme MyOfflineLLMApp -configuration Release -destination 'generic/platform=iOS Simulator' CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO",
+    "build:ios": "(cd ios && xcodegen generate && bundle install) && BUNDLE_GEMFILE=ios/Gemfile bundle exec pod install --deployment --project-directory=ios && xcodebuild -workspace ios/monGARS.xcworkspace -scheme monGARS -configuration Release -destination 'generic/platform=iOS Simulator' CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO",
     "bundle:android": "react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res",
     "bundle:ios": "react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ios/main.jsbundle --assets-dest ios",
     "codegen:ios": "RCT_NEW_ARCH_ENABLED=1 node node_modules/react-native/scripts/generate-codegen-artifacts.js --path . --targetPlatform ios --outputPath ios",
     "codegen": "npm run codegen:ios",
     "ci:install": "npm ci --legacy-peer-deps",
     "codex": "node ./scripts/codex/index.mjs",
-    "codex:analyze": "node ./scripts/codex/index.mjs analyze --log ${CODEX_LOG_PATH:-build/xcodebuild.log} --xcresult ${CODEX_XCRESULT_PATH:-build/MyOfflineLLMApp.xcresult} --out ${CODEX_REPORTS_DIR:-reports}",
+    "codex:analyze": "node ./scripts/codex/index.mjs analyze --log ${CODEX_LOG_PATH:-build/xcodebuild.log} --xcresult ${CODEX_XCRESULT_PATH:-build/monGARS.xcresult} --out ${CODEX_REPORTS_DIR:-reports}",
     "codex:fix": "node ./scripts/codex/index.mjs fix --report ${CODEX_REPORT_PATH:-reports/REPORT.md} --agent ${CODEX_AGENT_PATH:-reports/report_agent.md} --out ${CODEX_REPORTS_DIR:-reports}",
     "doctor:ios": "bash scripts/dev/doctor.sh",
     "doctor:ios:sim": "DESTINATION='platform=iOS Simulator,name=iPhone 16 Pro' bash scripts/dev/doctor.sh",
@@ -92,7 +92,7 @@
     "type": "modules",
     "jsSrcsDir": "src/specs",
     "android": {
-      "javaPackageName": "com.myofflinellmapp"
+      "javaPackageName": "com.mongars"
     },
     "ios": {
       "libraryName": "AppSpec",

--- a/scripts/apply_ios_mlx_fixes.sh
+++ b/scripts/apply_ios_mlx_fixes.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Helper to keep MLX sample project aligned with RN's iOS 18.0 minimum.
-YML="ios/MyOfflineLLMApp/project.yml"
+YML="ios/project.yml"
 PODFILE="ios/Podfile"
 
 if [ ! -f "$YML" ]; then
@@ -77,12 +77,12 @@ fi
 
 # 4) Ensure target dependencies include MLX + MLXLLM
 if ! grep -q 'product: MLX$' "$YML"; then
-  # Add under MyOfflineLLMApp target dependencies
+  # Add under monGARS target dependencies
   awk '
   BEGIN{inTarget=0; deps=0}
   /^targets:/ {print; next}
   {
-    if ($0 ~ /^  MyOfflineLLMApp:/) inTarget=1
+    if ($0 ~ /^  monGARS:/) inTarget=1
     if (inTarget && $0 ~ /dependencies:/) deps=1
     print
     if (inTarget && deps && $0 ~ /dependencies:/) {

--- a/scripts/build-ios-unsigned.sh
+++ b/scripts/build-ios-unsigned.sh
@@ -53,18 +53,18 @@ cd ..
 kill $BUNDLER_PID 2>/dev/null || true
 echo "🔨 Performing clean Xcode build..."
 cd ios
-if [ ! -d "MyOfflineLLMApp.xcworkspace" ]; then
-  echo "❌ Xcode workspace 'MyOfflineLLMApp.xcworkspace' not found."
+if [ ! -d "monGARS.xcworkspace" ]; then
+  echo "❌ Xcode workspace 'monGARS.xcworkspace' not found."
   exit 1
 fi
-xcodebuild clean -workspace MyOfflineLLMApp.xcworkspace -scheme MyOfflineLLMApp
+xcodebuild clean -workspace monGARS.xcworkspace -scheme monGARS
 mkdir -p build
 xcodebuild \
-  -workspace MyOfflineLLMApp.xcworkspace \
-  -scheme MyOfflineLLMApp \
+  -workspace monGARS.xcworkspace \
+  -scheme monGARS \
   -configuration Release \
   -destination 'generic/platform=iOS' \
-  -archivePath "build/MyOfflineLLMApp.xcarchive" \
+  -archivePath "build/monGARS.xcarchive" \
   archive \
   CODE_SIGNING_ALLOWED=NO \
   CODE_SIGNING_REQUIRED=NO
@@ -72,22 +72,22 @@ xcodebuild \
 # Step 6: Export the unsigned IPA
 # Step 6: Export the unsigned IPA (manual packaging to avoid signing requirements)
 OUT_DIR="build/unsigned_ipa"
-APP_PATH="build/MyOfflineLLMApp.xcarchive/Products/Applications/MyOfflineLLMApp.app"
+APP_PATH="build/monGARS.xcarchive/Products/Applications/monGARS.app"
 mkdir -p "$OUT_DIR/Payload"
 if [ ! -d "$APP_PATH" ]; then
   echo "❌ Error: App not found at $APP_PATH"; exit 1
 fi
 cp -R "$APP_PATH" "$OUT_DIR/Payload/"
 # Ensure truly unsigned bundle
-rm -rf "$OUT_DIR/Payload/MyOfflineLLMApp.app/_CodeSignature" "$OUT_DIR/Payload/MyOfflineLLMApp.app/embedded.mobileprovision"
+rm -rf "$OUT_DIR/Payload/monGARS.app/_CodeSignature" "$OUT_DIR/Payload/monGARS.app/embedded.mobileprovision"
 # Zip to IPA
 (
   cd "$OUT_DIR"
-  zip -qry "MyOfflineLLMApp.ipa" "Payload"
+  zip -qry "monGARS.ipa" "Payload"
 )
 # Clean up temporary Payload folder
 rm -rf "$OUT_DIR/Payload"
 cd ..
-echo "🎉 Unsigned IPA generated at ./ios/build/unsigned_ipa/MyOfflineLLMApp.ipa"
+echo "🎉 Unsigned IPA generated at ./ios/build/unsigned_ipa/monGARS.ipa"
 
 echo "✅ Failproof iOS build process completed successfully."

--- a/scripts/ci/bootstrap-build.sh
+++ b/scripts/ci/bootstrap-build.sh
@@ -81,7 +81,7 @@ if [ -d "$APP_PATH" ]; then
   rm -rf "$BUILD_DIR/Payload"
   mkdir -p "$BUILD_DIR/Payload"
   cp -R "$APP_PATH" "$BUILD_DIR/Payload/"
-  (cd "$BUILD_DIR" && zip -qry offLLM-unsigned.ipa Payload)
+  (cd "$BUILD_DIR" && zip -qry monGARS-unsigned.ipa Payload)
   (cd "$APP_DIR" && zip -qry "$PWD/../../$SCHEME.app.zip" "$SCHEME.app")
 fi
 

--- a/scripts/ci/bootstrap_ios.sh
+++ b/scripts/ci/bootstrap_ios.sh
@@ -310,7 +310,7 @@ fi
 rm -rf "${BUILD_DIR}/Payload"
 mkdir -p "${BUILD_DIR}/Payload"
 cp -R "$APP_PATH" "${BUILD_DIR}/Payload/"
-( cd "${BUILD_DIR}" && /usr/bin/zip -qry offLLM-unsigned.ipa Payload )
+( cd "${BUILD_DIR}" && /usr/bin/zip -qry monGARS-unsigned.ipa Payload )
 ( cd "$APP_DIR" && /usr/bin/zip -qry "$PWD/../../${SCHEME}.app.zip" "${SCHEME}.app" )
 
-echo "✅ Done. IPA at ${BUILD_DIR}/offLLM-unsigned.ipa"
+echo "✅ Done. IPA at ${BUILD_DIR}/monGARS-unsigned.ipa"

--- a/scripts/dev/commit-reports.sh
+++ b/scripts/dev/commit-reports.sh
@@ -60,7 +60,7 @@ if [[ "${ARCHIVE:-0}" == "1" ]]; then
   # rsync to preserve structure but avoid copying giant xcresult bundle content; link it instead
   rsync -a --delete --exclude '*.xcresult' "$REPORT_DIR/" "$DEST_DIR/"
   # Create a lightweight pointer to the xcresult if present
-  if [[ -d "$REPORT_DIR/MyOfflineLLMApp.xcresult" ]]; then
+  if [[ -d "$REPORT_DIR/monGARS.xcresult" ]]; then
     echo "(xcresult present in build dir; not copied here to keep repo light)" > "$DEST_DIR/NOTE_xcresult.txt"
   fi
 fi

--- a/scripts/dev/doctor.sh
+++ b/scripts/dev/doctor.sh
@@ -3,7 +3,7 @@
 # Reproduces CI steps, generates REPORT.md and report_agent.md you can commit.
 # Usage:
 #   bash scripts/dev/doctor.sh
-#   SCHEME=MyOfflineLLMApp CONFIGURATION=Debug bash scripts/dev/doctor.sh
+#   SCHEME=monGARS CONFIGURATION=Debug bash scripts/dev/doctor.sh
 #   NO_INSTALL=1 SKIP_XCODEGEN=1 bash scripts/dev/doctor.sh
 
 set -euo pipefail
@@ -11,7 +11,7 @@ set -euo pipefail
 ### ───────────────────────────────────────────────────────────────────────────────────
 ### Config (defaults can be overridden via env)
 ### ───────────────────────────────────────────────────────────────────────────────────
-SCHEME="${SCHEME:-MyOfflineLLMApp}"
+SCHEME="${SCHEME:-monGARS}"
 CONFIGURATION="${CONFIGURATION:-Release}"
 BUILD_DIR="${BUILD_DIR:-build}"
 IOS_DIR="${IOS_DIR:-ios}"
@@ -82,7 +82,7 @@ USE_HERMES="${USE_HERMES:-true}"
 ### ───────────────────────────────────────────────────────────────────────────────────
  if [[ -f "scripts/strip_hermes_phase.rb" ]]; then
    log "Scrubbing Hermes 'Replace Hermes' phases in Pods + app projects…"
-   (cd "$IOS_DIR" && bundle exec ruby ../scripts/strip_hermes_phase.rb Pods/Pods.xcodeproj ../ios/MyOfflineLLMApp.xcodeproj) || true
+   (cd "$IOS_DIR" && bundle exec ruby ../scripts/strip_hermes_phase.rb Pods/Pods.xcodeproj ../ios/monGARS.xcodeproj) || true
  else
    log "strip_hermes_phase.rb not found; continuing…"
  fi
@@ -94,7 +94,7 @@ USE_HERMES="${USE_HERMES:-true}"
 
  log "Resolve SPM dependencies…"
  xcodebuild -resolvePackageDependencies \
-   -workspace "$IOS_DIR/MyOfflineLLMApp.xcworkspace" \
+   -workspace "$IOS_DIR/monGARS.xcworkspace" \
    -scheme "$SCHEME" -UseModernBuildSystem=YES || true
 
  log "Archive (or build for simulator) with logs to $BUILD_DIR/xcodebuild.log…"
@@ -102,18 +102,18 @@ USE_HERMES="${USE_HERMES:-true}"
    if [[ "$DESTINATION" == generic/* ]]; then
      # Device archive (unsigned)
      xcodebuild clean archive \
-       -workspace "$IOS_DIR/MyOfflineLLMApp.xcworkspace" \
+       -workspace "$IOS_DIR/monGARS.xcworkspace" \
        -scheme "$SCHEME" \
        -configuration "$CONFIGURATION" \
        -destination "$DESTINATION" \
-       -archivePath "$BUILD_DIR/MyOfflineLLMApp.xcarchive" \
-       -resultBundlePath "$BUILD_DIR/MyOfflineLLMApp.xcresult" \
+       -archivePath "$BUILD_DIR/monGARS.xcarchive" \
+       -resultBundlePath "$BUILD_DIR/monGARS.xcresult" \
        -UseModernBuildSystem=YES \
        CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
    else
      # Simulator build
      xcodebuild \
-       -workspace "$IOS_DIR/MyOfflineLLMApp.xcworkspace" \
+       -workspace "$IOS_DIR/monGARS.xcworkspace" \
        -scheme "$SCHEME" \
        -configuration "$CONFIGURATION" \
        -sdk iphonesimulator \
@@ -128,13 +128,13 @@ USE_HERMES="${USE_HERMES:-true}"
 ### Diagnose: summarize xcodebuild.log + parse .xcresult → write reports
 ### ───────────────────────────────────────────────────────────────────────────────────
  LOG="$BUILD_DIR/xcodebuild.log"
- XCRESULT="$BUILD_DIR/MyOfflineLLMApp.xcresult"
+XCRESULT="$BUILD_DIR/monGARS.xcresult"
 
  cp "$LOG" "$REPORT_DIR/" 2>/dev/null || true
  if [[ -d "$XCRESULT" ]]; then
    log "Copying xcresult bundle to report dir…"
    # xcresult can be huge; copy the JSON summary + keep a symlink to the original bundle
-   (cd "$REPORT_DIR" && ln -sf "../../$XCRESULT" "MyOfflineLLMApp.xcresult")
+   (cd "$REPORT_DIR" && ln -sf "../../$XCRESULT" "monGARS.xcresult")
  fi
 
  # Extract issues from xcresult (if present)
@@ -184,7 +184,7 @@ USE_HERMES="${USE_HERMES:-true}"
    echo "## Top XCResult issues"
    if [[ -f "$XC_SUMMARY_JSON" ]]; then
      echo
-     echo "Parsed from \`MyOfflineLLMApp.xcresult\`:"
+     echo "Parsed from \`monGARS.xcresult\`:"
      echo
      # Pull out topDiagnostics if present (keep it short)
      /usr/bin/python3 - "$XC_SUMMARY_JSON" <<'PY' || true

--- a/tools/xcresult-parser.js
+++ b/tools/xcresult-parser.js
@@ -56,8 +56,7 @@ export function parseXCResult(xcresultPath) {
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  const target =
-    process.argv[2] || path.join("build", "MyOfflineLLMApp.xcresult");
+  const target = process.argv[2] || path.join("build", "monGARS.xcresult");
   const res = parseXCResult(target);
   if (!res.ok) {
     console.error(JSON.stringify(res, null, 2));


### PR DESCRIPTION
## Summary
- build iOS unsigned workflow against a generic device and force a clean build
- locate the built .app with `find` to avoid fragile Release-iphoneos assumptions

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68be6529c294833383e841ec799bb8b6

## Summary by Sourcery

Improve the iOS unsigned GitHub Actions workflow for more reliable builds and packaging

CI:
- Enforce a clean build in the xcodebuild invocation by adding the `clean` action
- Use `find` to dynamically locate the generated .app in the derived products directory instead of assuming Release-iphoneos
- Add a debug group to list the build products directory contents when packaging fails to aid troubleshooting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - More reliable iOS unsigned builds with dynamic .app discovery, improved diagnostics and clearer error messages.

- Chores
  - Project rebranded to "monGARS": app name/display name, bundle identifiers, and CI/artifact names updated across build and packaging flows.
  - Build workflows/scripts updated to separate dependency resolution, sanity checks, and build steps.

- Refactor
  - Android package namespace and native/JNI entry names updated to reflect the new package. 

- Documentation
  - README, playbook, and reports updated to monGARS naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->