### PR TITLE
ci: replace base64 quality workflow

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -1,1 +1,44 @@
-bmFtZTogUXVhbGl0eSBDaGVja3MKCm9uOiBbcHVzaCwgcHVsbF9yZXF1ZXN0XQoKam9iczogCiAgdGVzdDoKICAgICBydW5zLW9uOiB1YnVudHUtbGF0ZXN0CiAgICAgc3RlcHM6CiAgICAgIC0gbmFtZTogQ2hlY2tvdXQgY29kZQogICAgICAgICB1c2VzOiBhY3Rpb25zL2NoZWNrb3V0QHYyCiAgICAgIC0gbmFtZTogU2V0dXAgTm9kZS5qcwogICAgICAgICB1c2VzOiBhY3Rpb25zL3NldHVwLW5vZGVAdjIKICAgICAgICAgd2l0aDoKICAgICAgICAgICAgbm9kZS12ZXJzaW9uOiAnMTQnCiAgICAgIC0gbmFtZTogSW5zdGFsbCBkZXBlbmRlbmNpZXMKICAgICAgICAgcnVuOiBuZXBtIGluc3RhbGwKCiAgICAgIC0gbmFtZTogUnVuIHRlc3RzCiAgICAgICAgIHJ1bjogbnBtIHRlc3QKCiAgbGludDoKICAgICBydW5zLW9uOiB1YnVudHUtbGF0ZXN0CiAgICAgc3RlcHM6CiAgICAgIC0gbmFtZTogQ2hlY2tvdXQgY29kZQogICAgICAgICB1c2VzOiBhY3Rpb25zL2NoZWNrb3V0QHYyCiAgICAgIC0gbmFtZTogU2V0dXAgTm9kZS5qcwogICAgICAgICB1c2VzOiBhY3Rpb25zL3NldHVwLW5vZGVAdjIKICAgICAgICAgd2l0aDoKICAgICAgICAgICAgbm9kZS12ZXJzaW9uOiAnMTQnCiAgICAgIC0gbmFtZTogSW5zdGFsbCBkZXBlbmRlbmNpZXMKICAgICAgICAgcnVuOiBuZXBtIGluc3RhbGwKCiAgICAgIC0gbmFtZTogUnVuIGxpbnRlcgogICAgICAgIHJ1bjogbnBtIHJ1biBsaW50CgogIHNlY3VyaXR5LWNoZWNrOgogICAgIHJ1bnMtb246IHVidW50dS1sYXRlc3QKICAgICBzdGVwczogCiAgICAgIC0gbmFtZTogQ2hlY2tvdXQgY29kZQogICAgICAgICB1c2VzOiBhY3Rpb25zL2NoZWNrb3V0QHYyCiAgICAgIC0gbmFtZTogU2V0dXAgTm9kZS5qcwogICAgICAgICB1c2VzOiBhY3Rpb25zL3NldHVwLW5vZGVAdjIKICAgICAgICAgd2l0aDoKICAgICAgICAgICAgbm9kZS12ZXJzaW9uOiAnMTQnCiAgICAgIC0gbmFtZTogSW5zdGFsbCBkZXBlbmRlbmNpZXMKICAgICAgICAgcnVuOiBuZXBtIGluc3RhbGwKCiAgICAgIC0gbmFtZTogUnVuIHNlY3VyaXR5IGF1ZGl0CiAgICAgICAgIHJ1bjogbnBtIGF1ZGl0
+name: Quality Checks
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
+  lint:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run linter
+        run: npm run lint
+  security-check:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run security audit
+        run: npm audit

--- a/.github/workflows/test_and_analysis.yml
+++ b/.github/workflows/test_and_analysis.yml
@@ -4,26 +4,28 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: macos-15
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 20.x
+          cache: npm
       - name: Install dependencies
         run: npm ci
       - name: Run tests
         run: npm test
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: macos-15
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 20.x
+          cache: npm
       - name: Install dependencies
         run: npm ci
       - name: Run lint

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ To report a bug, please follow these steps:
 ## Do not commit (generated)
 
 - ios/Pods/
-- any *.xcworkspace
+- any \*.xcworkspace
 - DerivedData/
-- *.xcfilelist
+- \*.xcfilelist
 
 ---
 


### PR DESCRIPTION
## Summary
- replace base64 workflow with valid YAML and Node 20
- upgrade test and lint workflow to macos-15 and actions v4
- format readme

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68bfa69226ac833384820dc6f169dc61

## Summary by Sourcery

Revamp CI workflows to use Node.js 20 on macOS-15 runners with actions v4 and update README formatting.

CI:
- Replace base64 quality-checks workflow with a valid YAML-based workflow using Node.js 20, macOS-15, actions/checkout@v4, actions/setup-node@v4, and npm cache
- Upgrade test_and_analysis workflow to run on macOS-15 with actions/checkout@v4, actions/setup-node@v4 (Node.js 20.x), caching, and npm ci

Documentation:
- Escape wildcard patterns in README to prevent accidental commits of generated files