### PR TITLE
feat: shared Postgres memory with pgvector

### DIFF
--- a/__tests__/pgVectorStore.test.js
+++ b/__tests__/pgVectorStore.test.js
@@ -1,0 +1,16 @@
+import { newDb } from "pg-mem";
+import PgVectorStore from "../src/utils/pgVectorStore";
+
+test("PgVectorStore stores and retrieves vectors", async () => {
+  const db = newDb();
+  const { Pool } = db.adapters.createPg();
+  const pool = new Pool();
+  const store = new PgVectorStore({ pool, dimensions: 2 });
+  // pg-mem lacks pgvector; skip extension by forcing fallback
+  store.useArrayFallback = true;
+  await store.initialize();
+  await store.addVector("hello", [1, 0]);
+  await store.addVector("world", [0, 1]);
+  const res = await store.searchVectors([1, 0], 1);
+  expect(res[0].content).toBe("hello");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "commander": "^14.0.0",
         "crypto-js": "4.2.0",
         "langchain": "^0.3.31",
+        "pg": "^8.13.0",
+        "pgvector": "^0.2.1",
         "react": "19.1.1",
         "react-native": "0.81.1",
         "react-native-config": "^1.5.9",
@@ -51,6 +53,7 @@
         "eslint": "^9.35.0",
         "eslint-plugin-react": "^7.37.5",
         "jest": "^30.1.1",
+        "pg-mem": "^3.0.5",
         "prettier": "^3.6.2",
         "react-test-renderer": "19.1.1",
         "typescript": "5.9.2"
@@ -7827,6 +7830,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -9342,6 +9352,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
@@ -9929,6 +9946,13 @@
       "engines": {
         "node": ">=16.x"
       }
+    },
+    "node_modules/immutable": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -11728,6 +11752,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -11755,6 +11799,16 @@
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonpointer": {
@@ -13138,6 +13192,16 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/mongodb": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.18.0.tgz",
@@ -13194,6 +13258,13 @@
         "whatwg-url": "^14.1.0 || ^13.0.0"
       }
     },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -13238,6 +13309,36 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/nearley/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -13388,6 +13489,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -13970,6 +14081,194 @@
         "node": ">=8"
       }
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-mem": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/pg-mem/-/pg-mem-3.0.5.tgz",
+      "integrity": "sha512-Bh8xHD6u/wUXCoyFE2vyRs5pgaKbqjWFQowKDlbKWCiF0vOlo2A0PZdiUxmf2PKgb6Vb6C7gwAlA7jKvsfDHZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "functional-red-black-tree": "^1.0.1",
+        "immutable": "^4.3.4",
+        "json-stable-stringify": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "moment": "^2.27.0",
+        "object-hash": "^2.0.3",
+        "pgsql-ast-parser": "^12.0.1"
+      },
+      "peerDependencies": {
+        "@mikro-orm/core": ">=4.5.3",
+        "@mikro-orm/postgresql": ">=4.5.3",
+        "knex": ">=0.20",
+        "kysely": ">=0.26",
+        "pg-promise": ">=10.8.7",
+        "pg-server": "^0.1.5",
+        "postgres": "^3.4.4",
+        "slonik": ">=23.0.1",
+        "typeorm": ">=0.2.29"
+      },
+      "peerDependenciesMeta": {
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@mikro-orm/postgresql": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mikro-orm": {
+          "optional": true
+        },
+        "pg-promise": {
+          "optional": true
+        },
+        "pg-server": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "slonik": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-mem/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pg-mem/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/pgsql-ast-parser": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/pgsql-ast-parser/-/pgsql-ast-parser-12.0.1.tgz",
+      "integrity": "sha512-pe8C6Zh5MsS+o38WlSu18NhrTjAv1UNMeDTs2/Km2ZReZdYBYtwtbWGZKK2BM2izv5CrQpbmP0oI10wvHOwv4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moo": "^0.5.1",
+        "nearley": "^2.19.5"
+      }
+    },
+    "node_modules/pgvector": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/pgvector/-/pgvector-0.2.1.tgz",
+      "integrity": "sha512-nKaQY9wtuiidwLMdVIce1O3kL0d+FxrigCVzsShnoqzOSaWWWOvuctb/sYwlai5cTwwzRSNa+a/NtN2kVZGNJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -14138,6 +14437,45 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14427,11 +14765,32 @@
       ],
       "license": "MIT"
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/ramda": {
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
       "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
       "license": "MIT"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -15749,6 +16108,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -16667,6 +17036,15 @@
       "license": "MIT",
       "dependencies": {
         "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
     "react-native-vibration": "^0.2.0",
     "rxdb": "^16.19.0",
     "tiktoken": "^1.0.22",
-    "zustand": "^5.0.8"
+    "zustand": "^5.0.8",
+    "pg": "^8.13.0",
+    "pgvector": "^0.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.28.4",
@@ -73,7 +75,8 @@
     "jest": "^30.1.1",
     "prettier": "^3.6.2",
     "react-test-renderer": "19.1.1",
-    "typescript": "5.9.2"
+    "typescript": "5.9.2",
+    "pg-mem": "^3.0.5"
   },
   "overrides": {
     "@types/react": "^19.1.12"

--- a/src/core/memory/MemoryManager.js
+++ b/src/core/memory/MemoryManager.js
@@ -1,4 +1,6 @@
 import { HNSWVectorStore } from "../../utils/hnswVectorStore";
+import PgVectorStore from "../../utils/pgVectorStore";
+import { getEnv } from "../../config";
 import LLMService from "../../services/llmService";
 import { applySparseAttention } from "../../utils/sparseAttention";
 import VectorIndexer from "./services/VectorIndexer";
@@ -6,13 +8,12 @@ import Retriever from "./services/Retriever";
 import HistoryService from "./services/HistoryService";
 
 export class MemoryManager {
-  constructor({
-    vectorStore = new HNSWVectorStore(),
-    indexer,
-    retriever,
-    history,
-  } = {}) {
-    const store = vectorStore;
+  constructor({ vectorStore, indexer, retriever, history } = {}) {
+    const store =
+      vectorStore ||
+      (getEnv("PGVECTOR_URL") || getEnv("DATABASE_URL")
+        ? new PgVectorStore()
+        : new HNSWVectorStore());
     this.indexer = indexer || new VectorIndexer(store, LLMService);
     this.retriever =
       retriever || new Retriever(store, LLMService, applySparseAttention);

--- a/src/utils/pgVectorStore.js
+++ b/src/utils/pgVectorStore.js
@@ -1,0 +1,113 @@
+import { Pool } from "pg";
+import { cosineSimilarity } from "./vectorUtils";
+
+function toPgVector(arr) {
+  return `[${arr.join(",")}]`;
+}
+
+function toPgArray(arr) {
+  return `{${arr.join(",")}}`;
+}
+
+export class PgVectorStore {
+  constructor({
+    connectionString = process.env.PGVECTOR_URL || process.env.DATABASE_URL,
+    tableName = "agent_memory",
+    dimensions = 1536,
+    pool,
+  } = {}) {
+    this.connectionString = connectionString;
+    this.tableName = tableName;
+    this.dimensions = dimensions;
+    this.pool = pool || null;
+    this.initialized = false;
+    this.useArrayFallback = false;
+    this.nodeMap = new Map();
+  }
+
+  async _getPool() {
+    if (!this.pool) {
+      this.pool = new Pool({ connectionString: this.connectionString });
+    }
+    return this.pool;
+  }
+
+  async initialize() {
+    if (this.initialized) return;
+    const pool = await this._getPool();
+    let type = `vector(${this.dimensions})`;
+    if (!this.useArrayFallback) {
+      try {
+        await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
+      } catch (e) {
+        console.warn(
+          "pgvector extension unavailable, falling back to float8[] storage",
+          e,
+        );
+        this.useArrayFallback = true;
+      }
+    }
+    if (this.useArrayFallback) {
+      type = "double precision[]";
+    }
+    await pool.query(
+      `CREATE TABLE IF NOT EXISTS ${this.tableName} (\n        id SERIAL PRIMARY KEY,\n        content TEXT NOT NULL,\n        metadata JSONB,\n        embedding ${type}\n      )`,
+    );
+    this.initialized = true;
+  }
+
+  async addVector(content, vector, metadata = {}) {
+    await this.initialize();
+    const pool = await this._getPool();
+    const vec = this.useArrayFallback ? toPgArray(vector) : toPgVector(vector);
+    const cast = this.useArrayFallback ? "::double precision[]" : "::vector";
+    const res = await pool.query(
+      `INSERT INTO ${this.tableName} (content, metadata, embedding) VALUES ($1, $2, $3${cast}) RETURNING id`,
+      [content, metadata, vec],
+    );
+    const id = res.rows[0].id;
+    this.nodeMap.set(id, { content, metadata, vector });
+    return id;
+  }
+
+  async searchVectors(queryVector, limit = 5) {
+    await this.initialize();
+    const pool = await this._getPool();
+    if (!this.useArrayFallback) {
+      const q = toPgVector(queryVector);
+      const res = await pool.query(
+        `SELECT id, content, metadata, embedding <=> $1 AS dist FROM ${this.tableName} ORDER BY embedding <=> $1 LIMIT $2`,
+        [q, limit],
+      );
+      return res.rows.map((r) => ({
+        id: r.id,
+        content: r.content,
+        metadata: r.metadata,
+        similarity: 1 - Number(r.dist),
+      }));
+    }
+    // Fallback when pgvector extension is not available
+    const res = await pool.query(
+      `SELECT id, content, metadata, embedding FROM ${this.tableName}`,
+    );
+    const scored = res.rows.map((row) => {
+      const emb = row.embedding;
+      const sim = cosineSimilarity(queryVector, emb);
+      this.nodeMap.set(row.id, {
+        content: row.content,
+        metadata: row.metadata,
+        vector: emb,
+      });
+      return {
+        id: row.id,
+        content: row.content,
+        metadata: row.metadata,
+        similarity: sim,
+      };
+    });
+    scored.sort((a, b) => b.similarity - a.similarity);
+    return scored.slice(0, limit);
+  }
+}
+
+export default PgVectorStore;


### PR DESCRIPTION
## Summary
- add Postgres/pgvector vector store for cross-agent memory
- switch memory manager to Postgres store when connection URL is set
- cover PgVectorStore with unit tests

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check` *(fails: Code style issues found in 6 files. Run Prettier with --write to fix.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0404f47648333bb1bbf6b21b7d94f

## Summary by Sourcery

Provide support for a Postgres/pgvector-based vector store, update MemoryManager to auto-select it via environment variables, implement a fallback for missing pgvector extension, and add corresponding unit tests

New Features:
- Add PgVectorStore for Postgres-backed cross-agent memory storage
- Switch MemoryManager to use PgVectorStore when PGVECTOR_URL or DATABASE_URL is configured

Enhancements:
- Implement fallback to double precision array storage if pgvector extension is unavailable

Build:
- Add pg, pgvector, and pg-mem dependencies to package.json

Tests:
- Add unit tests for PgVectorStore functionality