### PR TITLE
Update MLXModule.swift

### DIFF
--- a/ios/MyOfflineLLMApp/MLXModule.swift
+++ b/ios/MyOfflineLLMApp/MLXModule.swift
@@ -77,7 +77,7 @@ extension MLXModule {
   public func setPerformanceMode(_ mode: NSString,
                                  resolver resolve: @escaping RCTPromiseResolveBlock,
                                  rejecter reject: @escaping RCTPromiseRejectBlock) {
-    let valid: Set<String> = ["high_quality", "balanced", "low_power"]
+    let valid: Set = ["high_quality", "balanced", "low_power"]
     let value = mode as String
     if valid.contains(value) {
       self.performanceMode = value


### PR DESCRIPTION
## Summary by Sourcery

Simplify the `valid` set declaration by inferring its generic type and add a missing newline at end of file

Enhancements:
- Remove explicit `String` generic parameter from `Set` initialization to leverage type inference
- Add newline at end of `MLXModule.swift` file