### PR TITLE
fix: capture SPM resolve xcresult

### DIFF
--- a/.github/workflows/ios-unsigned-device.yml
+++ b/.github/workflows/ios-unsigned-device.yml
@@ -109,10 +109,13 @@ jobs:
           set -euxo pipefail
           RB="$DERIVED_DATA/ResultBundle.xcresult"
           rm -rf "$RB"
+          mkdir -p "$DERIVED_DATA"
           xcodebuild -resolvePackageDependencies \
             -${XCODE_CONTAINER_TYPE} "$XCODE_CONTAINER" \
             -scheme "$SCHEME" \
-            -clonedSourcePackagesDirPath "$DERIVED_DATA/SourcePackages"
+            -clonedSourcePackagesDirPath "$DERIVED_DATA/SourcePackages" \
+            -derivedDataPath "$DERIVED_DATA" \
+            -resultBundlePath "$RB"
 
       - name: Export resolve-package xcresult JSON
         if: always()

--- a/.github/workflows/ios-unsigned-device.yml
+++ b/.github/workflows/ios-unsigned-device.yml
@@ -116,11 +116,31 @@ jobs:
             -clonedSourcePackagesDirPath "$DERIVED_DATA/SourcePackages" \
             -derivedDataPath "$DERIVED_DATA" \
             -resultBundlePath "$RB"
+          RESOLVE_RESULT_BUNDLE=""
+          if [ -d "$RB" ]; then
+            RESOLVE_RESULT_BUNDLE="$RB"
+          elif [ -d "$DERIVED_DATA/Logs" ]; then
+            while IFS= read -r candidate; do
+              if [ -z "$RESOLVE_RESULT_BUNDLE" ]; then
+                RESOLVE_RESULT_BUNDLE="$candidate"
+              else
+                BEST_MTIME="$(stat -f %m "$RESOLVE_RESULT_BUNDLE")"
+                CANDIDATE_MTIME="$(stat -f %m "$candidate")"
+                if [ "$CANDIDATE_MTIME" -gt "$BEST_MTIME" ]; then
+                  RESOLVE_RESULT_BUNDLE="$candidate"
+                fi
+              fi
+            done < <(find "$DERIVED_DATA/Logs" -type d \( -name 'ResolvePackageDependencies_*.xcresult' -o -name 'ResolveAppPackages_*.xcresult' \))
+          fi
+          if [ -n "$RESOLVE_RESULT_BUNDLE" ]; then
+            echo "RESOLVE_RESULT_BUNDLE=$RESOLVE_RESULT_BUNDLE" >> "$GITHUB_ENV"
+          fi
 
       - name: Export resolve-package xcresult JSON
         if: always()
         run: |
-          RB="$DERIVED_DATA/ResultBundle.xcresult"
+          set -euo pipefail
+          RB="${RESOLVE_RESULT_BUNDLE:-$DERIVED_DATA/ResultBundle.xcresult}"
           mkdir -p build
           if [ -d "$RB" ]; then
             if ! xcrun xcresulttool get --legacy --path "$RB" --format json > build/ResultBundle_resolve.json 2>/dev/null; then

--- a/.github/workflows/ios-unsigned-device.yml
+++ b/.github/workflows/ios-unsigned-device.yml
@@ -119,18 +119,27 @@ jobs:
           RESOLVE_RESULT_BUNDLE=""
           if [ -d "$RB" ]; then
             RESOLVE_RESULT_BUNDLE="$RB"
-          elif [ -d "$DERIVED_DATA/Logs" ]; then
-            while IFS= read -r candidate; do
-              if [ -z "$RESOLVE_RESULT_BUNDLE" ]; then
-                RESOLVE_RESULT_BUNDLE="$candidate"
-              else
-                BEST_MTIME="$(stat -f %m "$RESOLVE_RESULT_BUNDLE")"
-                CANDIDATE_MTIME="$(stat -f %m "$candidate")"
-                if [ "$CANDIDATE_MTIME" -gt "$BEST_MTIME" ]; then
-                  RESOLVE_RESULT_BUNDLE="$candidate"
+          fi
+          SEARCH_ROOTS=("$DERIVED_DATA/Logs" "$HOME/Library/Developer/Xcode/DerivedData")
+          for root in "${SEARCH_ROOTS[@]}"; do
+            if [ -d "$root" ]; then
+              while IFS= read -r candidate; do
+                if [ -d "$candidate" ]; then
+                  if [ -z "$RESOLVE_RESULT_BUNDLE" ]; then
+                    RESOLVE_RESULT_BUNDLE="$candidate"
+                  else
+                    BEST_MTIME="$(stat -f %m "$RESOLVE_RESULT_BUNDLE")"
+                    CANDIDATE_MTIME="$(stat -f %m "$candidate")"
+                    if [ "$CANDIDATE_MTIME" -gt "$BEST_MTIME" ]; then
+                      RESOLVE_RESULT_BUNDLE="$candidate"
+                    fi
+                  fi
                 fi
-              fi
-            done < <(find "$DERIVED_DATA/Logs" -type d \( -name 'ResolvePackageDependencies_*.xcresult' -o -name 'ResolveAppPackages_*.xcresult' \))
+              done < <(find "$root" -type d -path '*/Logs/Resolve*.xcresult')
+            fi
+          done
+          if [ -n "$RESOLVE_RESULT_BUNDLE" ]; then
+            echo "Using resolve bundle at $RESOLVE_RESULT_BUNDLE"
           fi
           if [ -n "$RESOLVE_RESULT_BUNDLE" ]; then
             echo "RESOLVE_RESULT_BUNDLE=$RESOLVE_RESULT_BUNDLE" >> "$GITHUB_ENV"

--- a/src/debug/useDebugSettings.ts
+++ b/src/debug/useDebugSettings.ts
@@ -14,7 +14,7 @@ const devFlag =
 const isDevelopment =
   typeof devFlag === "boolean"
     ? devFlag
-    : (process?.env?.NODE_ENV?.toLowerCase?.() === "development");
+    : process?.env?.NODE_ENV?.toLowerCase?.() === "development";
 const DEBUG_LOGGING = Config.DEBUG_LOGGING === "1";
 
 if (DEBUG_LOGGING) {


### PR DESCRIPTION
## Summary
- ensure the iOS unsigned device workflow creates the resolve-package xcresult by configuring derived data and the result bundle path

## Testing
- npm test
- npm run lint
- npm run format:check *(fails: prettier reports existing style issues in src/debug/useDebugSettings.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b20f85648333a145d4c2715bba06

## Summary by Sourcery

CI:
- Ensure the workflow creates the derived data directory and passes -derivedDataPath and -resultBundlePath to xcodebuild for Swift Package resolve results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.

- Chores
  - Improved iOS build workflow to create and store a dedicated build result bundle, ensuring Swift package resolution outputs are captured reliably.

- Style
  - Minor code cleanup in debug settings with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->