### PR TITLE
fix: repair react-native-contacts compile failure and stabilize env handling

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,0 +1,18 @@
+# Default environment values used when a project-specific .env is absent.
+# These placeholders unblock local iOS builds and CI bootstrap scripts.
+MEMORY_ENCRYPTION_KEY=dev-placeholder-32-byte-secret
+MEMORY_MAX_MB=10
+MEMORY_ENABLED=true
+EMOTION_AUDIO_ENABLED=false
+GOOGLE_API_KEY=
+GOOGLE_SEARCH_ENGINE_ID=
+BING_API_KEY=
+BRAVE_API_KEY=
+MODEL_URL=
+
+# iOS build defaults
+APP_IDENTIFIER=com.offllm.mongars
+BUNDLE_IDENTIFIER=com.offllm.mongars
+FASTLANE_USER=ci@offllm.invalid
+SCHEME=monGARS
+CONFIGURATION=Release

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR"
+ENV_FILE="$ROOT_DIR/.env"
+DEFAULT_ENV_FILE="$ROOT_DIR/.env.default"
+
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+elif [ -f "$DEFAULT_ENV_FILE" ]; then
+  echo "ℹ️ No .env file found; loading defaults from $DEFAULT_ENV_FILE"
+  set -a
+  # shellcheck disable=SC1090
+  source "$DEFAULT_ENV_FILE"
+  set +a
+fi
+
 # Configuration
 # Default to the monGARS scheme
 : "${SCHEME:=monGARS}"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -151,5 +151,16 @@ post_install do |installer|
     end
     user_project.save
   end
+
+  patch_script = File.join(__dir__, 'scripts', 'patch-react-native-contacts.sh')
+  if File.exist?(patch_script)
+    Pod::UI.puts('[Podfile] Ensuring react-native-contacts orientation compatibility…')
+    env = { 'PODS_ROOT' => installer.sandbox.root.to_s }
+    unless system(env, 'bash', patch_script)
+      Pod::UI.warn('[Podfile] Failed to patch react-native-contacts orientation enum.')
+    end
+  else
+    Pod::UI.warn('[Podfile] Missing ios/scripts/patch-react-native-contacts.sh; skipping contacts orientation patch.')
+  end
 end
 

--- a/ios/scripts/patch-react-native-contacts.sh
+++ b/ios/scripts/patch-react-native-contacts.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PODS_DIR="${PODS_ROOT:-$PROJECT_ROOT/Pods}"
+TARGET_FILE="$PODS_DIR/react-native-contacts/ios/RCTContacts.mm"
+
+if [ ! -f "$TARGET_FILE" ]; then
+  echo "ℹ️ react-native-contacts pod not found at $TARGET_FILE; skipping orientation patch."
+  exit 0
+fi
+
+python3 - "$TARGET_FILE" <<'PY'
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text()
+updated = False
+
+if '#import <ImageIO/CGImageProperties.h>' not in text:
+    marker = '#import <Photos/Photos.h>'
+    if marker in text:
+        text = text.replace(
+            marker,
+            marker + '\n#import <ImageIO/CGImageProperties.h>',
+            1,
+        )
+        updated = True
+
+pattern = re.compile(r'UIImageOrientation(?![A-Za-z0-9_])')
+new_text, count = pattern.subn('CGImagePropertyOrientation', text)
+if count:
+    text = new_text
+    updated = True
+
+if updated:
+    path.write_text(text)
+    print(f"✅ Patched {path} for CGImagePropertyOrientation compatibility.")
+else:
+    print(f"ℹ️ {path} already uses CGImagePropertyOrientation; no changes made.")
+PY

--- a/patches/react-native-contacts+8.0.7.patch
+++ b/patches/react-native-contacts+8.0.7.patch
@@ -5,6 +5,7 @@ index 5e2f0d6..ff51127 100644
 @@ -6,6 +6,62 @@
  #import <React/RCTUtils.h>
  #import <Photos/Photos.h>
++#import <ImageIO/CGImageProperties.h>
  
 +static UIWindow *RCTContactsActiveWindow(void)
 +{
@@ -189,7 +190,7 @@ index 5e2f0d6..ff51127 100644
 +
 +        [imageManager requestImageDataAndOrientationForAsset:asset
 +                                                     options:options
-+                                               resultHandler:^(NSData * _Nullable data, __unused NSString * _Nullable dataUTI, __unused UIImageOrientation orientation, __unused NSDictionary * _Nullable info) {
++                                               resultHandler:^(NSData * _Nullable data, __unused NSString * _Nullable dataUTI, __unused CGImagePropertyOrientation orientation, __unused NSDictionary * _Nullable info) {
 +            imageData = data;
 +            dispatch_semaphore_signal(semaphore);
 +        }];

--- a/scripts/build_unsigned_ios.sh
+++ b/scripts/build_unsigned_ios.sh
@@ -1,6 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="$ROOT_DIR/.env"
+DEFAULT_ENV_FILE="$ROOT_DIR/.env.default"
+
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+elif [ -f "$DEFAULT_ENV_FILE" ]; then
+  echo "ℹ️ No .env file found; loading defaults from $DEFAULT_ENV_FILE"
+  set -a
+  # shellcheck disable=SC1090
+  source "$DEFAULT_ENV_FILE"
+  set +a
+fi
+
 # Simple unsigned iOS Simulator build helper. Assumes pods and project are ready.
 
 ROOT="$(pwd)"

--- a/scripts/ci/bootstrap-build.sh
+++ b/scripts/ci/bootstrap-build.sh
@@ -1,6 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ENV_FILE="$ROOT_DIR/.env"
+DEFAULT_ENV_FILE="$ROOT_DIR/.env.default"
+
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+elif [ -f "$DEFAULT_ENV_FILE" ]; then
+  echo "ℹ️ No .env file found; loading defaults from $DEFAULT_ENV_FILE"
+  set -a
+  # shellcheck disable=SC1090
+  source "$DEFAULT_ENV_FILE"
+  set +a
+fi
+
 SCHEME="${SCHEME:-monGARS}"
 CONFIGURATION="${CONFIGURATION:-Release}"
 BUILD_DIR="${BUILD_DIR:-build}"

--- a/scripts/ci/bootstrap_ios.sh
+++ b/scripts/ci/bootstrap_ios.sh
@@ -1,6 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ENV_FILE="$ROOT_DIR/.env"
+DEFAULT_ENV_FILE="$ROOT_DIR/.env.default"
+
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+elif [ -f "$DEFAULT_ENV_FILE" ]; then
+  echo "ℹ️ No .env file found; loading defaults from $DEFAULT_ENV_FILE"
+  set -a
+  # shellcheck disable=SC1090
+  source "$DEFAULT_ENV_FILE"
+  set +a
+fi
+
 # ---------- Global logging (always captured) ----------
 mkdir -p build
 # Capture EVERYTHING (stdout+stderr) into build/bootstrap.log while also printing to console

--- a/scripts/dev/doctor.sh
+++ b/scripts/dev/doctor.sh
@@ -8,6 +8,24 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ENV_FILE="$ROOT_DIR/.env"
+DEFAULT_ENV_FILE="$ROOT_DIR/.env.default"
+
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+elif [ -f "$DEFAULT_ENV_FILE" ]; then
+  echo "ℹ️ No .env file found; loading defaults from $DEFAULT_ENV_FILE"
+  set -a
+  # shellcheck disable=SC1090
+  source "$DEFAULT_ENV_FILE"
+  set +a
+fi
+
 ### ───────────────────────────────────────────────────────────────────────────────────
 ### Config (defaults can be overridden via env)
 ### ───────────────────────────────────────────────────────────────────────────────────

--- a/scripts/ios_doctor.sh
+++ b/scripts/ios_doctor.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="$ROOT_DIR/.env"
+DEFAULT_ENV_FILE="$ROOT_DIR/.env.default"
+
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+elif [ -f "$DEFAULT_ENV_FILE" ]; then
+  echo "ℹ️ No .env file found; loading defaults from $DEFAULT_ENV_FILE"
+  set -a
+  # shellcheck disable=SC1090
+  source "$DEFAULT_ENV_FILE"
+  set +a
+fi
+
 IOS_DIR="${1:-"$ROOT_DIR/ios"}"
 WS=""
 for ws in "$IOS_DIR"/*.xcworkspace; do


### PR DESCRIPTION
## Summary
- patch the react-native-contacts pod after install so RCTContacts.mm imports ImageIO and uses CGImagePropertyOrientation
- add an .env.default and teach all iOS build/doctor scripts to source it whenever a project-specific .env is absent

## Testing
- npm test
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68c9bd27ce9c8333b4e8544690eedddd