### PR TITLE
fix: remove Hermes replacement build phase during pod install

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -120,6 +120,37 @@ post_install do |installer|
     end
   end
 
+  hermes_phase_labels = ['[Hermes] Replace Hermes']
+  remove_hermes_phase = lambda do |target, scope|
+    return 0 unless target.respond_to?(:shell_script_build_phases)
+
+    phases = target.shell_script_build_phases.select do |phase|
+      phase_name = phase.respond_to?(:name) ? phase.name.to_s.strip : ''
+      display_name =
+        if phase.respond_to?(:display_name)
+          phase.display_name.to_s.strip
+        else
+          phase_name
+        end
+      hermes_phase_labels.include?(phase_name) || hermes_phase_labels.include?(display_name)
+    end
+
+    phases.each do |phase|
+      label = if phase.respond_to?(:display_name)
+                phase.display_name
+              elsif phase.respond_to?(:name)
+                phase.name
+              else
+                '[Hermes] Replace Hermes'
+              end
+      Pod::UI.puts("[Podfile] Removing '#{label}' build phase from #{scope} target #{target.name}")
+      target.build_phases.delete(phase)
+    end
+
+    phases.length
+  end
+
+  pods_project_removed = 0
   installer.pods_project.targets.each do |t|
     t.build_configurations.each do |c|
       # Match project + satisfy RN 0.81+ minimums
@@ -136,7 +167,9 @@ post_install do |installer|
       c.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'YES'
       c.build_settings['DISABLE_INPUT_OUTPUT_PATHS'] = 'YES' if ENV['CI']
     end
+    pods_project_removed += remove_hermes_phase.call(t, 'Pods')
   end
+  installer.pods_project.save if pods_project_removed.positive?
 
   installer.aggregate_targets.each do |aggregate_target|
     user_project = aggregate_target.user_project
@@ -150,6 +183,7 @@ post_install do |installer|
         config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '18.0'
         config.build_settings['DISABLE_INPUT_OUTPUT_PATHS'] = 'YES' if ENV['CI']
       end
+      remove_hermes_phase.call(t, 'user')
     end
     user_project.save
   end


### PR DESCRIPTION
## Summary
- remove the `[Hermes] Replace Hermes` shell script from Pods and user targets so the device archive no longer trips over Hermes rewrites
- persist pod project changes after scrubbing the Hermes phase to keep the workflow output deterministic

## Testing
- npm test
- npm run lint
- CI=1 npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68c9e5524de88333b6c6021b3713ba67

## Summary by Sourcery

Remove the Hermes replacement build phase from iOS Pod and user targets during post-install and persist project changes to prevent archive failures and ensure deterministic CI output

Bug Fixes:
- Remove '[Hermes] Replace Hermes' shell script build phase from Pods and user targets to fix device archive errors

Enhancements:
- Save the Pods project only when Hermes phases have been removed to keep the workflow output deterministic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Prevents duplicate Hermes build steps that could cause iOS build warnings or failures.
- Chores
  - Streamlined iOS build process by automatically removing redundant Hermes-related build phases during installation.
  - Applies cleanup across Pods and user targets with scoped logging.
  - Saves project changes only when updates occur, reducing unnecessary churn.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->