### PR TITLE
feat: add workflow tracer logging instrumentation

### DIFF
--- a/__tests__/workflowTracer.test.js
+++ b/__tests__/workflowTracer.test.js
@@ -1,0 +1,57 @@
+describe("WorkflowTracer", () => {
+  let WorkflowTracer;
+  let loggerModule;
+  let logger;
+  let LogLevel;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "info").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    loggerModule = require("../src/utils/logger");
+    ({ logger, LogLevel } = loggerModule);
+    ({ WorkflowTracer } = require("../src/core/workflows/WorkflowTracer"));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("records lifecycle information for successful steps", async () => {
+    const tracer = new WorkflowTracer({ workflowName: "TestFlow" });
+    await tracer.withStep("demo", async () => "ok", {
+      startData: { note: "begin" },
+      successData: (value) => ({ value }),
+    });
+    tracer.finish({ summary: true });
+
+    const logs = logger.getLogs();
+    expect(
+      logs.some(
+        (entry) =>
+          entry.level === LogLevel.INFO && entry.message.includes("demo"),
+      ),
+    ).toBe(true);
+    expect(
+      logs.some((entry) => entry.message.includes("Workflow completed")),
+    ).toBe(true);
+  });
+
+  it("logs failures and rethrows errors", async () => {
+    const tracer = new WorkflowTracer({ workflowName: "TestFlow" });
+    await expect(
+      tracer.withStep("willFail", async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    const errorLogs = logger.getLogs(LogLevel.ERROR);
+    expect(errorLogs.some((entry) => entry.message.includes("willFail"))).toBe(
+      true,
+    );
+  });
+});

--- a/src/core/AgentOrchestrator.js
+++ b/src/core/AgentOrchestrator.js
@@ -4,6 +4,25 @@ import MemoryManager from "./memory/MemoryManager";
 import PluginSystem from "./plugins/PluginSystem";
 import PromptBuilder from "./prompt/PromptBuilder";
 import ToolHandler from "./tools/ToolHandler";
+import { WorkflowTracer } from "./workflows/WorkflowTracer";
+
+const WORKFLOW_NAME = "AgentOrchestrator";
+
+const normalizeModelOutput = (result) => {
+  if (typeof result === "string") {
+    return result;
+  }
+  if (result && typeof result.text === "string") {
+    return result.text;
+  }
+  if (result === undefined || result === null) {
+    return "";
+  }
+  return String(result);
+};
+
+const promptLength = (value) =>
+  typeof value === "string" ? value.length : normalizeModelOutput(value).length;
 
 export class AgentOrchestrator {
   constructor() {
@@ -16,30 +35,158 @@ export class AgentOrchestrator {
   }
 
   async run(prompt) {
-    const longMem = await this.memory.retrieve(prompt);
-    const shortMem = this.memory.getConversationHistory();
-    const fullCtx = [...longMem, ...shortMem];
+    const tracer = new WorkflowTracer({ workflowName: WORKFLOW_NAME });
+    tracer.info("Workflow started", {
+      promptLength: promptLength(prompt),
+      promptPreview: tracer.preview(typeof prompt === "string" ? prompt : ""),
+    });
 
-    const initialPrompt = this.promptBuilder.build(prompt, fullCtx);
-    const initial = await this.llm.generate(initialPrompt);
-    const initialText = initial.text ?? initial;
-    const calls = this.toolHandler.parse(initialText);
+    try {
+      const longMem = await tracer.withStep(
+        "retrieveLongTermMemory",
+        () => this.memory.retrieve(prompt),
+        {
+          startData: { promptLength: promptLength(prompt) },
+          successData: (entries) => ({ records: entries.length }),
+        },
+      );
 
-    if (!calls.length) {
-      this.memory.addInteraction(prompt, initialText);
-      return initialText;
+      const shortMem = await tracer.withStep(
+        "conversationHistory",
+        () => Promise.resolve(this.memory.getConversationHistory()),
+        {
+          successData: (entries) => ({ records: entries.length }),
+        },
+      );
+
+      const fullCtx = [...longMem, ...shortMem];
+      tracer.debug("Context assembled", {
+        longTerm: longMem.length,
+        shortTerm: shortMem.length,
+        total: fullCtx.length,
+      });
+
+      const initialPrompt = await tracer.withStep(
+        "buildInitialPrompt",
+        () => Promise.resolve(this.promptBuilder.build(prompt, fullCtx)),
+        {
+          successData: (value) => ({
+            length: typeof value === "string" ? value.length : 0,
+            preview:
+              typeof value === "string" ? tracer.preview(value) : undefined,
+          }),
+        },
+      );
+
+      const initial = await tracer.withStep(
+        "initialModelCall",
+        () => this.llm.generate(initialPrompt),
+        {
+          successData: (response) => {
+            const text = normalizeModelOutput(response);
+            return {
+              length: text.length,
+              preview: tracer.preview(text),
+            };
+          },
+        },
+      );
+
+      const initialText = normalizeModelOutput(initial);
+      tracer.debug("Initial model response normalized", {
+        length: initialText.length,
+      });
+
+      const calls = this.toolHandler.parse(initialText);
+      tracer.info("Parsed tool calls", {
+        count: calls.length,
+        toolNames: calls.map((call) => call.name),
+      });
+
+      if (!calls.length) {
+        tracer.info("No tool calls detected", {
+          responseLength: initialText.length,
+        });
+        await tracer.withStep(
+          "persistMemory",
+          () => this.memory.addInteraction(prompt, initialText, []),
+          {
+            successData: () => ({ toolResults: 0 }),
+          },
+        );
+        tracer.finish({
+          toolResults: 0,
+          finalResponseLength: initialText.length,
+          finalPreview: tracer.preview(initialText),
+        });
+        return initialText;
+      }
+
+      const toolResults = await tracer.withStep(
+        "executeTools",
+        () => this.toolHandler.execute(calls, { tracer }),
+        {
+          successData: (results) => ({
+            count: results.length,
+            toolNames: results.map((result) => result.name),
+          }),
+        },
+      );
+
+      const finalPrompt = await tracer.withStep(
+        "buildFinalPrompt",
+        () =>
+          Promise.resolve(
+            this.promptBuilder.build(prompt, [...fullCtx, ...toolResults]),
+          ),
+        {
+          successData: (value) => ({
+            length: typeof value === "string" ? value.length : 0,
+            preview:
+              typeof value === "string" ? tracer.preview(value) : undefined,
+          }),
+        },
+      );
+
+      const final = await tracer.withStep(
+        "finalModelCall",
+        () => this.llm.generate(finalPrompt),
+        {
+          successData: (response) => {
+            const text = normalizeModelOutput(response);
+            return {
+              length: text.length,
+              preview: tracer.preview(text),
+            };
+          },
+        },
+      );
+
+      const finalText = normalizeModelOutput(final);
+      tracer.info("Final model response ready", {
+        length: finalText.length,
+        preview: tracer.preview(finalText),
+      });
+
+      await tracer.withStep(
+        "persistMemory",
+        () => this.memory.addInteraction(prompt, finalText, toolResults),
+        {
+          successData: () => ({ toolResults: toolResults.length }),
+        },
+      );
+
+      tracer.finish({
+        toolResults: toolResults.length,
+        finalResponseLength: finalText.length,
+        finalPreview: tracer.preview(finalText),
+      });
+
+      return finalText;
+    } catch (error) {
+      tracer.fail(error, { promptLength: promptLength(prompt) });
+      throw error;
     }
-
-    const toolResults = await this.toolHandler.execute(calls);
-    const finalPrompt = this.promptBuilder.build(prompt, [
-      ...fullCtx,
-      ...toolResults,
-    ]);
-    const final = await this.llm.generate(finalPrompt);
-    const finalText = final.text ?? final;
-
-    this.memory.addInteraction(prompt, finalText, toolResults);
-    return finalText;
   }
 }
 

--- a/src/core/workflows/WorkflowTracer.js
+++ b/src/core/workflows/WorkflowTracer.js
@@ -1,0 +1,123 @@
+import logger from "../../utils/logger";
+
+const DEFAULT_TAG = "AgentWorkflow";
+const DEFAULT_PREVIEW_LIMIT = 160;
+
+const generateRunId = () =>
+  `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+
+const isFunction = (value) => typeof value === "function";
+
+const normalizePreview = (value, limit = DEFAULT_PREVIEW_LIMIT) => {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  const trimmed = value.replace(/\s+/g, " ").trim();
+  if (trimmed.length <= limit) {
+    return trimmed;
+  }
+
+  return `${trimmed.slice(0, limit)}…`;
+};
+
+export class WorkflowTracer {
+  constructor({ workflowName = "Workflow", tag = DEFAULT_TAG, runId } = {}) {
+    this.workflowName = workflowName;
+    this.tag = tag;
+    this.runId = runId || generateRunId();
+    this.startTime = Date.now();
+    this.stepCounter = 0;
+  }
+
+  preview(value, limit = DEFAULT_PREVIEW_LIMIT) {
+    return normalizePreview(value, limit);
+  }
+
+  debug(message, data) {
+    logger.debug(this.tag, `${this.#prefix()} ${message}`, data);
+  }
+
+  info(message, data) {
+    logger.info(this.tag, `${this.#prefix()} ${message}`, data);
+  }
+
+  warn(message, data) {
+    logger.warn(this.tag, `${this.#prefix()} ${message}`, data);
+  }
+
+  error(message, error, data) {
+    logger.error(this.tag, `${this.#prefix()} ${message}`, error, data);
+  }
+
+  startStep(name, data) {
+    const step = {
+      id: ++this.stepCounter,
+      name,
+      startTime: Date.now(),
+    };
+
+    this.debug(`▶️ ${name} start`, { step: step.id, ...data });
+    return step;
+  }
+
+  endStep(step, data) {
+    if (!step) {
+      return;
+    }
+
+    const duration = Date.now() - step.startTime;
+    this.info(`✅ ${step.name} completed`, {
+      step: step.id,
+      duration,
+      ...data,
+    });
+  }
+
+  failStep(step, error, data) {
+    if (!step) {
+      return;
+    }
+
+    const duration = Date.now() - step.startTime;
+    this.error(`❌ ${step.name} failed`, error, {
+      step: step.id,
+      duration,
+      ...data,
+    });
+  }
+
+  async withStep(name, operation, options = {}) {
+    const { startData, successData, errorData } = options;
+    const step = this.startStep(name, startData);
+
+    try {
+      const result = await operation();
+      const payload = isFunction(successData)
+        ? successData(result)
+        : successData;
+      this.endStep(step, payload);
+      return result;
+    } catch (error) {
+      const payload = isFunction(errorData) ? errorData(error) : errorData;
+      this.failStep(step, error, payload);
+      throw error;
+    }
+  }
+
+  finish(data) {
+    const duration = Date.now() - this.startTime;
+    this.info("🏁 Workflow completed", { duration, ...data });
+  }
+
+  fail(error, data) {
+    const duration = Date.now() - this.startTime;
+    this.error("💥 Workflow failed", error, { duration, ...data });
+  }
+
+  #prefix() {
+    return `[${this.workflowName}#${this.runId}]`;
+  }
+}
+
+export default WorkflowTracer;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -153,17 +153,17 @@ class Logger {
     }
   }
 
-  error(tag: string, message: string, error?: unknown): void {
+  error(tag: string, message: string, error?: unknown, data?: unknown): void {
     if (!this.shouldLog(LogLevel.ERROR)) {
       return;
     }
     const normalizedError =
       error instanceof Error
         ? error
-        : error
+        : error !== undefined && error !== null
           ? new Error(String(error))
           : undefined;
-    this.addLog(LogLevel.ERROR, tag, message, undefined, normalizedError);
+    this.addLog(LogLevel.ERROR, tag, message, data, normalizedError);
   }
 
   time(tag: string, label: string): void {


### PR DESCRIPTION
## Summary
- add a reusable `WorkflowTracer` helper to capture step-level telemetry and adopt it inside the agent orchestrator flow
- surface tool execution status through the tracer, logging successes and failures while enriching `logger.error` with metadata support
- cover the tracer with unit tests to ensure success and failure paths are recorded

## Testing
- npm test
- npm run lint
- CI=1 npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68ca51033cc08333b3f4214a70dcd02b