### PR TITLE
chore: silence metal c++17 warnings

### DIFF
--- a/.github/workflows/ios-unsigned-archive-unsigned-ipa.yml
+++ b/.github/workflows/ios-unsigned-archive-unsigned-ipa.yml
@@ -2,9 +2,9 @@ name: iOS (unsigned) — Archive + Unsigned IPA
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 concurrency:
   group: ios-unsigned-${{ github.ref }}
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: "npm"
 
       - name: Cache Pods
         uses: actions/cache@v4
@@ -93,7 +93,6 @@ jobs:
             build/xcodebuild-list.txt
             build/build-settings.txt
           if-no-files-found: error
-
 # Notes:
 # - This workflow produces an unsigned IPA suitable for re-signing later.
 # - To export a signed IPA, use `xcodebuild -exportArchive` with a valid exportOptionsPlist

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -63,6 +63,9 @@ targets:
         # Stable toolchain for RN/Folly
         CLANG_CXX_LIBRARY: libc++
         CLANG_CXX_LANGUAGE_STANDARD: c++17
+        OTHER_MTLFLAGS:
+          - "$(inherited)"
+          - "-Wno-c++17-extensions"
 
         # Allow CocoaPods header symlink scripts to write in Xcode 15+
         ENABLE_USER_SCRIPT_SANDBOXING: NO

--- a/project.yml
+++ b/project.yml
@@ -64,6 +64,9 @@ targets:
         # Stable toolchain for RN/Folly
         CLANG_CXX_LIBRARY: libc++
         CLANG_CXX_LANGUAGE_STANDARD: c++17
+        OTHER_MTLFLAGS:
+          - "$(inherited)"
+          - "-Wno-c++17-extensions"
 
         # Allow CocoaPods header symlink scripts to write in Xcode 15+
         ENABLE_USER_SCRIPT_SANDBOXING: NO


### PR DESCRIPTION
## Summary
- add Metal compiler flags in both XcodeGen project specs to silence the -Wc++17-extensions warnings that appear when building mlx-swift shaders
- format the iOS unsigned archive workflow so prettier no longer flags it during format checks

## Testing
- npm test
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68cb2cfd602883338e8123bf0948b0f9