### PR TITLE
fix: default pods to new architecture

### DIFF
--- a/ios/MyOfflineLLMApp/MLX/MLXModule.swift
+++ b/ios/MyOfflineLLMApp/MLX/MLXModule.swift
@@ -1,12 +1,9 @@
 import Foundation
 import React
 
-import MLXLLM
-import MLXLMCommon
+@preconcurrency import MLXLLM
+@preconcurrency import MLXLMCommon
 
-extension ChatSession: @unchecked Sendable {}
-
-@MainActor
 private actor ChatSessionActor {
   private struct Waiter {
     let id: UUID

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -2,6 +2,10 @@ require 'open3'
 
 platform :ios, '18.0'
 
+# Default to Fabric/New Architecture unless the caller opts out.
+ENV['RCT_NEW_ARCH_ENABLED'] = ENV.fetch('RCT_NEW_ARCH_ENABLED', '1')
+ENV['RCT_FABRIC_ENABLED'] = ENV.fetch('RCT_FABRIC_ENABLED', '1')
+
 install! 'cocoapods', :disable_input_output_paths => true
 
 # --- Auto-detect the .xcodeproj near this Podfile ---
@@ -50,7 +54,10 @@ end
 target 'monGARS' do
   config = use_native_modules!
 
-  flags = get_default_flags()
+  flags = get_default_flags({
+    :fabric_enabled => ENV['RCT_FABRIC_ENABLED'] == '1',
+    :new_arch_enabled => ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+  })
 
   use_react_native!(
     :path => config[:reactNativePath],

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "my-offline-llm-app",
       "version": "2.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@noble/post-quantum": "^0.5.1",
         "@react-native-async-storage/async-storage": "^2.2.0",

--- a/patches/@react-native-community+slider+5.0.1.patch
+++ b/patches/@react-native-community+slider+5.0.1.patch
@@ -1,26 +1,23 @@
 diff --git a/node_modules/@react-native-community/slider/ios/RNCSliderComponentView.mm b/node_modules/@react-native-community/slider/ios/RNCSliderComponentView.mm
-index 928c532..8d808ff 100644
+index 928c532..aff395b 100644
 --- a/node_modules/@react-native-community/slider/ios/RNCSliderComponentView.mm
 +++ b/node_modules/@react-native-community/slider/ios/RNCSliderComponentView.mm
 @@ -7,9 +7,19 @@
  #import <react/renderer/components/RNCSlider/Props.h>
  #import <react/renderer/components/RNCSlider/RCTComponentViewHelpers.h>
  #import <React/RCTBridge+Private.h>
--#import "RCTImagePrimitivesConversions.h"
--#import <React/RCTImageLoaderProtocol.h>
--#import "RCTFabricComponentsPlugins.h"
 +#if __has_include(<React/RCTImagePrimitivesConversions.h>)
 +#import <React/RCTImagePrimitivesConversions.h>
 +#elif __has_include(<react/renderer/imagemanager/RCTImagePrimitivesConversions.h>)
 +#import <react/renderer/imagemanager/RCTImagePrimitivesConversions.h>
 +#else
-+#import "RCTImagePrimitivesConversions.h"
+ #import "RCTImagePrimitivesConversions.h"
 +#endif
-+#import <React/RCTImageLoaderProtocol.h>
+ #import <React/RCTImageLoaderProtocol.h>
 +#if __has_include(<React/RCTFabricComponentsPlugins.h>)
 +#import <React/RCTFabricComponentsPlugins.h>
 +#else
-+#import "RCTFabricComponentsPlugins.h"
+ #import "RCTFabricComponentsPlugins.h"
 +#endif
  #import "RNCSlider.h"
  


### PR DESCRIPTION
## Summary
- default the Podfile to Fabric/New Architecture while still honoring external overrides
- pull Fabric/New Architecture settings from the environment when configuring React Native pods

## Testing
- npm test
- npm run lint
- npm run format:check -- --log-level=warn

------
https://chatgpt.com/codex/tasks/task_e_68cb40423a3c8333b8ecf716dd93b02d