### PR TITLE
fix: stabilize ios mlx bridge build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -86,6 +86,12 @@ ensure_workspace() {
 
 ensure_workspace
 
+# Step 3.5: Clean DerivedData/ModuleCache to avoid stale AST mismatches
+echo "🧽 Clearing Xcode derived data and module caches..."
+rm -rf ~/Library/Developer/Xcode/DerivedData/ModuleCache.noindex
+rm -rf ~/Library/Developer/Xcode/DerivedData
+rm -rf "$BUILD_DIR/DerivedData"
+
 # Step 4: Run the Xcode build (Simulator, unsigned)
 echo "📦 Building for iOS Simulator (unsigned)..."
 xcodebuild build \

--- a/build.sh
+++ b/build.sh
@@ -86,15 +86,19 @@ ensure_workspace() {
 
 ensure_workspace
 
-# Step 3.5: Clean DerivedData/ModuleCache to avoid stale AST mismatches
-echo "🧽 Clearing Xcode derived data and module caches..."
+# Step 3.5: Clear module caches without nuking the entire DerivedData tree
+echo "🧽 Clearing Xcode module caches..."
 rm -rf ~/Library/Developer/Xcode/DerivedData/ModuleCache.noindex
-rm -rf ~/Library/Developer/Xcode/DerivedData
-rm -rf "$BUILD_DIR/DerivedData"
+rm -rf ~/Library/Developer/Xcode/DerivedData/ModuleCache
+
+# Force a clean build without deleting caches wholesale
+XCODEBUILD_EXTRA_FLAGS=(
+  -IDEBuildOperationRebuildFromScratch=YES
+)
 
 # Step 4: Run the Xcode build (Simulator, unsigned)
 echo "📦 Building for iOS Simulator (unsigned)..."
-xcodebuild build \
+xcodebuild "${XCODEBUILD_EXTRA_FLAGS[@]}" build \
   -workspace "$WORKSPACE" \
   -scheme "$SCHEME" \
   -configuration Release \

--- a/ios/MyOfflineLLMApp/MLX/MLXEvents.swift
+++ b/ios/MyOfflineLLMApp/MLX/MLXEvents.swift
@@ -15,7 +15,7 @@ final class MLXEvents: RCTEventEmitter {
   @objc override static func requiresMainQueueSetup() -> Bool { false }
 
   // Single shared instance for convenience
-  static var shared: MLXEvents?
+  @MainActor static var shared: MLXEvents?
 
   override init() {
     super.init()

--- a/ios/MyOfflineLLMApp/MLX/MLXEvents.swift
+++ b/ios/MyOfflineLLMApp/MLX/MLXEvents.swift
@@ -17,12 +17,12 @@ final class MLXEvents: RCTEventEmitter {
   // Single shared instance for convenience
   @MainActor static var shared: MLXEvents?
 
-  override init() {
+  @MainActor override init() {
     super.init()
     MLXEvents.shared = self
   }
 
-  deinit {
+  @MainActor deinit {
     if MLXEvents.shared === self { MLXEvents.shared = nil }
   }
 

--- a/ios/MyOfflineLLMApp/MLX/MLXModule.swift
+++ b/ios/MyOfflineLLMApp/MLX/MLXModule.swift
@@ -41,8 +41,7 @@ private actor ChatSessionActor {
     defer { isResponding = false; shouldStop = false }
 
     var out = ""
-    let params = GenerateRequest.Parameters(topK: topK, temperature: temperature)
-    let req = GenerateRequest(text: prompt, parameters: params)
+    let req = makeRequest(prompt: prompt, topK: topK, temperature: temperature)
     for try await token in try session.generate(request: req) {
       if shouldStop { break }
       out.append(token)
@@ -55,12 +54,16 @@ private actor ChatSessionActor {
     isResponding = true
     defer { isResponding = false; shouldStop = false }
 
-    let params = GenerateRequest.Parameters(topK: topK, temperature: temperature)
-    let req = GenerateRequest(text: prompt, parameters: params)
+    let req = makeRequest(prompt: prompt, topK: topK, temperature: temperature)
     for try await token in try session.generate(request: req) {
       if shouldStop { break }
       onToken(token)
     }
+  }
+
+  private func makeRequest(prompt: String, topK: Int, temperature: Float) -> GenerateRequest {
+    let params = GenerateRequest.Parameters(topK: topK, temperature: temperature)
+    return GenerateRequest(text: prompt, parameters: params)
   }
 }
 

--- a/ios/MyOfflineLLMApp/MLX/MLXModule.swift
+++ b/ios/MyOfflineLLMApp/MLX/MLXModule.swift
@@ -41,7 +41,8 @@ private actor ChatSessionActor {
     defer { isResponding = false; shouldStop = false }
 
     var out = ""
-    let req = GenerateRequest(text: prompt, parameters: .init(topK: topK, temperature: temperature))
+    let params = GenerateRequest.Parameters(topK: topK, temperature: temperature)
+    let req = GenerateRequest(text: prompt, parameters: params)
     for try await token in try session.generate(request: req) {
       if shouldStop { break }
       out.append(token)
@@ -54,7 +55,8 @@ private actor ChatSessionActor {
     isResponding = true
     defer { isResponding = false; shouldStop = false }
 
-    let req = GenerateRequest(text: prompt, parameters: .init(topK: topK, temperature: temperature))
+    let params = GenerateRequest.Parameters(topK: topK, temperature: temperature)
+    let req = GenerateRequest(text: prompt, parameters: params)
     for try await token in try session.generate(request: req) {
       if shouldStop { break }
       onToken(token)

--- a/project.yml
+++ b/project.yml
@@ -54,6 +54,11 @@ targets:
         SWIFT_VERSION: "6.0"
         IPHONEOS_DEPLOYMENT_TARGET: "18.0"
         SWIFT_OBJC_BRIDGING_HEADER: MyOfflineLLMApp/Bridging/monGARS-Bridging-Header.h
+        HEADER_SEARCH_PATHS:
+          - "$(inherited)"
+          - "$(SRCROOT)/../Pods/Headers/Public"
+          - "$(SRCROOT)/../Pods/Headers/Public/RCTDeprecation"
+        CLANG_ENABLE_MODULES: YES
 
         # Unsigned/device builds in CI
         CODE_SIGNING_ALLOWED: NO


### PR DESCRIPTION
## Summary
- add explicit header search paths and enable modules for the iOS target to unblock RCTDeprecation imports
- clear the Xcode derived data and module caches before building in the iOS CI script
- qualify MLX generation parameters and mark the MLXEvents singleton as @MainActor for Swift 6

## Testing
- npm test
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68cb583da5c883339e4c240181035898

## Summary by Sourcery

Stabilize the iOS MLX bridge build by cleaning Xcode caches, updating project settings for module imports, and adapting code to Swift 6 concurrency requirements.

Enhancements:
- Add explicit HEADER_SEARCH_PATHS and enable modules for the iOS target to support RCTDeprecation imports
- Qualify GenerateRequest.Parameters usage in MLXModule to align with Swift 6 changes
- Annotate MLXEvents.shared as @MainActor to satisfy Swift 6 concurrency requirements

Build:
- Clear Xcode DerivedData and ModuleCache in the iOS build script to avoid stale AST mismatches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added a pre-build cleanup step to clear Xcode module caches for cleaner iOS builds.
  - Added a rebuild-from-scratch build flag to force full rebuilds when building iOS.
  - Updated iOS project settings to enable modules and configure header search paths for more reliable dependency resolution.

- Refactor
  - Streamlined request construction in chat generation for easier maintenance.

- Bug Fixes
  - Improved runtime stability by ensuring event handling runs on the main thread.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->