### PR TITLE
feat: harden iOS MLX runtime and tooling

### DIFF
--- a/ios/project.yml
+++ b/ios/project.yml
@@ -62,7 +62,13 @@ targets:
 
         # Stable toolchain for RN/Folly
         CLANG_CXX_LIBRARY: libc++
-        CLANG_CXX_LANGUAGE_STANDARD: c++17
+        OTHER_CPLUSPLUSFLAGS:
+          - "$(inherited)"
+          - "-std=gnu++17"
+          - "-Wno-c++17-extensions"
+        OTHER_CFLAGS:
+          - "$(inherited)"
+          - "-Wno-c++17-extensions"
         OTHER_MTLFLAGS:
           - "$(inherited)"
           - "-Wno-c++17-extensions"

--- a/ios/scripts/patch-react-native-contacts.sh
+++ b/ios/scripts/patch-react-native-contacts.sh
@@ -22,7 +22,6 @@ if ! python3 - <<'PY' >/dev/null 2>&1; then
 import sys
 sys.exit(0 if sys.version_info >= (3, 7) else 1)
 PY
-then
   PY_VERSION="$(python3 --version 2>/dev/null || echo 'python3 unavailable')"
   echo "❌ python3 3.7 or newer is required to patch react-native-contacts (detected: $PY_VERSION)."
   exit 1

--- a/project.yml
+++ b/project.yml
@@ -68,7 +68,13 @@ targets:
 
         # Stable toolchain for RN/Folly
         CLANG_CXX_LIBRARY: libc++
-        CLANG_CXX_LANGUAGE_STANDARD: c++17
+        OTHER_CPLUSPLUSFLAGS:
+          - "$(inherited)"
+          - "-std=gnu++17"
+          - "-Wno-c++17-extensions"
+        OTHER_CFLAGS:
+          - "$(inherited)"
+          - "-Wno-c++17-extensions"
         OTHER_MTLFLAGS:
           - "$(inherited)"
           - "-Wno-c++17-extensions"

--- a/scripts/ios_doctor.sh
+++ b/scripts/ios_doctor.sh
@@ -4,53 +4,106 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 IOS_DIR="$ROOT_DIR/ios"
 
-if ! command -v xcodebuild >/dev/null 2>&1; then
-  echo "❌ xcodebuild not available. Install Xcode command line tools before running the doctor."
-  exit 1
-fi
+require_command() {
+  local tool="$1"
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "❌ $tool not available. Install it before running the doctor."
+    exit 1
+  fi
+}
 
-echo "=== monGARS iOS Doctor (Enhanced: Blueprint + Codegen Check) ==="
-echo "Date: $(date)"
-echo "Xcode: $(xcodebuild -version | head -1)"
-echo "Node: $(node --version)"
-echo "Ruby: $(ruby --version)"
-echo "Pod: $(pod --version)"
+print_environment() {
+  echo "=== monGARS iOS Doctor ==="
+  echo "Date: $(date)"
+  echo "Xcode: $(xcodebuild -version | head -1)"
+  echo "Node: $(node --version)"
+  echo "Ruby: $(ruby --version)"
+  echo "Pod: $(pod --version)"
+}
 
-# Your existing checks...
-(
-  cd "$ROOT_DIR"
-  npm run lint
-  npm test
-)
-(
-  cd "$IOS_DIR"
-  xcodegen generate
-  bundle exec pod install --repo-update
-)
+run_js_checks() {
+  echo "Running JavaScript lint/tests..."
+  (
+    cd "$ROOT_DIR"
+    npm run lint
+    npm test
+  )
+}
 
-# New: Blueprint duplicate scan
-echo "Scanning for blueprint duplicates..."
-BLUEPRINT_ISSUES=$(cd "$IOS_DIR" && xcodebuild -workspace monGARS.xcworkspace -scheme monGARS -showBuildSettings 2>&1 | grep -c "Unexpectedly found another blueprint" || true)
-if [ "${BLUEPRINT_ISSUES:-0}" -gt 0 ]; then
-  echo "⚠️  $BLUEPRINT_ISSUES blueprint duplicates detected. Running auto-clean..."
-  find "$IOS_DIR/build/generated/ios" -name "*JSI-generated*" -delete 2>/dev/null || true
-  find "$IOS_DIR/build/generated/ios" -name "*Spec-generated*" -delete 2>/dev/null || true
+sync_ios_dependencies() {
+  echo "Regenerating iOS project files..."
   (
     cd "$IOS_DIR"
-    bundle exec pod install  # Re-gen clean
+    xcodegen generate
+    bundle exec pod install --repo-update
   )
-fi
+}
 
-# New: Test archive dry-run
-echo "Dry-run archive..."
-if ! (cd "$IOS_DIR" && xcodebuild -workspace monGARS.xcworkspace -scheme monGARS \
-  -configuration Release \
-  -destination "generic/platform=iOS" \
-  CODE_SIGNING_ALLOWED=NO \
-  -dry-run clean archive); then
-  echo "❌ Archive dry-run failed. Check logs."
-  exit 1
-fi
+collect_codegen_duplicates() {
+  local generated_root="$IOS_DIR/build/generated/ios"
+  [[ -d "$generated_root" ]] || return 0
 
-# Your existing sim/device tests...
-echo "✅ Doctor passed. Ready for full build."
+  find "$generated_root" -type f \
+    \( -name '*JSI-generated*' -o -name '*Spec-generated*' \) -print0 2>/dev/null |
+    while IFS= read -r -d '' artifact; do
+      local manual="${artifact/-generated/}"
+      if [[ -e "$manual" ]]; then
+        printf '%s\0' "$artifact"
+      fi
+    done
+}
+
+clean_codegen_duplicates() {
+  echo "Scanning generated specs for duplicates..."
+  local duplicates=()
+  if mapfile -d '' duplicates < <(collect_codegen_duplicates || true); then
+    :
+  fi
+
+  local count=${#duplicates[@]}
+  if ((count > 0)); then
+    echo "⚠️  Found $count duplicate codegen artifacts. Removing and reinstalling pods..."
+    for path in "${duplicates[@]}"; do
+      rm -f "$path"
+    done
+    (
+      cd "$IOS_DIR"
+      bundle exec pod install
+    )
+  else
+    echo "No duplicate codegen artifacts detected."
+  fi
+}
+
+dry_run_archive() {
+  echo "Dry-run archive..."
+  if ! (
+    cd "$IOS_DIR" && \
+      xcodebuild -workspace monGARS.xcworkspace -scheme monGARS \
+        -configuration Release \
+        -destination "generic/platform=iOS" \
+        CODE_SIGNING_ALLOWED=NO \
+        -dry-run clean archive
+  ); then
+    echo "❌ Archive dry-run failed. Check logs."
+    exit 1
+  fi
+}
+
+main() {
+  require_command xcodebuild
+  require_command node
+  require_command ruby
+  require_command pod
+  require_command xcodegen
+
+  print_environment
+  run_js_checks
+  sync_ios_dependencies
+  clean_codegen_duplicates
+  dry_run_archive
+
+  echo "✅ Doctor passed. Ready for full build."
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- update the MLX event emitter to hold a weak shared reference and register/unregister on the main actor
- rebuild the MLXModule chat session handling to configure per-request parameters and keep async work on the main actor
- refresh Xcode project flags and the iOS doctor script to better handle duplicate codegen artifacts and archive checks

## Testing
- npm test
- npm run lint
- CI=1 npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68cb8a1e2afc83338b869a7df89bd781