### PR TITLE
Align React Native & Hermes to 0.81.4 (JS + iOS Pods)

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1748,11 +1748,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - react-native-config (1.5.7):
-    - react-native-config/App (= 1.5.7)
-  - react-native-config/App (1.5.7):
+  - react-native-config (1.5.9):
+    - react-native-config/App (= 1.5.9)
+  - react-native-config/App (1.5.9):
     - React-Core
-  - react-native-contacts (8.0.6):
+  - react-native-contacts (8.0.7):
     - boost
     - DoubleConversion
     - fast_float
@@ -2378,9 +2378,35 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNCClipboard (1.5.1):
+  - RNCClipboard (1.16.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
-  - RNDeviceInfo (14.0.4):
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - RNDeviceInfo (14.1.1):
     - React-Core
   - RNFS (2.20.0):
     - React-Core
@@ -2469,7 +2495,6 @@ DEPENDENCIES:
   - React-utils (from `../node_modules/react-native/ReactCommon/react/utils`)
   - ReactAppDependencyProvider (from `build/generated/ios`)
   - ReactCodegen (from `build/generated/ios`)
-  - ReactCommon/turbomodule/bridging (from `../node_modules/react-native/ReactCommon`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCClipboard (from `../node_modules/@react-native-clipboard/clipboard`)"
@@ -2657,91 +2682,91 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
-  DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
+  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: b8f1312d48447cca7b4abc21ed155db14742bd03
+  FBLazyVector: 941bef1c8eeabd9fe1f501e30a5220beee913886
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
-  hermes-engine: 60d6f980cfd9ae66858600adf551182ab32164ad
+  glog: 582871a8288ec5d97471068603abdf773be671f8
+  hermes-engine: 35c763d57c9832d0eef764316ca1c4d043581394
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
-  RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
-  RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a
-  RCTTypeSafety: 720403058b7c1380c6a3ae5706981d6362962c89
-  React: f1486d005993b0af01943af1850d3d4f3b597545
-  React-callinvoker: 133f69368c8559e744efa345223625d412f5dfbe
-  React-Core: 559823921b4f294c2840fa8238ca958a29ddc211
-  React-CoreModules: c41e7bbfabbc420783bb926f45837a0d5e53341e
-  React-cxxreact: 9cb9fa738274a1b36b97ede09c8a6717dec1a20b
-  React-debug: d4dd8b9174acc68da48a3a3142226f261b2cb396
-  React-defaultsnativemodule: e864080ab91e49b9bab9660c3b5c6b98ee6c240a
-  React-domnativemodule: 85767121bbc74f9d0dd3a7cb2ea52c35e875e414
-  React-Fabric: cecbea344f271a2b4492466c849af0d4a4d14f22
-  React-FabricComponents: 882e9c2a5474ed7720ee045e7fc277372feb0fd7
-  React-FabricImage: e156a269356cbad4ffa353ac3dae3ba82ea152fd
-  React-featureflags: ee9192bbf6de80f2bffaf215745782bab9e54055
-  React-featureflagsnativemodule: 72b5a385f9e60d8cbcc5dd5017816001ae4e9f3e
-  React-graphics: 3253493eeb93788ba254d610928128eaccd1ba4d
-  React-hermes: 811606c0aca5a3f9c6fa8e4994e02ca8f677e68e
-  React-idlecallbacksnativemodule: dd71c48d7f2e1f35031a8da8dec11228439ba498
-  React-ImageManager: d7a4bab16976900b4cc29ce1dfaf669fd4a586f2
-  React-jserrorhandler: 1730fe458229969d6de405149154d1d368b8ea31
-  React-jsi: ece95417fedbed0e7153a855cb8342b7c72ab75e
-  React-jsiexecutor: 2b0bb644b533df2f5c0cd6ade9a4560d0bf1dd84
-  React-jsinspector: 2d6b5b3d0e528f7b796796d79f360a95b0f8365b
-  React-jsinspectorcdp: 3337aa3a6c0fcd06a6c6d8a689039acfa15fa792
-  React-jsinspectornetwork: c75fb6ef29feaf9381405b676f4350b3115a5607
-  React-jsinspectortracing: 94f6858d1a2436ea130c2ce4023ff6a88172d47f
-  React-jsitooling: 19224f2f6deb70458d5a31f2bd4ee7b9e9fb1dd9
-  React-jsitracing: 09f434f39e1f2d7bd4da00422049898dc2823406
-  React-logger: 7aef4d74123e5e3d267e5af1fbf5135b5a0d8381
-  React-Mapbuffer: bd9e0b326013ba621165bad90b83979fcdaebe6f
-  React-microtasksnativemodule: b0aca6ebaea96c8c5ecdf3050ef6d04eda73ff18
-  react-native-config: 963b5efabc864cf69412e54b5de49b6a23e4af03
-  react-native-contacts: 7b27874065f9111e8b94f4667882af7d59469b06
+  RCTDeprecation: c0ed3249a97243002615517dff789bf4666cf585
+  RCTRequired: 58719f5124f9267b5f9649c08bf23d9aea845b23
+  RCTTypeSafety: 4aefa8328ab1f86da273f08517f1f6b343f6c2cc
+  React: 2073376f47c71b7e9a0af7535986a77522ce1049
+  React-callinvoker: 751b6f2c83347a0486391c3f266f291f0f53b27e
+  React-Core: dff5d29973349b11dd6631c9498456d75f846d5e
+  React-CoreModules: c0ae04452e4c5d30e06f8e94692a49107657f537
+  React-cxxreact: 376fd672c95dfb64ad5cc246e6a1e9edb78dec4c
+  React-debug: 7b56a0a7da432353287d2eedac727903e35278f5
+  React-defaultsnativemodule: 393b81aaa6211408f50a6ef00a277847256dd881
+  React-domnativemodule: 5fb5829baa7a7a0f217019cbad1eb226d94f7062
+  React-Fabric: a17c4ae35503673b57b91c2d1388429e7cbee452
+  React-FabricComponents: a76572ddeba78ebe4ec58615291e9db4a55cd46a
+  React-FabricImage: d806eb2695d7ef355ec28d1a21f5a14ac26b1cae
+  React-featureflags: 1690ec3c453920b6308e23a4e24eb9c3632f9c75
+  React-featureflagsnativemodule: 7b7e8483fc671c5a33aefd699b7c7a3c0bdfdfec
+  React-graphics: ea146ee799dc816524a3a0922fc7be0b5a52dcc1
+  React-hermes: fcbdc45ecf38259fe3b12642bd0757c52270a107
+  React-idlecallbacksnativemodule: a353f9162eaa7ad787e68aba9f52a1cfa8154098
+  React-ImageManager: ec5cf55ce9cc81719eb5f1f51d23d04db851c86c
+  React-jserrorhandler: 594c593f3d60f527be081e2cace7710c2bd9f524
+  React-jsi: 59ec3190dd364cca86a58869e7755477d2468948
+  React-jsiexecutor: b87d78a2e8dd7a6f56e9cdac038da45de98c944f
+  React-jsinspector: b9204adf1af622c98e78af96ec1bca615c2ce2bd
+  React-jsinspectorcdp: 4a356fa69e412d35d3a38c44d4a6cc555c5931e8
+  React-jsinspectornetwork: 7820056773178f321cbf18689e1ffcd38276a878
+  React-jsinspectortracing: b341c5ef6e031a33e0bd462d67fd397e8e9cd612
+  React-jsitooling: 401655e05cb966b0081225c5201d90734a567cb9
+  React-jsitracing: 67eff6dea0cb58a1e7bd8b49243012d88c0f511e
+  React-logger: a3cb5b29c32b8e447b5a96919340e89334062b48
+  React-Mapbuffer: 9d2434a42701d6144ca18f0ca1c4507808ca7696
+  React-microtasksnativemodule: 75b6604b667d297292345302cc5bfb6b6aeccc1b
+  react-native-config: d08b60865268872495a43e211059b4606131fe01
+  react-native-contacts: aff87a9bbd66e06cefe6e173be4102e95a824cd1
   react-native-music-control: d6228bcce5830c311e21aad075fc43475fd70637
   react-native-render-html: 5afc4751f1a98621b3009432ef84c47019dcb2bd
-  react-native-slider: 6201419b3e3f7c6b7cf2068e0c01274fa86a1da5
+  react-native-slider: 663776e5683e257de8df8091abc2d93ff6ec67db
   react-native-sqlite-storage: 0c84826214baaa498796c7e46a5ccc9a82e114ed
   react-native-voice: 908a0eba96c8c3d643e4f98b7232c6557d0a6f9c
-  React-NativeModulesApple: be767e4e204802b135c68a81024f5b758bc0653e
-  React-oscompat: b12c633e9c00f1f99467b1e0e0b8038895dae436
-  React-perflogger: 58d12c4e5df1403030c97b9c621375c312cca454
-  React-performancetimeline: e0d95d9b6d581cbe01722fc4ee9a0dcb9617a6de
-  React-RCTActionSheet: 3f741a3712653611a6bfc5abceb8260af9d0b218
-  React-RCTAnimation: 408ad69ea136e99a463dd33eadecc29e586b3d72
-  React-RCTAppDelegate: f03b46e80b8a3dbfa84b35abfe123e02f3ceef83
-  React-RCTBlob: bd42e92a00ad22eaab92ffe5c137e7a2f725887a
-  React-RCTFabric: f8322f0f293d76569beefbf942be2796e59e6de1
-  React-RCTFBReactNativeSpec: 5db3e244c6fc9adebdaff632168fc9fdd5273574
-  React-RCTImage: 0f1c74f7cd20027f8c34976a211b35d4263a0add
-  React-RCTLinking: 6d7dfc3a74110df56c3a73cc7626bf4415656542
-  React-RCTNetwork: 6a25d8645a80d5b86098675ca39bf8fcf1afa08b
-  React-RCTRuntime: 6ee42a86209296e18938d446ec05525ac889e33e
-  React-RCTSettings: 651d9ae2cdd32f547ad0d225a2c13886d6ad2358
-  React-RCTText: 9bc66cd288478e23195e01f5cb45eba79986b2b4
-  React-RCTVibration: 371226f5667a00c76d792dcdb5c2e0fcbcde0c3b
-  React-rendererconsistency: 13a33f6c0f6acfc02e8613b9b86ad42a47686270
-  React-renderercss: 3087877775222c08813e96935ab1d30ba76188d2
-  React-rendererdebug: bca6bc0039995664e262ef1cf84382d2832e858d
-  React-RuntimeApple: c54a5a96836da5034d820c5989f4f042f6b50b86
-  React-RuntimeCore: cccf9427142d2c5d177873ee3c36d28fea30d2a4
-  React-runtimeexecutor: ddedb7e6e8d7104b901ad56aa9e6828cda927272
-  React-RuntimeHermes: c7a9778619c32d84dc22df00f9a2aa4b2a9ea04a
-  React-runtimescheduler: 5114a56c333cf4c1c19056cd8779d333567d9eb1
-  React-timing: 16eb1255bf7da45c72214c8908064e6c2cc10205
-  React-utils: 2d674da7c078d11350d931be2240bbdbfda9697d
-  ReactAppDependencyProvider: 3eb9096cb139eb433965693bbe541d96eb3d3ec9
-  ReactCodegen: 3b88de7347f2d72e4ed7dccb54612f838126db7e
-  ReactCommon: e5df435ef0892875b7d503fbe3ec73a1a3712049
-  RNCAsyncStorage: fd44f4b03e007e642e98df6726737bc66e9ba609
-  RNCClipboard: b0541df1bb88935d40bdc93b41b7d8e3334c998a
-  RNDeviceInfo: d863506092aef7e7af3a1c350c913d867d795047
+  React-NativeModulesApple: 879fbdc5dcff7136abceb7880fe8a2022a1bd7c3
+  React-oscompat: 93b5535ea7f7dff46aaee4f78309a70979bdde9d
+  React-perflogger: 5536d2df3d18fe0920263466f7b46a56351c0510
+  React-performancetimeline: 9041c53efa07f537164dcfe7670a36642352f4c2
+  React-RCTActionSheet: 42195ae666e6d79b4af2346770f765b7c29435b9
+  React-RCTAnimation: fa103ccc3503b1ed8dedca7e62e7823937748843
+  React-RCTAppDelegate: 665d4baf19424cef08276e9ac0d8771eec4519f9
+  React-RCTBlob: 0fa9530c255644db095f2c4fd8d89738d9d9ecc0
+  React-RCTFabric: 1fcd8af6e25f92532f56b4ba092e58662c14d156
+  React-RCTFBReactNativeSpec: db171247585774f9f0a30f75109cc51568686213
+  React-RCTImage: ba824e61ce2e920a239a65d130b83c3a1d426dff
+  React-RCTLinking: d2dc199c37e71e6f505d9eca3e5c33be930014d4
+  React-RCTNetwork: 87137d4b9bd77e5068f854dd5c1f30d4b072faf6
+  React-RCTRuntime: 137fafaa808a8b7e76a510e8be45f9f827899daa
+  React-RCTSettings: 71f5c7fd7b5f4e725a4e2114a4b4373d0e46048f
+  React-RCTText: b94d4699b49285bee22b8ebf768924d607eccee3
+  React-RCTVibration: 6e3993c4f6c36a3899059f9a9ead560ddaf5a7d7
+  React-rendererconsistency: b4785e5ed837dc7c242bbc5fdd464b33ef5bfae7
+  React-renderercss: e6fb0ba387b389c595ffa86b8b628716d31f58dc
+  React-rendererdebug: 60a03de5c7ea59bf2d39791eb43c4c0f5d8b24e3
+  React-RuntimeApple: 3df6788cd9b938bb8cb28298d80b5fbd98a4d852
+  React-RuntimeCore: fad8adb4172c414c00ff6980250caf35601a0f5d
+  React-runtimeexecutor: d2db7e72d97751855ea0bf5273d2ac84e5ea390c
+  React-RuntimeHermes: 04faa4cf9a285136a6d73738787fe36020170613
+  React-runtimescheduler: f6a1c9555e7131b4a8b64cce01489ad0405f6e8d
+  React-timing: 1e6a8acb66e2b7ac9d418956617fd1fdb19322fd
+  React-utils: 52bbb03f130319ef82e4c3bc7a85eaacdb1fec87
+  ReactAppDependencyProvider: 433ddfb4536948630aadd5bd925aff8a632d2fe3
+  ReactCodegen: 74fdbbdc2cdf72e2d4edeb00b9abad389923ac4a
+  ReactCommon: 394c6b92765cf6d211c2c3f7f6bc601dffb316a6
+  RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
+  RNCClipboard: 4b58c780f63676367640f23c8e114e9bd0cf86ac
+  RNDeviceInfo: bcce8752b5043a623fe3c26789679b473f705d3c
   RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
   RNSensors: 111159597ac51505df10413c61b28bcd28e88983
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   TextToSpeech: 89b239221ec378d213af422d14789a729705360b
-  Yoga: f95f7e60346fa6828def95fbe5017346ccc8940e
+  Yoga: a3ed390a19db0459bd6839823a6ac6d9c6db198d
 
-PODFILE CHECKSUM: b43ea18882d32bf0a31bb4ace86e8bcdf95a37a0
+PODFILE CHECKSUM: d6da2ad6d8acb028335ec798a0e4f4c674250fdf
 
 COCOAPODS: 1.16.2

--- a/ios/build/generated/ios/RCTUnstableModulesRequiringMainQueueSetupProvider.mm
+++ b/ios/build/generated/ios/RCTUnstableModulesRequiringMainQueueSetupProvider.mm
@@ -12,12 +12,7 @@
 +(NSArray<NSString *> *)modules
 {
   return @[
-    @"AccessibilityManager",
-		@"Appearance",
-		@"AppState",
-		@"DeviceInfo",
-		@"PlatformConstants",
-		@"StatusBarManager"
+    
   ];
 }
 

--- a/ios/build/generated/ios/ReactAppDependencyProvider.podspec
+++ b/ios/build/generated/ios/ReactAppDependencyProvider.podspec
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-version = "0.81.1"
+version = "0.81.4"
 source = { :git => 'https://github.com/facebook/react-native.git' }
 if version == '1000.0.0'
   # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.

--- a/scripts/verify-ios-rn-versions.py
+++ b/scripts/verify-ios-rn-versions.py
@@ -6,8 +6,11 @@ def main():
     pkg_path = Path("package.json")
     lock_path = Path("ios/Podfile.lock")
 
-    if not pkg_path.exists() or not lock_path.exists():
-        print("Missing package.json or ios/Podfile.lock", file=sys.stderr)
+    if not pkg_path.exists():
+        print("package.json not found", file=sys.stderr)
+        sys.exit(2)
+    if not lock_path.exists():
+        print("ios/Podfile.lock not found (run pod install)", file=sys.stderr)
         sys.exit(2)
 
     pkg = json.loads(pkg_path.read_text())
@@ -18,7 +21,10 @@ def main():
     if not expected:
         print("No react-native in dependencies", file=sys.stderr)
         sys.exit(2)
-    expected_version = expected.lstrip("^~")
+    if expected[:1] in {"^", "~"}:
+        expected_version = expected[1:]
+    else:
+        expected_version = expected
 
     lock = lock_path.read_text()
     react_versions = set(re.findall(r"^\s+- React(?:-[^\s]+)? \((\d+(?:\.\d+){1,2})\)", lock, re.MULTILINE))
@@ -28,7 +34,36 @@ def main():
     print("React-* pods (Podfile.lock):", sorted(react_versions) or "NONE")
     print("hermes-engine pods (Podfile.lock):", sorted(hermes_versions) or "NONE")
 
-    ok = react_versions == {expected_version} and hermes_versions == {expected_version}
+    ok = True
+    if expected_version not in react_versions:
+        print(
+            f"Expected React pods at {expected_version} not found in Podfile.lock",
+            file=sys.stderr,
+        )
+        ok = False
+    unexpected_react = sorted(v for v in react_versions if v != expected_version)
+    if unexpected_react:
+        print(
+            "Unexpected React pod versions detected: " + ", ".join(unexpected_react),
+            file=sys.stderr,
+        )
+        ok = False
+
+    if expected_version not in hermes_versions:
+        print(
+            f"Expected hermes-engine pods at {expected_version} not found in Podfile.lock",
+            file=sys.stderr,
+        )
+        ok = False
+    unexpected_hermes = sorted(v for v in hermes_versions if v != expected_version)
+    if unexpected_hermes:
+        print(
+            "Unexpected hermes-engine pod versions detected: "
+            + ", ".join(unexpected_hermes),
+            file=sys.stderr,
+        )
+        ok = False
+
     sys.exit(0 if ok else 2)
 
 if __name__ == "__main__":

--- a/scripts/verify-ios-rn-versions.py
+++ b/scripts/verify-ios-rn-versions.py
@@ -1,21 +1,14 @@
 #!/usr/bin/env python3
-"""Ensure React Native and Hermes pod versions match package.json."""
-import json
-import re
-import sys
+import json, re, sys
 from pathlib import Path
 
-
-def main() -> int:
+def main():
     pkg_path = Path("package.json")
     lock_path = Path("ios/Podfile.lock")
 
-    if not pkg_path.exists():
-        print("package.json not found at repo root", file=sys.stderr)
-        return 2
-    if not lock_path.exists():
-        print("ios/Podfile.lock not found (run pod install)", file=sys.stderr)
-        return 2
+    if not pkg_path.exists() or not lock_path.exists():
+        print("Missing package.json or ios/Podfile.lock", file=sys.stderr)
+        sys.exit(2)
 
     pkg = json.loads(pkg_path.read_text())
     deps = {}
@@ -23,34 +16,20 @@ def main() -> int:
     deps.update(pkg.get("devDependencies", {}))
     expected = deps.get("react-native")
     if not expected:
-        print("No react-native dependency in package.json", file=sys.stderr)
-        return 2
-
+        print("No react-native in dependencies", file=sys.stderr)
+        sys.exit(2)
     expected_version = expected.lstrip("^~")
 
-    lock_data = lock_path.read_text()
-    react_versions = set(
-        re.findall(r"^\s+- React(?:-[^\s]+)? \((\d+(?:\.\d+){1,2})\)", lock_data, re.MULTILINE)
-    )
-    hermes_versions = set(
-        re.findall(r"^\s+- hermes-engine(?:/[^\s]+)? \((\d+(?:\.\d+){1,2})\)", lock_data, re.MULTILINE)
-    )
+    lock = lock_path.read_text()
+    react_versions = set(re.findall(r"^\s+- React(?:-[^\s]+)? \((\d+(?:\.\d+){1,2})\)", lock, re.MULTILINE))
+    hermes_versions = set(re.findall(r"^\s+- hermes-engine(?:/[^\s]+)? \((\d+(?:\.\d+){1,2})\)", lock, re.MULTILINE))
 
     print("react-native (package.json):", expected_version)
     print("React-* pods (Podfile.lock):", sorted(react_versions) or "NONE")
     print("hermes-engine pods (Podfile.lock):", sorted(hermes_versions) or "NONE")
 
-    if react_versions == {expected_version} and hermes_versions == {expected_version}:
-        return 0
-
-    print(
-        "\nMismatch detected. Run:\n"
-        "  rm -rf ios/Pods ios/Podfile.lock\n"
-        "  cd ios && pod repo update && pod install --repo-update\n",
-        file=sys.stderr,
-    )
-    return 2
-
+    ok = react_versions == {expected_version} and hermes_versions == {expected_version}
+    sys.exit(0 if ok else 2)
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()


### PR DESCRIPTION
## Summary
- align the iOS Pods lockfile to React Native and Hermes 0.81.4
- regenerate generated iOS dependency specs for the new React Native release
- replace the RN/Hermes alignment verifier with the prescribed implementation

## Testing
- python3 scripts/verify-ios-rn-versions.py
- npm test
- npm run lint
- npm run format:check

Verifier output:
```
react-native (package.json): 0.81.4
React-* pods (Podfile.lock): ['0.81.4']
hermes-engine pods (Podfile.lock): ['0.81.4']
```

------
https://chatgpt.com/codex/tasks/task_e_68cca6ec72c8833390e66b5850e38d32

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/offLLM/169)
<!-- GitContextEnd -->

## Summary by Sourcery

Align iOS pods and verification script to React Native & Hermes 0.81.4

Enhancements:
- Regenerate Podfile.lock and generated iOS dependency specs for React Native and Hermes 0.81.4
- Refactor verify-ios-rn-versions.py to consolidate imports, unify error handling and exit codes, and simplify version checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.

- Refactor
  - Simplified the iOS React Native version verification script for clearer, more granular validation of dependencies and consistent success/failure handling.
  - Standardized exit behavior and clarified error messages for missing files and version mismatches.

- Chores
  - Cleaned up script structure and imports; removed outdated guidance from output to reduce noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->