### PR TITLE
fix(ios): resolve Swift 6 strict concurrency build failures

### DIFF
--- a/ios/MyOfflineLLMApp/MLX/MLXEvents.swift
+++ b/ios/MyOfflineLLMApp/MLX/MLXEvents.swift
@@ -39,7 +39,7 @@ final class MLXEvents: RCTEventEmitter {
   }
 
   func emitCompleted() {
-    sendEvent(withName: "mlxCompleted", body: nil)
+    sendEvent(withName: "mlxCompleted", body: [:])
   }
 
   func emitError(_ code: String, message: String) {
@@ -47,6 +47,6 @@ final class MLXEvents: RCTEventEmitter {
   }
 
   func emitStopped() {
-    sendEvent(withName: "mlxStopped", body: nil)
+    sendEvent(withName: "mlxStopped", body: [:])
   }
 }


### PR DESCRIPTION
## Summary
- ensure the MLXEvents bridge emits empty dictionaries for completion and stop events so the @MainActor emitter stays concurrency-safe when bridged to React Native

## Testing
- npm test
- npm run lint *(TypeScript version warning from tooling)*
- npm run format:check -- --log-level warn
- xcodebuild -workspace monGARS.xcworkspace -scheme monGARS -configuration Release -sdk iphoneos -UseModernBuildSystem=YES CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO clean build *(fails in container: xcodebuild unavailable outside macOS; no swift-concurrency-build.log generated)*

------
https://chatgpt.com/codex/tasks/task_e_68ccac8bacf88333a1cd842d204847c6

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/offLLM/170)
<!-- GitContextEnd -->

## Summary by Sourcery

Resolve Swift 6 strict concurrency build failures by modifying MLXEvents to emit empty dictionaries instead of nil for completion and stop events.

Bug Fixes:
- Emit empty dictionary for mlxCompleted events to maintain @MainActor concurrency safety.
- Emit empty dictionary for mlxStopped events to maintain @MainActor concurrency safety.