### PR TITLE
chore(ios): C++20 + clean Pods & caches; deterministic build & unsigned IPA

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -117,6 +117,8 @@ post_install do |installer|
   installer.pods_project.targets.each do |t|
     t.build_configurations.each do |c|
       c.build_settings['DISABLE_INPUT_OUTPUT_PATHS'] = 'YES'
+      c.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++20'
+      c.build_settings['CLANG_CXX_LIBRARY'] = 'libc++'
     end
   end
 
@@ -243,6 +245,8 @@ post_install do |installer|
       next unless target.name == 'monGARS'
 
       target.build_configurations.each do |config|
+        config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++20'
+        config.build_settings['CLANG_CXX_LIBRARY'] = 'libc++'
         existing = config.build_settings['HEADER_SEARCH_PATHS']
 
         if existing.nil?

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -13,6 +13,11 @@ packages:
     url: https://github.com/ml-explore/mlx-swift-examples
     exactVersion: 2.25.6
 
+settings:
+  base:
+    CLANG_CXX_LANGUAGE_STANDARD: c++20
+    CLANG_CXX_LIBRARY: libc++
+
 targets:
   monGARS:
     type: application
@@ -62,7 +67,7 @@ targets:
 
         # Stable toolchain for RN/Folly
         CLANG_CXX_LIBRARY: libc++
-        CLANG_CXX_LANGUAGE_STANDARD: c++17
+        CLANG_CXX_LANGUAGE_STANDARD: c++20
         OTHER_MTLFLAGS:
           - "$(inherited)"
           - "-Wno-c++17-extensions"

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -70,7 +70,6 @@ targets:
         CLANG_CXX_LANGUAGE_STANDARD: c++20
         OTHER_MTLFLAGS:
           - "$(inherited)"
-          - "-Wno-c++17-extensions"
 
         # Allow CocoaPods header symlink scripts to write in Xcode 15+
         ENABLE_USER_SCRIPT_SANDBOXING: NO

--- a/project.yml
+++ b/project.yml
@@ -78,10 +78,9 @@ targets:
 
         # Stable toolchain for RN/Folly
         CLANG_CXX_LIBRARY: libc++
-        CLANG_CXX_LANGUAGE_STANDARD: c++17
+        CLANG_CXX_LANGUAGE_STANDARD: c++20
         OTHER_MTLFLAGS:
           - "$(inherited)"
-          - "-Wno-c++17-extensions"
 
         # Allow CocoaPods header symlink scripts to write in Xcode 15+
         ENABLE_USER_SCRIPT_SANDBOXING: NO


### PR DESCRIPTION
## Summary
- raise the iOS project default C++ dialect/library to C++20/libc++ so React Native 0.81 bridging headers compile cleanly
- extend the `post_install` hook to force every CocoaPods target and the monGARS user target to inherit the same C++20 settings

## Testing
- npm test
- npm run lint
- npm run format:check

## Notes
- Built XcodeGen 2.44.1 from source, but the binary crashes under Linux when resolving the current user (`libFoundation` bad pointer) so `monGARS.xcodeproj` could not be regenerated (`xcodegen generate` → segmentation fault).
- Because no `.xcodeproj` was produced, CocoaPods commands abort (`pod install --allow-root --repo-update` → "No .xcodeproj found").
- The container does not include Xcode CLI tools (`xcodebuild` is not present), so deterministic build/archive commands and unsigned IPA generation were not possible in this environment; corresponding logs/artifacts are therefore unavailable.

------
https://chatgpt.com/codex/tasks/task_e_68ccae1a88e4833393a3d6e3fef3d81b

## Summary by Sourcery

Raise the iOS project C++ standard to C++20 with libc++ and enforce these settings across all CocoaPods and application targets

Enhancements:
- Upgrade XcodeGen project settings and monGARS target to use C++20 and libc++
- Extend Podfile post_install hook to apply C++20 and libc++ build settings to every CocoaPods target and the monGARS user target