### PR TITLE
chore(ios): persist build settings (C++20) + CI verifiers

### DIFF
--- a/.github/actions/verify-ios-config/action.yml
+++ b/.github/actions/verify-ios-config/action.yml
@@ -1,0 +1,11 @@
+name: Verify iOS build configuration
+description: Run RN/Hermes and C++20 verification scripts to detect drift.
+runs:
+  using: "composite"
+  steps:
+    - name: Verify RN/Hermes versions match package.json
+      shell: bash
+      run: python3 scripts/verify-ios-rn-versions.py
+    - name: Verify Pods use C++20
+      shell: bash
+      run: python3 scripts/verify-ios-cpp-standard.py

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -76,13 +76,8 @@ jobs:
           bundle exec pod repo update
           bundle exec pod install --repo-update
 
-      - name: Verify RN/Hermes versions match package.json
-        run: |
-          python3 scripts/verify-ios-rn-versions.py
-
-      - name: Verify Pods use C++20
-        run: |
-          python3 scripts/verify-ios-cpp-standard.py
+      - name: Run iOS configuration verifiers
+        uses: ./.github/actions/verify-ios-config
 
       - name: Clean DerivedData caches
         run: |
@@ -173,13 +168,8 @@ jobs:
           bundle exec pod repo update
           bundle exec pod install --repo-update
 
-      - name: Verify RN/Hermes versions match package.json
-        run: |
-          python3 scripts/verify-ios-rn-versions.py
-
-      - name: Verify Pods use C++20
-        run: |
-          python3 scripts/verify-ios-cpp-standard.py
+      - name: Run iOS configuration verifiers
+        uses: ./.github/actions/verify-ios-config
 
       - name: Clean DerivedData caches
         run: |

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -80,6 +80,10 @@ jobs:
         run: |
           python3 scripts/verify-ios-rn-versions.py
 
+      - name: Verify Pods use C++20
+        run: |
+          python3 scripts/verify-ios-cpp-standard.py
+
       - name: Clean DerivedData caches
         run: |
           rm -rf ~/Library/Developer/Xcode/DerivedData
@@ -172,6 +176,10 @@ jobs:
       - name: Verify RN/Hermes versions match package.json
         run: |
           python3 scripts/verify-ios-rn-versions.py
+
+      - name: Verify Pods use C++20
+        run: |
+          python3 scripts/verify-ios-cpp-standard.py
 
       - name: Clean DerivedData caches
         run: |

--- a/scripts/verify-ios-cpp-standard.py
+++ b/scripts/verify-ios-cpp-standard.py
@@ -2,22 +2,177 @@
 """Fail if any Pods targets use a C++ standard other than c++20."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 import re
 import sys
 from pathlib import Path
+from typing import Iterable
 
 PODS_PROJECT = Path("ios/Pods/Pods.xcodeproj/project.pbxproj")
 APP_PROJECT = Path("ios/monGARS.xcodeproj/project.pbxproj")
 
+SECTION_TEMPLATE = r"/\* Begin {section} section \*/(?P<body>.*?)/\* End {section} section \*/"
+BUILD_CONFIG_RE = re.compile(
+    r"\s*(?P<id>[0-9A-Fa-f]+) /\* (?P<name>[^*]+) \*/ = \{\s*"
+    r"isa = XCBuildConfiguration;\s*(?P<body>.*?)\};",
+    re.DOTALL,
+)
+CONFIG_LIST_RE = re.compile(
+    r"\s*(?P<id>[0-9A-Fa-f]+) /\* Build configuration list for (?P<kind>[^\"]+) \"(?P<name>[^\"]+)\" \*/ = \{\s*"
+    r"isa = XCConfigurationList;\s*buildConfigurations = \((?P<configs>.*?)\);",
+    re.DOTALL,
+)
+CONFIG_ID_RE = re.compile(r"([0-9A-Fa-f]+) /\*")
+STD_SETTING_RE = re.compile(
+    r"CLANG_CXX_LANGUAGE_STANDARD(?:\[[^\]]+\])?\s*=\s*(?P<value>[^;]+);"
+)
 
-def extract_standards(text: str) -> set[str]:
-    pattern = re.compile(r"CLANG_CXX_LANGUAGE_STANDARD\s*=\s*([^;\n]+)")
+
+@dataclass
+class Configuration:
+    identifier: str
+    config_name: str
+    target_label: str
+    values: list[str]
+
+
+def normalize_value(raw_value: str) -> str:
+    value = raw_value.strip()
+    if value.startswith('"') and value.endswith('"'):
+        value = value[1:-1]
+    return value.strip()
+
+
+def is_variable(value: str) -> bool:
+    return value.startswith("$(") or value.startswith("${")
+
+
+def extract_section(text: str, section: str) -> str:
+    pattern = re.compile(SECTION_TEMPLATE.format(section=re.escape(section)), re.DOTALL)
+    match = pattern.search(text)
+    return match.group("body") if match else ""
+
+
+def parse_configurations(text: str) -> dict[str, tuple[str, list[str]]]:
+    section = extract_section(text, "XCBuildConfiguration")
+    configurations: dict[str, tuple[str, list[str]]] = {}
+
+    for match in BUILD_CONFIG_RE.finditer(section):
+        config_id = match.group("id")
+        config_name = match.group("name").strip()
+        body = match.group("body")
+        values: list[str] = []
+        for setting_match in STD_SETTING_RE.finditer(body):
+            if value := normalize_value(setting_match.group("value")):
+                values.append(value)
+        configurations[config_id] = (config_name, values)
+
+    return configurations
+
+
+def format_target(kind: str, name: str) -> str:
+    prefixes = {
+        "PBXProject": "Project",
+        "PBXNativeTarget": "Target",
+        "PBXAggregateTarget": "Aggregate target",
+    }
+    prefix = prefixes.get(kind.strip(), kind.strip() or "Unknown")
+    return f"{prefix} \"{name.strip()}\""
+
+
+def map_configuration_targets(text: str) -> dict[str, tuple[str, str]]:
+    section = extract_section(text, "XCConfigurationList")
+    mapping: dict[str, tuple[str, str]] = {}
+
+    for match in CONFIG_LIST_RE.finditer(section):
+        kind = match.group("kind")
+        name = match.group("name")
+        configs_blob = match.group("configs")
+        for config_id_match in CONFIG_ID_RE.finditer(configs_blob):
+            config_id = config_id_match.group(1)
+            mapping[config_id] = (kind, name)
+
+    return mapping
+
+
+def collect_configuration_reports(path: Path) -> list[Configuration]:
+    text = path.read_text(errors="ignore")
+    values_by_id = parse_configurations(text)
+    target_mapping = map_configuration_targets(text)
+
+    reports: list[Configuration] = []
+    for config_id, (config_name, values) in values_by_id.items():
+        kind, name = target_mapping.get(config_id, ("Unknown", config_id))
+        reports.append(
+            Configuration(
+                identifier=config_id,
+                config_name=config_name,
+                target_label=format_target(kind, name),
+                values=values,
+            )
+        )
+
+    return sorted(reports, key=lambda cfg: (cfg.target_label, cfg.config_name))
+
+
+def summarize_values(configurations: Iterable[Configuration]) -> set[str]:
     values: set[str] = set()
-    for match in pattern.finditer(text):
-        value = match.group(1).strip().strip('"')
-        if value:
-            values.add(value)
+    for config in configurations:
+        values.update(config.values)
     return values
+
+
+def evaluate_pods_configs(configurations: list[Configuration]) -> tuple[bool, list[str]]:
+    failures: list[str] = []
+    for config in configurations:
+        explicit_values = [value for value in config.values if not is_variable(value)]
+        if not explicit_values:
+            failures.append(
+                f"{config.target_label} [{config.config_name}]: "
+                f"{', '.join(config.values) if config.values else '(missing)'}"
+            )
+            continue
+
+        for value in explicit_values:
+            if value.lower() != "c++20":
+                failures.append(
+                    f"{config.target_label} [{config.config_name}]: {', '.join(config.values)}"
+                )
+                break
+
+    return (not failures, failures)
+
+
+def print_app_summary(configurations: list[Configuration]) -> None:
+    explicit_values = {
+        value
+        for config in configurations
+        for value in config.values
+        if not is_variable(value)
+    }
+    if explicit_values:
+        print("App CLANG_CXX_LANGUAGE_STANDARD values:", explicit_values)
+    else:
+        print("App CLANG_CXX_LANGUAGE_STANDARD values:", {"(none)"})
+
+    inherited_configs = [
+        config
+        for config in configurations
+        if config.values and all(is_variable(value) for value in config.values)
+    ]
+    missing_configs = [config for config in configurations if not config.values]
+
+    if inherited_configs:
+        joined = ", ".join(
+            f"{config.target_label} [{config.config_name}]" for config in inherited_configs
+        )
+        print("App configurations inheriting the standard:", joined)
+
+    if missing_configs:
+        joined = ", ".join(
+            f"{config.target_label} [{config.config_name}]" for config in missing_configs
+        )
+        print("App configurations without the setting:", joined)
 
 
 def main() -> int:
@@ -25,21 +180,25 @@ def main() -> int:
         print("Pods.xcodeproj not found (run pod install)", file=sys.stderr)
         return 2
 
-    pods_text = PODS_PROJECT.read_text(errors="ignore")
-    pods_values = extract_standards(pods_text)
+    pods_configs = collect_configuration_reports(PODS_PROJECT)
+    pods_values = summarize_values(pods_configs)
     print("Pods CLANG_CXX_LANGUAGE_STANDARD values:", pods_values or {"(none)"})
-
-    effective_pods_values = {value for value in pods_values if not value.startswith("$(")}
-    pods_ok = (effective_pods_values == {"c++20"})
+    pods_ok, failures = evaluate_pods_configs(pods_configs)
 
     if APP_PROJECT.exists():
-        app_text = APP_PROJECT.read_text(errors="ignore")
-        app_values = extract_standards(app_text)
-        print("App CLANG_CXX_LANGUAGE_STANDARD values:", app_values or {"(none)"})
+        app_configs = collect_configuration_reports(APP_PROJECT)
+        print_app_summary(app_configs)
     else:
         print("App project not found at", APP_PROJECT, "(skipping app check)")
 
-    return 0 if pods_ok else 2
+    if not pods_ok:
+        print("Found Pods targets without an explicit CLANG_CXX_LANGUAGE_STANDARD=c++20:")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 2
+
+    print("All Pods targets explicitly set CLANG_CXX_LANGUAGE_STANDARD=c++20.")
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/verify-ios-cpp-standard.py
+++ b/scripts/verify-ios-cpp-standard.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Fail if any Pods targets use a C++ standard other than c++20."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+PODS_PROJECT = Path("ios/Pods/Pods.xcodeproj/project.pbxproj")
+APP_PROJECT = Path("ios/monGARS.xcodeproj/project.pbxproj")
+
+
+def extract_standards(text: str) -> set[str]:
+    pattern = re.compile(r"CLANG_CXX_LANGUAGE_STANDARD\s*=\s*([^;\n]+)")
+    values: set[str] = set()
+    for match in pattern.finditer(text):
+        value = match.group(1).strip().strip('"')
+        if value:
+            values.add(value)
+    return values
+
+
+def main() -> int:
+    if not PODS_PROJECT.exists():
+        print("Pods.xcodeproj not found (run pod install)", file=sys.stderr)
+        return 2
+
+    pods_text = PODS_PROJECT.read_text(errors="ignore")
+    pods_values = extract_standards(pods_text)
+    print("Pods CLANG_CXX_LANGUAGE_STANDARD values:", pods_values or {"(none)"})
+
+    effective_pods_values = {value for value in pods_values if not value.startswith("$(")}
+    pods_ok = (effective_pods_values == {"c++20"})
+
+    if APP_PROJECT.exists():
+        app_text = APP_PROJECT.read_text(errors="ignore")
+        app_values = extract_standards(app_text)
+        print("App CLANG_CXX_LANGUAGE_STANDARD values:", app_values or {"(none)"})
+    else:
+        print("App project not found at", APP_PROJECT, "(skipping app check)")
+
+    return 0 if pods_ok else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a Pods.xcodeproj verifier that enforces CLANG_CXX_LANGUAGE_STANDARD=c++20 and reports any drift
- hook the new C++ standard verifier plus the existing RN/Hermes alignment script into the iOS build and archive workflows
- ensure the scripts remain executable so CI can block configuration drift that would break RN 0.81’s C++20 bridge

## Testing
- npm test
- npm run lint
- npm run format:check


------
https://chatgpt.com/codex/tasks/task_e_68ccb1fcc540833391294832a17bfb49

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/offLLM/175)
<!-- GitContextEnd -->

## Summary by Sourcery

Enforce C++20 as the Clang C++ language standard for iOS Pods by introducing a verification script and integrating it into the build and archive CI pipelines to block configuration drift.

New Features:
- Add a Python script to verify that all iOS Pod targets use C++20

Enhancements:
- Integrate the C++20 verifier into the iOS build and archive GitHub Actions workflows
- Ensure the verification scripts remain executable to prevent C++20 bridge drift

CI:
- Add CI steps in ios-build.yml to run the new C++ standard verifier