### PR TITLE
Add ios unsigned diagnostics fixtures for tests

### DIFF
--- a/__tests__/fixtures/iosUnsigned/ResultBundle_unsigned_sample.json
+++ b/__tests__/fixtures/iosUnsigned/ResultBundle_unsigned_sample.json
@@ -1,0 +1,77 @@
+{
+  "_type": { "_name": "ActionsInvocationRecord" },
+  "actions": {
+    "_type": { "_name": "Array" },
+    "_values": [
+      {
+        "_type": { "_name": "ActionRecord" },
+        "actionResult": {
+          "_type": { "_name": "ActionResult" },
+          "issues": {
+            "_type": { "_name": "ResultIssueSummaries" },
+            "issueSummaries": {
+              "_type": { "_name": "IssueSummaries" },
+              "_values": [
+                {
+                  "_type": { "_name": "IssueSummary" },
+                  "issueType": {
+                    "_type": { "_name": "String" },
+                    "_value": "Swift Compiler Error"
+                  },
+                  "message": {
+                    "_type": { "_name": "String" },
+                    "_value": "Sending 'session' risks causing data races"
+                  },
+                  "documentLocationInCreatingWorkspace": {
+                    "_type": { "_name": "DocumentLocation" },
+                    "concreteTypeName": {
+                      "_type": { "_name": "String" },
+                      "_value": "DVTTextDocumentLocation"
+                    },
+                    "url": {
+                      "_type": { "_name": "String" },
+                      "_value": "file:///Users/runner/work/offLLM/offLLM/ios/MyOfflineLLMApp/MLX/MLXModule.swift#EndingColumnNumber=29&EndingLineNumber=153&StartingColumnNumber=29&StartingLineNumber=153&Timestamp=779766553.001115"
+                    }
+                  }
+                },
+                {
+                  "_type": { "_name": "IssueSummary" },
+                  "issueType": {
+                    "_type": { "_name": "String" },
+                    "_value": "Warning"
+                  },
+                  "message": {
+                    "_type": { "_name": "String" },
+                    "_value": "Run script build phase '[CP-User] [Hermes] Replace Hermes for the right configuration, if needed' will be run during every build because it does not specify any outputs. To address this issue, either add output dependencies to the script phase, or configure it to run in every build by unchecking \"Based on dependency analysis\" in the script phase."
+                  }
+                },
+                {
+                  "_type": { "_name": "IssueSummary" },
+                  "issueType": {
+                    "_type": { "_name": "String" },
+                    "_value": "Parse Issue"
+                  },
+                  "message": {
+                    "_type": { "_name": "String" },
+                    "_value": "Use of GNU ?: conditional expression extension, omitting middle operand"
+                  },
+                  "documentLocationInCreatingWorkspace": {
+                    "_type": { "_name": "DocumentLocation" },
+                    "concreteTypeName": {
+                      "_type": { "_name": "String" },
+                      "_value": "DVTTextDocumentLocation"
+                    },
+                    "url": {
+                      "_type": { "_name": "String" },
+                      "_value": "file:///Users/runner/work/offLLM/offLLM/node_modules/react-native/Libraries/TypeSafety/RCTConvertHelpers.h#EndingColumnNumber=23&EndingLineNumber=26&StartingColumnNumber=23&StartingLineNumber=26&Timestamp=779766553.001115"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/__tests__/fixtures/iosUnsigned/archive_result_sample.json
+++ b/__tests__/fixtures/iosUnsigned/archive_result_sample.json
@@ -1,0 +1,66 @@
+{
+  "_type": { "_name": "ActionsInvocationRecord" },
+  "actions": {
+    "_type": { "_name": "Array" },
+    "_values": [
+      {
+        "_type": { "_name": "ActionRecord" },
+        "actionResult": {
+          "_type": { "_name": "ActionResult" },
+          "issues": {
+            "_type": { "_name": "ResultIssueSummaries" },
+            "issueSummaries": {
+              "_type": { "_name": "IssueSummaries" },
+              "_values": [
+                {
+                  "_type": { "_name": "IssueSummary" },
+                  "issueType": {
+                    "_type": { "_name": "String" },
+                    "_value": "Swift Compiler Error"
+                  },
+                  "message": {
+                    "_type": { "_name": "String" },
+                    "_value": "Sending 'session' risks causing data races"
+                  },
+                  "documentLocationInCreatingWorkspace": {
+                    "_type": { "_name": "DocumentLocation" },
+                    "concreteTypeName": {
+                      "_type": { "_name": "String" },
+                      "_value": "DVTTextDocumentLocation"
+                    },
+                    "url": {
+                      "_type": { "_name": "String" },
+                      "_value": "file:///Users/runner/work/offLLM/offLLM/ios/MyOfflineLLMApp/MLX/MLXModule.swift#EndingColumnNumber=29&EndingLineNumber=153&StartingColumnNumber=29&StartingLineNumber=153&Timestamp=779766553.001115"
+                    }
+                  }
+                },
+                {
+                  "_type": { "_name": "IssueSummary" },
+                  "issueType": {
+                    "_type": { "_name": "String" },
+                    "_value": "Warning"
+                  },
+                  "message": {
+                    "_type": { "_name": "String" },
+                    "_value": "Run script build phase 'Create Symlinks to Header Folders' will be run during every build because it does not specify any outputs. To address this issue, either add output dependencies to the script phase, or configure it to run in every build by unchecking \"Based on dependency analysis\" in the script phase."
+                  }
+                },
+                {
+                  "_type": { "_name": "IssueSummary" },
+                  "issueType": {
+                    "_type": { "_name": "String" },
+                    "_value": "Warning"
+                  },
+                  "message": {
+                    "_type": { "_name": "String" },
+                    "_value": "Skipping duplicate build file in Copy Headers build phase: /Users/runner/work/offLLM/offLLM/node_modules/react-native/ReactCommon/yoga/yoga/enums/FlexDirection.h"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/__tests__/iosDiagnosticsSummary.test.js
+++ b/__tests__/iosDiagnosticsSummary.test.js
@@ -1,0 +1,97 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+describe("emit_ios_diagnostics_summary", () => {
+  test("summarizes unsigned device build issues from Apple xcresult JSON", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ios-summary-"));
+    const envLog = path.join(tmpDir, "environment.log");
+    const errorLog = path.join(tmpDir, "xcode-errors.log");
+    const derivedLog = path.join(tmpDir, "derived-data.log");
+    const unifiedLog = path.join(tmpDir, "unified.log");
+
+    fs.writeFileSync(envLog, "macOS 15.0.1\nXcode 16.4\n", "utf8");
+    fs.writeFileSync(errorLog, "warning: sample log\n", "utf8");
+    fs.writeFileSync(
+      derivedLog,
+      "DerivedData base: /Users/runner/Library/Developer/Xcode/DerivedData\n",
+      "utf8",
+    );
+    fs.writeFileSync(unifiedLog, "log show unavailable\n", "utf8");
+
+    const unsignedFixture = path.join(
+      __dirname,
+      "fixtures",
+      "iosUnsigned",
+      "ResultBundle_unsigned_sample.json",
+    );
+    const archiveFixture = path.join(
+      __dirname,
+      "fixtures",
+      "iosUnsigned",
+      "archive_result_sample.json",
+    );
+
+    const result = spawnSync(
+      "python3",
+      [
+        "scripts/ci/emit_ios_diagnostics_summary.py",
+        "--label",
+        "iOS unsigned device build",
+        "--env-log",
+        envLog,
+        "--error-log",
+        errorLog,
+        "--derived-log",
+        derivedLog,
+        "--unified-log",
+        unifiedLog,
+        "--artifact-path",
+        "build/diagnostics",
+        "--result-json",
+        unsignedFixture,
+        "--result-json",
+        archiveFixture,
+        "--issue-limit",
+        "5",
+      ],
+      {
+        encoding: "utf8",
+        cwd: path.join(__dirname, ".."),
+        env: { ...process.env, PYTHONUTF8: "1" },
+      },
+    );
+
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // best effort cleanup
+    }
+
+    if (result.stderr) {
+      // Improve debugging on CI by surfacing stderr when the command fails.
+      console.error(result.stderr);
+    }
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("## iOS unsigned device build diagnostics");
+    expect(result.stdout).toContain("Swift Compiler Error");
+    expect(result.stdout).toContain(
+      "Sending 'session' risks causing data races",
+    );
+    expect(result.stdout).toContain(
+      "Run script build phase '[CP-User] [Hermes] Replace Hermes",
+    );
+    expect(result.stdout).toContain(
+      "Run script build phase 'Create Symlinks to Header Folders'",
+    );
+    expect(result.stdout).toContain(
+      "Use of GNU ?: conditional expression extension, omitting middle operand",
+    );
+    expect(result.stdout).toContain(
+      "Skipping duplicate build file in Copy Headers build phase",
+    );
+    expect(result.stdout).toContain("Artifacts: `build/diagnostics`");
+  });
+});

--- a/__tests__/iosDiagnosticsSummary.test.js
+++ b/__tests__/iosDiagnosticsSummary.test.js
@@ -4,8 +4,24 @@ const path = require("path");
 const { spawnSync } = require("child_process");
 
 describe("emit_ios_diagnostics_summary", () => {
+  let tmpDir;
+
+  afterEach(() => {
+    if (!tmpDir) {
+      return;
+    }
+
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // best effort cleanup
+    }
+
+    tmpDir = undefined;
+  });
+
   test("summarizes unsigned device build issues from Apple xcresult JSON", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ios-summary-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ios-summary-"));
     const envLog = path.join(tmpDir, "environment.log");
     const errorLog = path.join(tmpDir, "xcode-errors.log");
     const derivedLog = path.join(tmpDir, "derived-data.log");
@@ -62,12 +78,6 @@ describe("emit_ios_diagnostics_summary", () => {
         env: { ...process.env, PYTHONUTF8: "1" },
       },
     );
-
-    try {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    } catch {
-      // best effort cleanup
-    }
 
     if (result.stderr) {
       // Improve debugging on CI by surfacing stderr when the command fails.

--- a/__tests__/iosDiagnosticsSummary.test.js
+++ b/__tests__/iosDiagnosticsSummary.test.js
@@ -49,6 +49,11 @@ describe("emit_ios_diagnostics_summary", () => {
       "archive_result_sample.json",
     );
 
+    // The script writes to GITHUB_STEP_SUMMARY when it is defined, so clear it to
+    // keep stdout assertions deterministic across environments.
+    const childEnv = { ...process.env, PYTHONUTF8: "1" };
+    delete childEnv.GITHUB_STEP_SUMMARY;
+
     const result = spawnSync(
       "python3",
       [
@@ -75,7 +80,7 @@ describe("emit_ios_diagnostics_summary", () => {
       {
         encoding: "utf8",
         cwd: path.join(__dirname, ".."),
-        env: { ...process.env, PYTHONUTF8: "1" },
+        env: childEnv,
       },
     );
 


### PR DESCRIPTION
## Summary
- add lightweight xcresult JSON fixtures extracted from the iOS unsigned device build
- add a Jest test that runs emit_ios_diagnostics_summary.py against the Apple fixtures to cover error and warning extraction

## Testing
- npm test -- --runTestsByPath __tests__/iosDiagnosticsSummary.test.js
- npm test
- npm run lint
- CI=true npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68cdeb4b5ac883339d6429ecb60cd1d6

## Summary by Sourcery

Add lightweight xcresult fixtures and a Jest-based integration test to validate the emit_ios_diagnostics_summary.py script against iOS unsigned device build data

New Features:
- Add xcresult JSON fixtures for iOS unsigned device builds
- Add Jest test that runs emit_ios_diagnostics_summary.py against the new fixtures

Tests:
- Add integration-style test to verify error and warning extraction and artifact reporting