### PR TITLE
fix: avoid duplicate RCTDeprecation module map

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -175,8 +175,14 @@ post_install do |installer|
   module_map_path = '$(PODS_ROOT)/Headers/Public/RCTDeprecation/module.modulemap'
   legacy_module_map_path = '$(PODS_ROOT)/Headers/Public/RCTDeprecation/RCTDeprecation.modulemap'
   module_map_flag = "-fmodule-map-file=#{module_map_path}"
-  legacy_module_map_flag = "-fmodule-map-file=#{legacy_module_map_path}"
-  module_map_flags = [module_map_flag, legacy_module_map_flag]
+  # Keep the legacy module map on disk for older toolchains that still probe for
+  # `RCTDeprecation.modulemap`, but avoid feeding it directly to clang.
+  # Xcode 16's clang treats duplicate `-fmodule-map-file` entries defining the
+  # same module as a hard error ("redefinition of module"), which surfaced in CI.
+  # Limiting the compiler flags to the canonical module map sidesteps the clash
+  # while maintaining the compatibility file for consumers that reference it
+  # directly on disk.
+  module_map_flags = [module_map_flag]
   module_map_dir = File.join(installer.sandbox.root.to_s, 'Headers', 'Public', 'RCTDeprecation')
   module_map_disk = File.join(module_map_dir, 'module.modulemap')
   legacy_module_map_disk = File.join(module_map_dir, 'RCTDeprecation.modulemap')

--- a/project.yml
+++ b/project.yml
@@ -61,17 +61,13 @@ targets:
         OTHER_CFLAGS:
           - "$(inherited)"
           - "-fmodule-map-file=$(PODS_ROOT)/Headers/Public/RCTDeprecation/module.modulemap"
-          - "-fmodule-map-file=$(PODS_ROOT)/Headers/Public/RCTDeprecation/RCTDeprecation.modulemap"
         OTHER_CPLUSPLUSFLAGS:
           - "$(inherited)"
           - "-fmodule-map-file=$(PODS_ROOT)/Headers/Public/RCTDeprecation/module.modulemap"
-          - "-fmodule-map-file=$(PODS_ROOT)/Headers/Public/RCTDeprecation/RCTDeprecation.modulemap"
         OTHER_SWIFT_FLAGS:
           - "$(inherited)"
           - "-Xcc"
           - "-fmodule-map-file=$(PODS_ROOT)/Headers/Public/RCTDeprecation/module.modulemap"
-          - "-Xcc"
-          - "-fmodule-map-file=$(PODS_ROOT)/Headers/Public/RCTDeprecation/RCTDeprecation.modulemap"
         CLANG_ENABLE_MODULES: YES
 
         # Unsigned/device builds in CI


### PR DESCRIPTION
## Summary
- stop passing both the primary and legacy RCTDeprecation module maps to clang so the pod no longer redefines the module under Xcode 16
- keep the compatibility module map on disk but update the XcodeGen template to rely on the canonical module map flag

## Testing
- npm test -- --runInBand
- npm run lint
- CI=1 npm run format:check
- npm run build:ios *(fails: `xcodegen` is unavailable in the Linux container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce17b06d088333ae60655e17191d92