### PR TITLE
feat: persist recurring session notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 *.log
 vector_memory.dat
+session_notes.dat
 ios/vendor/
 ios/monGARS.xcodeproj/
 ios/.bundle/

--- a/__tests__/sessionNotes.test.js
+++ b/__tests__/sessionNotes.test.js
@@ -1,0 +1,96 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+import SessionNotesStore from "../src/memory/SessionNotesStore";
+import SessionNoteManager from "../src/core/memory/SessionNoteManager";
+
+describe("SessionNotesStore", () => {
+  let filePath;
+
+  afterEach(async () => {
+    if (filePath) {
+      try {
+        await fs.unlink(filePath);
+      } catch (error) {
+        if (error?.code !== "ENOENT") {
+          throw error;
+        }
+      }
+      filePath = undefined;
+    }
+  });
+
+  it("records occurrences and persists notes to disk", async () => {
+    filePath = path.join(
+      os.tmpdir(),
+      `session-notes-${Date.now()}-${Math.random()}.dat`,
+    );
+
+    const store = new SessionNotesStore({ filePath, maxNotes: 5 });
+
+    await store.record({
+      key: "test-note",
+      message: "Initial failure detected",
+      suggestion: "Investigate the failure",
+    });
+
+    await store.record({
+      key: "test-note",
+      message: "Initial failure detected",
+      suggestion: "Retry with smaller batches",
+    });
+
+    const notes = await store.getTopNotes({ limit: 1 });
+    expect(notes).toHaveLength(1);
+    expect(notes[0].occurrences).toBe(2);
+    expect(notes[0].suggestion).toBe("Retry with smaller batches");
+
+    const reloaded = new SessionNotesStore({ filePath, maxNotes: 5 });
+    const persisted = await reloaded.getTopNotes({ limit: 1 });
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].occurrences).toBe(2);
+  });
+});
+
+describe("SessionNoteManager", () => {
+  let filePath;
+
+  afterEach(async () => {
+    if (filePath) {
+      try {
+        await fs.unlink(filePath);
+      } catch (error) {
+        if (error?.code !== "ENOENT") {
+          throw error;
+        }
+      }
+      filePath = undefined;
+    }
+  });
+
+  it("surfaces CLI overflow guidance for repeated shell output errors", async () => {
+    filePath = path.join(
+      os.tmpdir(),
+      `session-notes-${Date.now()}-${Math.random()}.dat`,
+    );
+
+    const store = new SessionNotesStore({ filePath, maxNotes: 5 });
+    const manager = new SessionNoteManager({ store });
+
+    const error = new Error(
+      "Error: Output for session 'shell1' contained a line exceeding the max of 4096 bytes (observed at least 8049 bytes).",
+    );
+
+    await manager.recordError(error, { step: "shell", command: "grep" });
+
+    let context = await manager.getContextEntries({ limit: 3 });
+    expect(context).toHaveLength(1);
+    expect(context[0].content).toContain("4096");
+    expect(context[0].content).toContain("Mitigation");
+
+    await manager.recordError(error, { step: "shell", command: "grep" });
+    context = await manager.getContextEntries({ limit: 3 });
+    expect(context[0].content).toContain("2\u00d7");
+  });
+});

--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -9,6 +9,7 @@
 ## Memory and Context Management
 
 - `MemoryManager` couples a vector indexer, retriever, and bounded conversation history so that every interaction is embedded, added to the vector store, and made available for future context retrieval during orchestration.【F:src/core/memory/MemoryManager.js†L1-L37】
+- `SessionNoteManager` pulls encrypted session notes from the persistent store and injects them into the prompt so recurring failures (like oversized shell output) ship with proven mitigations before the agent acts again.【F:src/core/memory/SessionNoteManager.js†L1-L66】【F:src/memory/SessionNotesStore.ts†L1-L195】【F:src/core/AgentOrchestrator.js†L28-L118】
 - `VectorIndexer`, `Retriever`, and `HistoryService` handle the respective responsibilities of embedding new content, fetching similarity matches (with sparse-attention re-ranking), and tracking the sliding conversational window.【F:src/core/memory/services/VectorIndexer.js†L1-L26】【F:src/core/memory/services/Retriever.js†L1-L37】【F:src/core/memory/services/HistoryService.js†L1-L17】
 - `ContextEngineer` provides higher-level context planning features such as hierarchical attention, sparse retrieval fallbacks, device-aware token budgeting, and adaptive summarization so the agent can scale prompts across device tiers.【F:src/services/contextEngineer.js†L1-L409】
 

--- a/src/core/memory/SessionNoteManager.js
+++ b/src/core/memory/SessionNoteManager.js
@@ -1,0 +1,88 @@
+import SessionNotesStore from "../../memory/SessionNotesStore";
+import { deriveNoteFromError } from "./sessionNoteHeuristics";
+
+const DEFAULT_LIMIT = 3;
+const DEFAULT_MIN_OCCURRENCES = 1;
+
+const TERMINAL_PUNCTUATION = /[.!?]$/;
+
+export default class SessionNoteManager {
+  constructor({
+    store,
+    limit = DEFAULT_LIMIT,
+    minOccurrences = DEFAULT_MIN_OCCURRENCES,
+  } = {}) {
+    this.store = store || new SessionNotesStore();
+    this.limit = limit;
+    this.minOccurrences = minOccurrences;
+  }
+
+  async getContextEntries(options = {}) {
+    const limit =
+      typeof options.limit === "number" ? options.limit : this.limit;
+    const minOccurrences =
+      typeof options.minOccurrences === "number"
+        ? options.minOccurrences
+        : this.minOccurrences;
+
+    const notes = await this.store.getTopNotes({ limit, minOccurrences });
+    return notes.map((note) => this.#formatNote(note));
+  }
+
+  async recordError(error, metadata = {}) {
+    const entry = deriveNoteFromError(error, metadata);
+    if (!entry) {
+      return;
+    }
+
+    try {
+      await this.store.record(entry);
+    } catch (storeError) {
+      if (process.env.NODE_ENV !== "test") {
+        console.warn(
+          "[SessionNoteManager] Failed to persist session note",
+          storeError,
+        );
+      }
+    }
+  }
+
+  async clear() {
+    await this.store.clear();
+  }
+
+  #formatNote(note) {
+    const firstSeenIso = new Date(note.firstSeen).toISOString();
+    const occurrenceLabel =
+      note.occurrences > 1
+        ? `${note.occurrences}\u00d7 since ${firstSeenIso}`
+        : `recorded ${firstSeenIso}`;
+
+    const message = this.#ensureSentence(note.message || "");
+    const mitigationText = this.#ensureSentence(note.suggestion || "");
+    const mitigation = mitigationText ? ` Mitigation: ${mitigationText}` : "";
+
+    return {
+      role: "system",
+      content: `Session note (${occurrenceLabel}): ${message}${mitigation}`,
+      metadata: {
+        noteId: note.id,
+        key: note.key,
+        occurrences: note.occurrences,
+        lastSeen: note.lastSeen,
+        tags: note.tags,
+      },
+    };
+  }
+
+  #ensureSentence(text) {
+    const trimmed = String(text || "").trim();
+    if (!trimmed) {
+      return trimmed;
+    }
+    if (TERMINAL_PUNCTUATION.test(trimmed)) {
+      return trimmed;
+    }
+    return `${trimmed}.`;
+  }
+}

--- a/src/core/memory/sessionNoteHeuristics.js
+++ b/src/core/memory/sessionNoteHeuristics.js
@@ -1,0 +1,100 @@
+import { createHash } from "crypto";
+
+const KNOWN_ERROR_NOTES = [
+  {
+    key: "shell-output-4096-limit",
+    pattern: /line exceeding the max of 4096 bytes/i,
+    message:
+      "Shell output exceeded the 4096-byte line limit enforced by the CLI bridge, so results were truncated and the session aborted.",
+    suggestion:
+      "Chunk long command output (pipe through `rg`, `grep -n`, `sed -n '1,200p'`, `cut -c1-200`, or `head`/`tail`) so no single line exceeds 4 KB.",
+    tags: ["shell", "telemetry"],
+  },
+];
+
+const DEFAULT_FALLBACK_SUGGESTION =
+  "Investigate this recurring error, capture the remediation steps, and break workflows into smaller chunks to avoid repeating it.";
+
+const FALLBACK_TAGS = ["error"];
+
+const HASH_PREFIX = "error:";
+
+const MAX_MESSAGE_LENGTH = 1024;
+
+export function deriveNoteFromError(error, metadata = {}) {
+  if (!error) {
+    return null;
+  }
+
+  const rawMessage = extractMessage(error);
+  if (!rawMessage) {
+    return null;
+  }
+
+  const context = {
+    ...metadata,
+    sourceError: rawMessage,
+  };
+
+  const heuristic = KNOWN_ERROR_NOTES.find((entry) =>
+    entry.pattern.test(rawMessage),
+  );
+
+  if (heuristic) {
+    return {
+      key: heuristic.key,
+      message: heuristic.message,
+      suggestion: heuristic.suggestion,
+      tags: heuristic.tags,
+      context,
+    };
+  }
+
+  const digest = createHash("sha1")
+    .update(rawMessage.slice(0, MAX_MESSAGE_LENGTH))
+    .digest("hex");
+
+  const suggestion =
+    typeof metadata.suggestion === "string" && metadata.suggestion.trim().length
+      ? metadata.suggestion
+      : DEFAULT_FALLBACK_SUGGESTION;
+
+  const tags =
+    Array.isArray(metadata.tags) && metadata.tags.length
+      ? metadata.tags
+      : FALLBACK_TAGS;
+
+  return {
+    key: `${HASH_PREFIX}${digest}`,
+    message: `Recurring error observed: ${rawMessage}`,
+    suggestion,
+    tags,
+    context,
+  };
+}
+
+function extractMessage(error) {
+  if (!error) {
+    return "";
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  if (error instanceof Error) {
+    return error.message || String(error);
+  }
+
+  if (typeof error.message === "string") {
+    return error.message;
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+export default deriveNoteFromError;

--- a/src/memory/SessionNotesStore.ts
+++ b/src/memory/SessionNotesStore.ts
@@ -1,0 +1,274 @@
+import path from "path";
+import { randomBytes } from "crypto";
+import FileStorage from "../services/fileStorage";
+import EncryptionService from "../services/encryption";
+import { getEnv } from "../config";
+
+export interface SessionNoteRecord {
+  id: string;
+  key: string;
+  message: string;
+  suggestion?: string;
+  tags?: string[];
+  occurrences: number;
+  firstSeen: number;
+  lastSeen: number;
+  lastContext?: Record<string, unknown>;
+}
+
+interface StoredNotes {
+  version: number;
+  notes: SessionNoteRecord[];
+}
+
+const DEFAULT_MAX_NOTES = 50;
+export const SESSION_NOTES_CURRENT_VERSION = 1;
+
+let cachedEphemeralKey: string | null = null;
+let hasWarnedMissingKey = false;
+
+function normalizeKeyLength(key: string) {
+  return key.padEnd(32, "0").slice(0, 32);
+}
+
+function resolveEncryptionKey() {
+  const envKey =
+    getEnv("SESSION_NOTES_ENCRYPTION_KEY") || getEnv("MEMORY_ENCRYPTION_KEY");
+
+  if (!envKey) {
+    if (process.env.NODE_ENV === "production") {
+      throw new Error(
+        "[SessionNotes] SESSION_NOTES_ENCRYPTION_KEY (or MEMORY_ENCRYPTION_KEY) is required in production.",
+      );
+    }
+
+    const shouldWarn = process.env.NODE_ENV !== "test" && !hasWarnedMissingKey;
+    if (shouldWarn) {
+      console.warn(
+        "[SessionNotes] Missing encryption key; falling back to ephemeral development key.",
+      );
+      hasWarnedMissingKey = true;
+    }
+
+    if (!cachedEphemeralKey) {
+      cachedEphemeralKey = randomBytes(16).toString("hex");
+    }
+
+    return normalizeKeyLength(cachedEphemeralKey);
+  }
+
+  hasWarnedMissingKey = false;
+  cachedEphemeralKey = null;
+  return normalizeKeyLength(envKey);
+}
+
+export interface SessionNoteInput {
+  key: string;
+  message: string;
+  suggestion?: string;
+  tags?: string[];
+  context?: Record<string, unknown>;
+  timestamp?: number;
+}
+
+export interface GetNotesOptions {
+  limit?: number;
+  minOccurrences?: number;
+}
+
+export default class SessionNotesStore {
+  private storage: FileStorage;
+  private crypto: EncryptionService;
+  private maxNotes: number;
+  private data: StoredNotes;
+  private loaded: boolean;
+
+  constructor({
+    filePath = path.join(process.cwd(), "session_notes.dat"),
+    maxNotes = DEFAULT_MAX_NOTES,
+  }: {
+    filePath?: string;
+    maxNotes?: number;
+  } = {}) {
+    this.storage = new FileStorage(filePath);
+    this.crypto = new EncryptionService(
+      Buffer.from(resolveEncryptionKey(), "utf8"),
+    );
+    this.maxNotes = maxNotes;
+    this.data = { version: SESSION_NOTES_CURRENT_VERSION, notes: [] };
+    this.loaded = false;
+  }
+
+  async load() {
+    if (this.loaded) {
+      return;
+    }
+
+    const raw = await this.storage.loadRaw();
+    if (raw) {
+      try {
+        const json = this.crypto.decrypt(raw);
+        const parsed = JSON.parse(json) as StoredNotes;
+        this.data = this.#normalise(parsed);
+      } catch (error) {
+        console.warn(
+          "[SessionNotes] Failed to load existing notes, resetting store.",
+          error,
+        );
+        this.data = { version: SESSION_NOTES_CURRENT_VERSION, notes: [] };
+        await this.#save();
+      }
+    } else {
+      await this.#save();
+    }
+
+    this.loaded = true;
+  }
+
+  async getTopNotes({ limit = 3, minOccurrences = 1 }: GetNotesOptions = {}) {
+    await this.load();
+    const filtered = this.data.notes.filter(
+      (note) => note.occurrences >= minOccurrences,
+    );
+
+    const sorted = [...filtered].sort((a, b) => {
+      if (a.occurrences !== b.occurrences) {
+        return b.occurrences - a.occurrences;
+      }
+      return b.lastSeen - a.lastSeen;
+    });
+
+    return sorted.slice(0, limit).map((note) => ({
+      ...note,
+      tags: note.tags ? [...note.tags] : undefined,
+      lastContext: note.lastContext ? { ...note.lastContext } : undefined,
+    }));
+  }
+
+  async record(input: SessionNoteInput) {
+    if (!input?.key || !input.message) {
+      return;
+    }
+
+    await this.load();
+    const now =
+      typeof input.timestamp === "number" && !Number.isNaN(input.timestamp)
+        ? input.timestamp
+        : Date.now();
+
+    const existing = this.data.notes.find((note) => note.key === input.key);
+
+    if (existing) {
+      existing.occurrences += 1;
+      existing.lastSeen = now;
+      existing.message = input.message || existing.message;
+      if (input.suggestion) {
+        existing.suggestion = input.suggestion;
+      }
+      if (input.tags?.length) {
+        const merged = new Set([...(existing.tags || []), ...input.tags]);
+        existing.tags = Array.from(merged);
+      }
+      if (input.context) {
+        existing.lastContext = { ...input.context };
+      }
+    } else {
+      const record: SessionNoteRecord = {
+        id: randomBytes(8).toString("hex"),
+        key: input.key,
+        message: input.message,
+        suggestion: input.suggestion,
+        tags: input.tags ? [...input.tags] : undefined,
+        occurrences: 1,
+        firstSeen: now,
+        lastSeen: now,
+        lastContext: input.context ? { ...input.context } : undefined,
+      };
+      this.data.notes.push(record);
+    }
+
+    this.#trim();
+    await this.#save();
+  }
+
+  async clear() {
+    await this.load();
+    this.data.notes = [];
+    await this.#save();
+  }
+
+  #normalise(data: StoredNotes | null | undefined): StoredNotes {
+    if (!data || typeof data !== "object") {
+      return { version: SESSION_NOTES_CURRENT_VERSION, notes: [] };
+    }
+
+    const version =
+      typeof data.version === "number"
+        ? data.version
+        : SESSION_NOTES_CURRENT_VERSION;
+
+    const notes = Array.isArray(data.notes)
+      ? data.notes
+          .filter((note) => note && typeof note === "object")
+          .map((note) => ({
+            id: String(
+              (note as SessionNoteRecord).id || randomBytes(8).toString("hex"),
+            ),
+            key: String((note as SessionNoteRecord).key || ""),
+            message: String((note as SessionNoteRecord).message || ""),
+            suggestion:
+              typeof (note as SessionNoteRecord).suggestion === "string"
+                ? (note as SessionNoteRecord).suggestion
+                : undefined,
+            tags: Array.isArray((note as SessionNoteRecord).tags)
+              ? ((note as SessionNoteRecord).tags as string[]).map((tag) =>
+                  String(tag),
+                )
+              : undefined,
+            occurrences:
+              typeof (note as SessionNoteRecord).occurrences === "number"
+                ? Math.max(
+                    1,
+                    Math.floor((note as SessionNoteRecord).occurrences),
+                  )
+                : 1,
+            firstSeen:
+              typeof (note as SessionNoteRecord).firstSeen === "number"
+                ? (note as SessionNoteRecord).firstSeen
+                : Date.now(),
+            lastSeen:
+              typeof (note as SessionNoteRecord).lastSeen === "number"
+                ? (note as SessionNoteRecord).lastSeen
+                : Date.now(),
+            lastContext:
+              (note as SessionNoteRecord).lastContext &&
+              typeof (note as SessionNoteRecord).lastContext === "object"
+                ? { ...(note as SessionNoteRecord).lastContext }
+                : undefined,
+          }))
+      : [];
+
+    return { version, notes };
+  }
+
+  #trim() {
+    this.data.notes.sort((a, b) => {
+      if (a.occurrences !== b.occurrences) {
+        return b.occurrences - a.occurrences;
+      }
+      return b.lastSeen - a.lastSeen;
+    });
+
+    if (this.data.notes.length <= this.maxNotes) {
+      return;
+    }
+
+    this.data.notes = this.data.notes.slice(0, this.maxNotes);
+  }
+
+  async #save() {
+    const json = JSON.stringify(this.data);
+    const encrypted = this.crypto.encrypt(json);
+    await this.storage.saveRaw(encrypted);
+  }
+}


### PR DESCRIPTION
## Summary
- add an encrypted session notes store with CLI overflow heuristics and ignore the generated datastore
- surface recurring session notes in the orchestrator context and persist new failures when runs abort
- cover the note workflow with unit tests and document the new memory guidance

## Testing
- npm test
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68ce183644248333b1122698497f46c5