### PR TITLE
Fix RCTDeprecation module map drift in Pod build settings

### DIFF
--- a/.github/workflows/ios-unsigned-archive-unsigned-ipa.yml
+++ b/.github/workflows/ios-unsigned-archive-unsigned-ipa.yml
@@ -58,6 +58,12 @@ jobs:
           pod repo update
           pod install --repo-update
 
+      - name: Install xcresultparser
+        run: |
+          set -euo pipefail
+          brew tap a7ex/homebrew-formulae
+          brew install xcresultparser
+
       - name: Verify RN/Hermes versions
         run: python3 scripts/verify-ios-rn-versions.py
 
@@ -100,6 +106,20 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             clean archive | xcpretty && exit ${PIPESTATUS[0]}
 
+      - name: Summarize xcresult bundle
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          mkdir -p build
+          if [ -d "${RESULT_BUNDLE_DEV}" ]; then
+            if ! xcresultparser -o md "${RESULT_BUNDLE_DEV}" > build/ResultBundle_device.md; then
+              echo "::warning title=xcresultparser failed::Unable to summarize ${RESULT_BUNDLE_DEV}."
+              rm -f build/ResultBundle_device.md || true
+            fi
+          else
+            echo "::warning title=xcresult missing::${RESULT_BUNDLE_DEV} not found; skipping summary."
+          fi
+
       - name: Package Unsigned IPA (zip Payload)
         run: |
           APP_PATH="$(/usr/bin/find "${DERIVED_DATA}/Build/Products/Release-iphoneos" -maxdepth 1 -name '*.app' -print -quit)"
@@ -122,6 +142,7 @@ jobs:
             ${{ env.ARCHIVE_PATH }}
             ${{ env.IPA_OUT }}
             ${{ env.RESULT_BUNDLE_DEV }}
+            build/ResultBundle_device.md
             build/xcodebuild-list.txt
             build/build-settings.txt
           if-no-files-found: error

--- a/.github/workflows/ios-unsigned-device.yml
+++ b/.github/workflows/ios-unsigned-device.yml
@@ -75,6 +75,12 @@ jobs:
             brew install xcodegen
           fi
 
+      - name: Install xcresultparser
+        run: |
+          set -euo pipefail
+          brew tap a7ex/homebrew-formulae
+          brew install xcresultparser
+
       - name: Generate Xcode project (XcodeGen)
         working-directory: ios
         run: xcodegen generate
@@ -541,6 +547,27 @@ jobs:
             exit 65
           fi
 
+      - name: Summarize xcresult bundles
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          mkdir -p build
+          summarize() {
+            local label="$1"
+            local bundle="$2"
+            local output="$3"
+            if [ -d "$bundle" ]; then
+              if ! xcresultparser -o md "$bundle" > "$output"; then
+                echo "::warning title=xcresultparser failed::Unable to summarize ${label} xcresult at ${bundle}."
+                rm -f "$output" || true
+              fi
+            else
+              echo "::warning title=xcresult missing::${label} xcresult bundle not found at ${bundle}."
+            fi
+          }
+          summarize "resolve" "${DERIVED_DATA}/ResultBundle_resolve.xcresult" build/ResultBundle_resolve.md
+          summarize "archive" "${DERIVED_DATA}/ResultBundle_archive.xcresult" build/ResultBundle_archive.md
+
       - name: Package unsigned IPA from archive (robust)
         if: ${{ steps.sdk.outputs.present == 'true' }}
         run: |
@@ -559,6 +586,8 @@ jobs:
             ${{ env.DERIVED_DATA }}/ResultBundle_archive.xcresult
             build/ResultBundle_archive.json
             build/ResultBundle_resolve.json
+            build/ResultBundle_archive.md
+            build/ResultBundle_resolve.md
             build/diagnostics
           if-no-files-found: warn
           compression-level: 6

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -65,6 +65,12 @@ jobs:
             brew install xcodegen
           fi
 
+      - name: Install xcresultparser
+        run: |
+          set -euo pipefail
+          brew tap a7ex/homebrew-formulae
+          brew install xcresultparser
+
       - name: Generate Xcode project
         working-directory: ios
         run: xcodegen generate
@@ -123,6 +129,20 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             clean build | xcpretty && exit ${PIPESTATUS[0]}
 
+      - name: Summarize simulator xcresult
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          mkdir -p build
+          if [ -d "${RESULT_BUNDLE_SIM}" ]; then
+            if ! xcresultparser -o md "${RESULT_BUNDLE_SIM}" > build/ResultBundle_sim.md; then
+              echo "::warning title=xcresultparser failed::Unable to summarize ${RESULT_BUNDLE_SIM}."
+              rm -f build/ResultBundle_sim.md || true
+            fi
+          else
+            echo "::warning title=xcresult missing::${RESULT_BUNDLE_SIM} not found; skipping summary."
+          fi
+
       - name: Remove temporary module cache
         if: env.MODULE_CACHE_DIR != ''
         run: |
@@ -139,6 +159,7 @@ jobs:
           path: |
             build/DerivedData/Build/Products/Release-iphonesimulator/*.app
             ${{ env.RESULT_BUNDLE_SIM }}
+            build/ResultBundle_sim.md
           if-no-files-found: warn
 
   device-archive:
@@ -183,6 +204,12 @@ jobs:
           if ! command -v xcodegen >/dev/null 2>&1; then
             brew install xcodegen
           fi
+
+      - name: Install xcresultparser
+        run: |
+          set -euo pipefail
+          brew tap a7ex/homebrew-formulae
+          brew install xcresultparser
 
       - name: Generate Xcode project
         working-directory: ios
@@ -241,6 +268,20 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             clean build archive | xcpretty && exit ${PIPESTATUS[0]}
 
+      - name: Summarize device xcresult
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          mkdir -p build
+          if [ -d "${RESULT_BUNDLE_DEV}" ]; then
+            if ! xcresultparser -o md "${RESULT_BUNDLE_DEV}" > build/ResultBundle_device.md; then
+              echo "::warning title=xcresultparser failed::Unable to summarize ${RESULT_BUNDLE_DEV}."
+              rm -f build/ResultBundle_device.md || true
+            fi
+          else
+            echo "::warning title=xcresult missing::${RESULT_BUNDLE_DEV} not found; skipping summary."
+          fi
+
       - name: Remove temporary module cache
         if: env.MODULE_CACHE_DIR != ''
         run: |
@@ -258,4 +299,5 @@ jobs:
             build/DerivedData/Build/Products/Release-iphoneos/*.app
             build/DerivedData/Build/Intermediates.noindex/ArchiveIntermediates/${{ env.SCHEME }}/BuildProductsPath/Release-iphoneos/*.app
             ${{ env.RESULT_BUNDLE_DEV }}
+            build/ResultBundle_device.md
           if-no-files-found: warn

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -212,101 +212,6 @@ def ensure_swift_module_flags(swift_flags, module_map_flags, forbidden_flags: []
   [materialize_tokens(tokens, preference), changed]
 end
 
-def dedupe_existing_directories(paths)
-  seen = {}
-  paths.each_with_object([]) do |raw, acc|
-    next if raw.nil?
-
-    trimmed = raw.to_s.strip
-    next if trimmed.empty?
-
-    expanded = File.expand_path(trimmed)
-    next unless Dir.exist?(expanded)
-    next if seen[expanded]
-
-    seen[expanded] = true
-    acc << expanded
-  end
-end
-
-def purge_legacy_rctdeprecation_artifacts(project_dir, module_name:, legacy_module_map_name:, app_target:)
-  project_dir = File.expand_path(project_dir)
-  project_root = File.expand_path('..', project_dir)
-  home_dir = if Dir.respond_to?(:home)
-               Dir.home
-             else
-               ENV['HOME']
-             end
-
-  candidate_roots = [
-    ENV['DERIVED_DATA_DIR'],
-    ENV['OBJROOT'],
-    ENV['SYMROOT'],
-    File.join(project_root, 'build', 'DerivedData')
-  ]
-  candidate_roots << File.join(home_dir, 'Library', 'Developer', 'Xcode', 'DerivedData') if home_dir && !home_dir.empty?
-
-  roots = dedupe_existing_directories(candidate_roots)
-  return if roots.empty?
-
-  roots.each do |root|
-    begin
-      bridging_patterns = [
-        File.join(root, 'PrecompiledHeaders', "#{app_target}-Bridging-Header-swift*.pch"),
-        File.join(root, 'Build', 'Intermediates.noindex', 'PrecompiledHeaders', "#{app_target}-Bridging-Header-swift*.pch"),
-        File.join(root, '*', 'Build', 'Intermediates.noindex', 'PrecompiledHeaders', "#{app_target}-Bridging-Header-swift*.pch")
-      ]
-
-      bridging_patterns.each do |pattern|
-        Dir.glob(pattern).each do |pch_path|
-          next unless File.file?(pch_path)
-
-          Pod::UI.puts "[Podfile] Removing cached bridging header PCH at #{pch_path}"
-          FileUtils.rm_f(pch_path)
-        rescue => e
-          Pod::UI.warn("[Podfile] Failed to remove bridging header PCH at #{pch_path}: #{e.message}")
-        end
-      end
-
-      module_cache_patterns = [
-        File.join(root, 'ModuleCache.noindex', "*#{module_name}*"),
-        File.join(root, '*', 'ModuleCache.noindex', "*#{module_name}*"),
-        File.join(root, '*', 'Build', 'Intermediates.noindex', 'ModuleCache.noindex', "*#{module_name}*")
-      ]
-
-      module_cache_patterns.each do |pattern|
-        Dir.glob(pattern).each do |entry|
-          next unless File.exist?(entry)
-
-          Pod::UI.puts "[Podfile] Removing cached module cache entry #{entry}"
-          FileUtils.rm_rf(entry)
-        rescue => e
-          Pod::UI.warn("[Podfile] Failed to purge module cache entry #{entry}: #{e.message}")
-        end
-      end
-
-      legacy_patterns = [
-        File.join(root, legacy_module_map_name),
-        File.join(root, 'Build', '**', legacy_module_map_name),
-        File.join(root, 'SourcePackages', '**', legacy_module_map_name)
-      ]
-
-      legacy_patterns.each do |pattern|
-        Dir.glob(pattern).each do |legacy_path|
-          next unless File.exist?(legacy_path)
-
-          Pod::UI.puts "[Podfile] Removing cached legacy module map at #{legacy_path}"
-          FileUtils.rm_f(legacy_path)
-        rescue => e
-          Pod::UI.warn("[Podfile] Failed to delete cached legacy module map #{legacy_path}: #{e.message}")
-        end
-      end
-    rescue Errno::EACCES => e
-      Pod::UI.warn("[Podfile] Skipped derived data root #{root} due to #{e.message}")
-    end
-  end
-end
-
 install! 'cocoapods', :disable_input_output_paths => true
 
 # --- Auto-detect the .xcodeproj near this Podfile ---
@@ -559,12 +464,33 @@ post_install do |installer|
     FileUtils.rm_f(stray_module_map)
   end
 
-  purge_legacy_rctdeprecation_artifacts(
-    __dir__,
-    :module_name => 'RCTDeprecation',
-    :legacy_module_map_name => 'RCTDeprecation.modulemap',
-    :app_target => 'monGARS'
-  )
+  purge_script = File.join(__dir__, 'scripts', 'purge-rctdeprecation-caches.sh')
+  if File.exist?(purge_script)
+    env = {
+      'PROJECT_DIR' => __dir__,
+      'APP_TARGET' => 'monGARS',
+      'MODULE_NAME' => 'RCTDeprecation',
+      'LEGACY_MODULE_MAP_NAME' => 'RCTDeprecation.modulemap'
+    }
+
+    stdout_str, stderr_str, status = Open3.capture3(env, 'bash', purge_script)
+
+    stdout_str.each_line do |line|
+      line = line.strip
+      Pod::UI.puts("[Podfile] #{line}") unless line.empty?
+    end
+
+    stderr_str.each_line do |line|
+      line = line.strip
+      Pod::UI.warn("[Podfile] STDERR: #{line}") unless line.empty?
+    end
+
+    unless status.success?
+      Pod::UI.warn('[Podfile] Failed to purge legacy RCTDeprecation caches; manual cleanup may be required.')
+    end
+  else
+    Pod::UI.warn('[Podfile] Missing ios/scripts/purge-rctdeprecation-caches.sh; derived data may still reference legacy module maps.')
+  end
 
   mlx_patch_script = File.join(__dir__, 'scripts', 'patch-mlx-metal-cxx17.sh')
   if File.exist?(mlx_patch_script)

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -212,6 +212,101 @@ def ensure_swift_module_flags(swift_flags, module_map_flags, forbidden_flags: []
   [materialize_tokens(tokens, preference), changed]
 end
 
+def dedupe_existing_directories(paths)
+  seen = {}
+  paths.each_with_object([]) do |raw, acc|
+    next if raw.nil?
+
+    trimmed = raw.to_s.strip
+    next if trimmed.empty?
+
+    expanded = File.expand_path(trimmed)
+    next unless Dir.exist?(expanded)
+    next if seen[expanded]
+
+    seen[expanded] = true
+    acc << expanded
+  end
+end
+
+def purge_legacy_rctdeprecation_artifacts(project_dir, module_name:, legacy_module_map_name:, app_target:)
+  project_dir = File.expand_path(project_dir)
+  project_root = File.expand_path('..', project_dir)
+  home_dir = if Dir.respond_to?(:home)
+               Dir.home
+             else
+               ENV['HOME']
+             end
+
+  candidate_roots = [
+    ENV['DERIVED_DATA_DIR'],
+    ENV['OBJROOT'],
+    ENV['SYMROOT'],
+    File.join(project_root, 'build', 'DerivedData')
+  ]
+  candidate_roots << File.join(home_dir, 'Library', 'Developer', 'Xcode', 'DerivedData') if home_dir && !home_dir.empty?
+
+  roots = dedupe_existing_directories(candidate_roots)
+  return if roots.empty?
+
+  roots.each do |root|
+    begin
+      bridging_patterns = [
+        File.join(root, 'PrecompiledHeaders', "#{app_target}-Bridging-Header-swift*.pch"),
+        File.join(root, 'Build', 'Intermediates.noindex', 'PrecompiledHeaders', "#{app_target}-Bridging-Header-swift*.pch"),
+        File.join(root, '*', 'Build', 'Intermediates.noindex', 'PrecompiledHeaders', "#{app_target}-Bridging-Header-swift*.pch")
+      ]
+
+      bridging_patterns.each do |pattern|
+        Dir.glob(pattern).each do |pch_path|
+          next unless File.file?(pch_path)
+
+          Pod::UI.puts "[Podfile] Removing cached bridging header PCH at #{pch_path}"
+          FileUtils.rm_f(pch_path)
+        rescue => e
+          Pod::UI.warn("[Podfile] Failed to remove bridging header PCH at #{pch_path}: #{e.message}")
+        end
+      end
+
+      module_cache_patterns = [
+        File.join(root, 'ModuleCache.noindex', "*#{module_name}*"),
+        File.join(root, '*', 'ModuleCache.noindex', "*#{module_name}*"),
+        File.join(root, '*', 'Build', 'Intermediates.noindex', 'ModuleCache.noindex', "*#{module_name}*")
+      ]
+
+      module_cache_patterns.each do |pattern|
+        Dir.glob(pattern).each do |entry|
+          next unless File.exist?(entry)
+
+          Pod::UI.puts "[Podfile] Removing cached module cache entry #{entry}"
+          FileUtils.rm_rf(entry)
+        rescue => e
+          Pod::UI.warn("[Podfile] Failed to purge module cache entry #{entry}: #{e.message}")
+        end
+      end
+
+      legacy_patterns = [
+        File.join(root, legacy_module_map_name),
+        File.join(root, 'Build', '**', legacy_module_map_name),
+        File.join(root, 'SourcePackages', '**', legacy_module_map_name)
+      ]
+
+      legacy_patterns.each do |pattern|
+        Dir.glob(pattern).each do |legacy_path|
+          next unless File.exist?(legacy_path)
+
+          Pod::UI.puts "[Podfile] Removing cached legacy module map at #{legacy_path}"
+          FileUtils.rm_f(legacy_path)
+        rescue => e
+          Pod::UI.warn("[Podfile] Failed to delete cached legacy module map #{legacy_path}: #{e.message}")
+        end
+      end
+    rescue Errno::EACCES => e
+      Pod::UI.warn("[Podfile] Skipped derived data root #{root} due to #{e.message}")
+    end
+  end
+end
+
 install! 'cocoapods', :disable_input_output_paths => true
 
 # --- Auto-detect the .xcodeproj near this Podfile ---
@@ -463,6 +558,13 @@ post_install do |installer|
     Pod::UI.puts "[Podfile] Removing stray legacy module map at #{stray_module_map}"
     FileUtils.rm_f(stray_module_map)
   end
+
+  purge_legacy_rctdeprecation_artifacts(
+    __dir__,
+    :module_name => 'RCTDeprecation',
+    :legacy_module_map_name => 'RCTDeprecation.modulemap',
+    :app_target => 'monGARS'
+  )
 
   mlx_patch_script = File.join(__dir__, 'scripts', 'patch-mlx-metal-cxx17.sh')
   if File.exist?(mlx_patch_script)

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -14,36 +14,68 @@ def env_flag_enabled?(name, default:)
   default
 end
 
-def append_flag(value, flag)
+def normalize_tokens(value)
   case value
   when nil
-    ['$(inherited)', flag]
+    [[], :array]
   when Array
-    value.include?(flag) ? value : (value + [flag])
+    [value.compact.dup, :array]
   else
-    current = value.to_s
-    current.include?(flag) ? current : "#{current} #{flag}"
+    [value.to_s.split(/\s+/), :string]
   end
+end
+
+def materialize_tokens(tokens, preference)
+  filtered = tokens.compact
+  return nil if filtered.empty?
+
+  preference == :array ? filtered : filtered.join(' ')
+end
+
+def append_flag(value, flag)
+  return ['$(inherited)', flag] if value.nil?
+
+  tokens, preference = normalize_tokens(value)
+  return materialize_tokens(tokens, preference) if tokens.include?(flag)
+
+  tokens << flag
+  materialize_tokens(tokens, preference)
 end
 
 def append_flags(value, flags)
   flags.reduce(value) { |memo, flag| append_flag(memo, flag) }
 end
 
-def ensure_swift_module_flags(swift_flags, module_map_flags)
-  tokens =
-    case swift_flags
-    when nil
-      []
-    when Array
-      swift_flags.dup
-    else
-      swift_flags.to_s.split(/\s+/)
-    end
-
-  tokens.unshift('$(inherited)') unless tokens.include?('$(inherited)')
-
+def remove_flag(value, flag)
+  tokens, preference = normalize_tokens(value)
   original = tokens.dup
+  tokens.reject! { |token| token == flag }
+  [materialize_tokens(tokens, preference), tokens != original]
+end
+
+def ensure_swift_module_flags(swift_flags, module_map_flags, forbidden_flags: [])
+  tokens, preference = normalize_tokens(swift_flags)
+  changed = false
+
+  unless tokens.include?('$(inherited)')
+    tokens.unshift('$(inherited)')
+    changed = true
+  end
+
+  forbidden_flags.each do |flag|
+    before = tokens.length
+    tokens.reject! { |token| token == flag }
+    changed ||= tokens.length != before
+
+    loop do
+      entry = tokens.each_cons(2).with_index.find { |(first, second), _i| first == '-Xcc' && second == flag }
+      break unless entry
+
+      _, removal_index = entry
+      tokens.slice!(removal_index, 2)
+      changed = true
+    end
+  end
 
   module_map_flags.each do |flag|
     has_pair = tokens.each_cons(2).any? { |first, second| first == '-Xcc' && second == flag }
@@ -51,9 +83,10 @@ def ensure_swift_module_flags(swift_flags, module_map_flags)
 
     tokens << '-Xcc'
     tokens << flag
+    changed = true
   end
 
-  [tokens, tokens != original]
+  [materialize_tokens(tokens, preference), changed]
 end
 
 install! 'cocoapods', :disable_input_output_paths => true
@@ -175,6 +208,7 @@ post_install do |installer|
   module_map_path = '$(PODS_ROOT)/Headers/Public/RCTDeprecation/module.modulemap'
   legacy_module_map_path = '$(PODS_ROOT)/Headers/Public/RCTDeprecation/RCTDeprecation.modulemap'
   module_map_flag = "-fmodule-map-file=#{module_map_path}"
+  legacy_module_map_flag = "-fmodule-map-file=#{legacy_module_map_path}"
   # Keep the legacy module map on disk for older toolchains that still probe for
   # `RCTDeprecation.modulemap`, but avoid feeding it directly to clang.
   # Xcode 16's clang treats duplicate `-fmodule-map-file` entries defining the
@@ -231,19 +265,41 @@ post_install do |installer|
         end
       end
 
-      new_c_flags = append_flags(config.build_settings['OTHER_CFLAGS'], module_map_flags)
-      if new_c_flags != config.build_settings['OTHER_CFLAGS']
+      existing_c_flags = config.build_settings['OTHER_CFLAGS']
+      pruned_c_flags, pruned = remove_flag(existing_c_flags, legacy_module_map_flag)
+      if pruned
+        config.build_settings['OTHER_CFLAGS'] = pruned_c_flags
+        existing_c_flags = pruned_c_flags
+        updated = true
+      end
+
+      new_c_flags = append_flags(existing_c_flags, module_map_flags)
+      if new_c_flags != existing_c_flags
         config.build_settings['OTHER_CFLAGS'] = new_c_flags
+        existing_c_flags = new_c_flags
         updated = true
       end
 
-      new_cpp_flags = append_flags(config.build_settings['OTHER_CPLUSPLUSFLAGS'], module_map_flags)
-      if new_cpp_flags != config.build_settings['OTHER_CPLUSPLUSFLAGS']
+      existing_cpp_flags = config.build_settings['OTHER_CPLUSPLUSFLAGS']
+      pruned_cpp_flags, pruned_cpp = remove_flag(existing_cpp_flags, legacy_module_map_flag)
+      if pruned_cpp
+        config.build_settings['OTHER_CPLUSPLUSFLAGS'] = pruned_cpp_flags
+        existing_cpp_flags = pruned_cpp_flags
+        updated = true
+      end
+
+      new_cpp_flags = append_flags(existing_cpp_flags, module_map_flags)
+      if new_cpp_flags != existing_cpp_flags
         config.build_settings['OTHER_CPLUSPLUSFLAGS'] = new_cpp_flags
+        existing_cpp_flags = new_cpp_flags
         updated = true
       end
 
-      swift_tokens, swift_changed = ensure_swift_module_flags(config.build_settings['OTHER_SWIFT_FLAGS'], module_map_flags)
+      swift_tokens, swift_changed = ensure_swift_module_flags(
+        config.build_settings['OTHER_SWIFT_FLAGS'],
+        module_map_flags,
+        :forbidden_flags => [legacy_module_map_flag]
+      )
       if swift_changed
         config.build_settings['OTHER_SWIFT_FLAGS'] = swift_tokens
         updated = true
@@ -301,19 +357,41 @@ post_install do |installer|
           end
         end
 
-        updated_c_flags = append_flags(config.build_settings['OTHER_CFLAGS'], module_map_flags)
-        if updated_c_flags != config.build_settings['OTHER_CFLAGS']
+        existing_c_flags = config.build_settings['OTHER_CFLAGS']
+        pruned_c_flags, pruned = remove_flag(existing_c_flags, legacy_module_map_flag)
+        if pruned
+          config.build_settings['OTHER_CFLAGS'] = pruned_c_flags
+          existing_c_flags = pruned_c_flags
+          project_modified = true
+        end
+
+        updated_c_flags = append_flags(existing_c_flags, module_map_flags)
+        if updated_c_flags != existing_c_flags
           config.build_settings['OTHER_CFLAGS'] = updated_c_flags
+          existing_c_flags = updated_c_flags
           project_modified = true
         end
 
-        updated_cpp_flags = append_flags(config.build_settings['OTHER_CPLUSPLUSFLAGS'], module_map_flags)
-        if updated_cpp_flags != config.build_settings['OTHER_CPLUSPLUSFLAGS']
+        existing_cpp_flags = config.build_settings['OTHER_CPLUSPLUSFLAGS']
+        pruned_cpp_flags, pruned_cpp = remove_flag(existing_cpp_flags, legacy_module_map_flag)
+        if pruned_cpp
+          config.build_settings['OTHER_CPLUSPLUSFLAGS'] = pruned_cpp_flags
+          existing_cpp_flags = pruned_cpp_flags
+          project_modified = true
+        end
+
+        updated_cpp_flags = append_flags(existing_cpp_flags, module_map_flags)
+        if updated_cpp_flags != existing_cpp_flags
           config.build_settings['OTHER_CPLUSPLUSFLAGS'] = updated_cpp_flags
+          existing_cpp_flags = updated_cpp_flags
           project_modified = true
         end
 
-        swift_tokens, swift_changed = ensure_swift_module_flags(config.build_settings['OTHER_SWIFT_FLAGS'], module_map_flags)
+        swift_tokens, swift_changed = ensure_swift_module_flags(
+          config.build_settings['OTHER_SWIFT_FLAGS'],
+          module_map_flags,
+          :forbidden_flags => [legacy_module_map_flag]
+        )
         if swift_changed
           config.build_settings['OTHER_SWIFT_FLAGS'] = swift_tokens
           project_modified = true
@@ -322,6 +400,22 @@ post_install do |installer|
     end
 
     user_project.save if project_modified
+  end
+
+  support_files_root = File.join(__dir__, 'Pods', 'Target Support Files')
+  if Dir.exist?(support_files_root)
+    Dir.glob(File.join(support_files_root, '**', '*.xcconfig')).each do |xcconfig_path|
+      original = File.read(xcconfig_path)
+      replaced = original.gsub(legacy_module_map_flag, module_map_flag)
+      replaced = replaced.gsub(legacy_module_map_path, module_map_path)
+      replaced = replaced.gsub("\"#{legacy_module_map_flag}\"", "\"#{module_map_flag}\"")
+      replaced = replaced.gsub("\"#{legacy_module_map_path}\"", "\"#{module_map_path}\"")
+
+      next if replaced == original
+
+      Pod::UI.puts "[Podfile] Updated #{xcconfig_path} to prefer module.modulemap"
+      File.write(xcconfig_path, replaced)
+    end
   end
 
   # Try to apply RN Contacts orientation patch (if repo has the script)

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -27,7 +27,7 @@ end
 
 def materialize_tokens(tokens, preference)
   filtered = tokens.compact
-  return nil if filtered.empty?
+  return preference == :array ? [] : '' if filtered.empty?
 
   preference == :array ? filtered : filtered.join(' ')
 end
@@ -75,6 +75,36 @@ def ensure_swift_module_flags(swift_flags, module_map_flags, forbidden_flags: []
       tokens.slice!(removal_index, 2)
       changed = true
     end
+  end
+
+  original_tokens = tokens.dup
+  cleaned_tokens = []
+  index = 0
+  while index < tokens.length
+    token = tokens[index]
+
+    if token == '-Xcc'
+      next_token = tokens[index + 1]
+
+      if next_token.nil? || next_token == '-Xcc'
+        changed = true
+        index += 1
+        next
+      end
+
+      cleaned_tokens << token
+      cleaned_tokens << next_token
+      index += 2
+      next
+    end
+
+    cleaned_tokens << token
+    index += 1
+  end
+
+  if cleaned_tokens != original_tokens
+    tokens = cleaned_tokens
+    changed = true
   end
 
   module_map_flags.each do |flag|
@@ -209,6 +239,10 @@ post_install do |installer|
   legacy_module_map_path = '$(PODS_ROOT)/Headers/Public/RCTDeprecation/RCTDeprecation.modulemap'
   module_map_flag = "-fmodule-map-file=#{module_map_path}"
   legacy_module_map_flag = "-fmodule-map-file=#{legacy_module_map_path}"
+  legacy_module_map_flag_pattern = /(?<!\S)#{Regexp.escape(legacy_module_map_flag)}(?!\S)/
+  legacy_module_map_path_pattern = /(?<!\S)#{Regexp.escape(legacy_module_map_path)}(?!\S)/
+  legacy_module_map_flag_quoted_pattern = /"#{Regexp.escape(legacy_module_map_flag)}"/
+  legacy_module_map_path_quoted_pattern = /"#{Regexp.escape(legacy_module_map_path)}"/
   # Keep the legacy module map on disk for older toolchains that still probe for
   # `RCTDeprecation.modulemap`, but avoid feeding it directly to clang.
   # Xcode 16's clang treats duplicate `-fmodule-map-file` entries defining the
@@ -406,10 +440,10 @@ post_install do |installer|
   if Dir.exist?(support_files_root)
     Dir.glob(File.join(support_files_root, '**', '*.xcconfig')).each do |xcconfig_path|
       original = File.read(xcconfig_path)
-      replaced = original.gsub(legacy_module_map_flag, module_map_flag)
-      replaced = replaced.gsub(legacy_module_map_path, module_map_path)
-      replaced = replaced.gsub("\"#{legacy_module_map_flag}\"", "\"#{module_map_flag}\"")
-      replaced = replaced.gsub("\"#{legacy_module_map_path}\"", "\"#{module_map_path}\"")
+      replaced = original.gsub(legacy_module_map_flag_pattern, module_map_flag)
+      replaced = replaced.gsub(legacy_module_map_path_pattern, module_map_path)
+      replaced = replaced.gsub(legacy_module_map_flag_quoted_pattern, "\"#{module_map_flag}\"")
+      replaced = replaced.gsub(legacy_module_map_path_quoted_pattern, "\"#{module_map_path}\"")
 
       next if replaced == original
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -53,6 +53,99 @@ def remove_flag(value, flag)
   [materialize_tokens(tokens, preference), tokens != original]
 end
 
+def swift_flag_pair?(value, flag)
+  return false if flag.nil?
+
+  tokens, _ = normalize_tokens(value)
+  tokens.each_cons(2).any? { |first, second| first == '-Xcc' && second == flag }
+end
+
+def sanitize_module_map_settings(config, header_search_fix:, module_map_flags:, module_map_path:, legacy_module_map_flag:, force_tokens: false, enforce_module_map: false, enforce_defines_module: false)
+  updated = false
+  module_flag = module_map_flags.first
+
+  existing_c_flags = config.build_settings['OTHER_CFLAGS']
+  c_tokens, _ = normalize_tokens(existing_c_flags)
+  contains_legacy_c_flag = c_tokens.include?(legacy_module_map_flag)
+  contains_canonical_c_flag = module_flag ? c_tokens.include?(module_flag) : false
+
+  existing_cpp_flags = config.build_settings['OTHER_CPLUSPLUSFLAGS']
+  cpp_tokens, _ = normalize_tokens(existing_cpp_flags)
+  contains_legacy_cpp_flag = cpp_tokens.include?(legacy_module_map_flag)
+  contains_canonical_cpp_flag = module_flag ? cpp_tokens.include?(module_flag) : false
+
+  existing_swift_flags = config.build_settings['OTHER_SWIFT_FLAGS']
+  contains_legacy_swift = swift_flag_pair?(existing_swift_flags, legacy_module_map_flag)
+  contains_canonical_swift = swift_flag_pair?(existing_swift_flags, module_flag)
+
+  requires_tokens = force_tokens || contains_legacy_c_flag || contains_canonical_c_flag ||
+                    contains_legacy_cpp_flag || contains_canonical_cpp_flag ||
+                    contains_legacy_swift || contains_canonical_swift
+
+  if requires_tokens
+    existing_header_paths = config.build_settings['HEADER_SEARCH_PATHS']
+    desired_header_paths = append_flag(existing_header_paths, header_search_fix)
+    if desired_header_paths != existing_header_paths
+      config.build_settings['HEADER_SEARCH_PATHS'] = desired_header_paths
+      updated = true
+    end
+  end
+
+  if contains_legacy_c_flag
+    pruned_c_flags, _ = remove_flag(existing_c_flags, legacy_module_map_flag)
+    config.build_settings['OTHER_CFLAGS'] = pruned_c_flags
+    existing_c_flags = pruned_c_flags
+    updated = true
+  end
+
+  if requires_tokens
+    updated_c_flags = append_flags(existing_c_flags, module_map_flags)
+    if updated_c_flags != existing_c_flags
+      config.build_settings['OTHER_CFLAGS'] = updated_c_flags
+      updated = true
+    end
+  end
+
+  if contains_legacy_cpp_flag
+    pruned_cpp_flags, _ = remove_flag(existing_cpp_flags, legacy_module_map_flag)
+    config.build_settings['OTHER_CPLUSPLUSFLAGS'] = pruned_cpp_flags
+    existing_cpp_flags = pruned_cpp_flags
+    updated = true
+  end
+
+  if requires_tokens
+    updated_cpp_flags = append_flags(existing_cpp_flags, module_map_flags)
+    if updated_cpp_flags != existing_cpp_flags
+      config.build_settings['OTHER_CPLUSPLUSFLAGS'] = updated_cpp_flags
+      updated = true
+    end
+  end
+
+  if requires_tokens
+    swift_tokens, swift_changed = ensure_swift_module_flags(
+      existing_swift_flags,
+      module_map_flags,
+      :forbidden_flags => [legacy_module_map_flag]
+    )
+    if swift_changed
+      config.build_settings['OTHER_SWIFT_FLAGS'] = swift_tokens
+      updated = true
+    end
+  end
+
+  if enforce_module_map && config.build_settings['MODULEMAP_FILE'] != module_map_path
+    config.build_settings['MODULEMAP_FILE'] = module_map_path
+    updated = true
+  end
+
+  if enforce_defines_module && config.build_settings['DEFINES_MODULE'] != 'YES'
+    config.build_settings['DEFINES_MODULE'] = 'YES'
+    updated = true
+  end
+
+  updated
+end
+
 def ensure_swift_module_flags(swift_flags, module_map_flags, forbidden_flags: [])
   tokens, preference = normalize_tokens(swift_flags)
   changed = false
@@ -251,10 +344,13 @@ post_install do |installer|
   # build because the AST referenced a different module map path. Keeping only the
   # canonical file and updating build settings to point at it ensures every
   # invocation resolves the module identically.
-  module_map_flags = [module_map_flag]
+  module_map_flags = [module_map_flag].compact
   module_map_dir = File.join(installer.sandbox.root.to_s, 'Headers', 'Public', 'RCTDeprecation')
   module_map_disk = File.join(module_map_dir, 'module.modulemap')
   legacy_module_map_disk = File.join(module_map_dir, 'RCTDeprecation.modulemap')
+  target_support_dir = File.join(installer.sandbox.root.to_s, 'Target Support Files', 'RCTDeprecation')
+  target_support_module_map = File.join(target_support_dir, 'module.modulemap')
+  legacy_target_support_module_map = File.join(target_support_dir, 'RCTDeprecation.modulemap')
   module_map_template = File.join(__dir__, 'Config', 'RCTDeprecation.modulemap')
   raise "Missing #{module_map_template}; ensure it is checked in" unless File.exist?(module_map_template)
   desired_module_map = File.read(module_map_template)
@@ -281,77 +377,21 @@ post_install do |installer|
   end
 
   installer.pods_project.targets.each do |target|
-    next unless target.name == 'RCTDeprecation'
+    target_name = target.respond_to?(:name) ? target.name.to_s : ''
+    force_tokens = target_name == 'RCTDeprecation' || target_name.start_with?('Pods-')
+    enforce_module_identity = target_name == 'RCTDeprecation'
 
     target.build_configurations.each do |config|
-      updated = false
-
-      header_paths = config.build_settings['HEADER_SEARCH_PATHS']
-      if header_paths.nil?
-        config.build_settings['HEADER_SEARCH_PATHS'] = ['$(inherited)', header_search_fix]
-        updated = true
-      elsif header_paths.is_a?(Array)
-        unless header_paths.include?(header_search_fix)
-          config.build_settings['HEADER_SEARCH_PATHS'] = header_paths + [header_search_fix]
-          updated = true
-        end
-      else
-        value = header_paths.to_s
-        unless value.include?(header_search_fix)
-          config.build_settings['HEADER_SEARCH_PATHS'] = "#{value} #{header_search_fix}"
-          updated = true
-        end
-      end
-
-      existing_c_flags = config.build_settings['OTHER_CFLAGS']
-      pruned_c_flags, pruned = remove_flag(existing_c_flags, legacy_module_map_flag)
-      if pruned
-        config.build_settings['OTHER_CFLAGS'] = pruned_c_flags
-        existing_c_flags = pruned_c_flags
-        updated = true
-      end
-
-      new_c_flags = append_flags(existing_c_flags, module_map_flags)
-      if new_c_flags != existing_c_flags
-        config.build_settings['OTHER_CFLAGS'] = new_c_flags
-        existing_c_flags = new_c_flags
-        updated = true
-      end
-
-      existing_cpp_flags = config.build_settings['OTHER_CPLUSPLUSFLAGS']
-      pruned_cpp_flags, pruned_cpp = remove_flag(existing_cpp_flags, legacy_module_map_flag)
-      if pruned_cpp
-        config.build_settings['OTHER_CPLUSPLUSFLAGS'] = pruned_cpp_flags
-        existing_cpp_flags = pruned_cpp_flags
-        updated = true
-      end
-
-      new_cpp_flags = append_flags(existing_cpp_flags, module_map_flags)
-      if new_cpp_flags != existing_cpp_flags
-        config.build_settings['OTHER_CPLUSPLUSFLAGS'] = new_cpp_flags
-        existing_cpp_flags = new_cpp_flags
-        updated = true
-      end
-
-      swift_tokens, swift_changed = ensure_swift_module_flags(
-        config.build_settings['OTHER_SWIFT_FLAGS'],
-        module_map_flags,
-        :forbidden_flags => [legacy_module_map_flag]
+      updated = sanitize_module_map_settings(
+        config,
+        :header_search_fix => header_search_fix,
+        :module_map_flags => module_map_flags,
+        :module_map_path => module_map_path,
+        :legacy_module_map_flag => legacy_module_map_flag,
+        :force_tokens => force_tokens,
+        :enforce_module_map => enforce_module_identity,
+        :enforce_defines_module => enforce_module_identity
       )
-      if swift_changed
-        config.build_settings['OTHER_SWIFT_FLAGS'] = swift_tokens
-        updated = true
-      end
-
-      if config.build_settings['MODULEMAP_FILE'] != module_map_path
-        config.build_settings['MODULEMAP_FILE'] = module_map_path
-        updated = true
-      end
-
-      if config.build_settings['DEFINES_MODULE'] != 'YES'
-        config.build_settings['DEFINES_MODULE'] = 'YES'
-        updated = true
-      end
 
       if updated
         Pod::UI.puts "[Podfile] Updated build settings for #{target.name} (#{config.name})"
@@ -373,67 +413,17 @@ post_install do |installer|
       target.build_configurations.each do |config|
         config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++20'
         config.build_settings['CLANG_CXX_LIBRARY'] = 'libc++'
-        existing = config.build_settings['HEADER_SEARCH_PATHS']
 
-        if existing.nil?
-          config.build_settings['HEADER_SEARCH_PATHS'] = ['$(inherited)', header_search_fix]
-          project_modified = true
-          next
-        end
-
-        if existing.is_a?(Array)
-          unless existing.include?(header_search_fix)
-            existing << header_search_fix
-            config.build_settings['HEADER_SEARCH_PATHS'] = existing
-            project_modified = true
-          end
-        else
-          value = existing.to_s
-          unless value.include?(header_search_fix)
-            config.build_settings['HEADER_SEARCH_PATHS'] = "#{value} #{header_search_fix}"
-            project_modified = true
-          end
-        end
-
-        existing_c_flags = config.build_settings['OTHER_CFLAGS']
-        pruned_c_flags, pruned = remove_flag(existing_c_flags, legacy_module_map_flag)
-        if pruned
-          config.build_settings['OTHER_CFLAGS'] = pruned_c_flags
-          existing_c_flags = pruned_c_flags
-          project_modified = true
-        end
-
-        updated_c_flags = append_flags(existing_c_flags, module_map_flags)
-        if updated_c_flags != existing_c_flags
-          config.build_settings['OTHER_CFLAGS'] = updated_c_flags
-          existing_c_flags = updated_c_flags
-          project_modified = true
-        end
-
-        existing_cpp_flags = config.build_settings['OTHER_CPLUSPLUSFLAGS']
-        pruned_cpp_flags, pruned_cpp = remove_flag(existing_cpp_flags, legacy_module_map_flag)
-        if pruned_cpp
-          config.build_settings['OTHER_CPLUSPLUSFLAGS'] = pruned_cpp_flags
-          existing_cpp_flags = pruned_cpp_flags
-          project_modified = true
-        end
-
-        updated_cpp_flags = append_flags(existing_cpp_flags, module_map_flags)
-        if updated_cpp_flags != existing_cpp_flags
-          config.build_settings['OTHER_CPLUSPLUSFLAGS'] = updated_cpp_flags
-          existing_cpp_flags = updated_cpp_flags
-          project_modified = true
-        end
-
-        swift_tokens, swift_changed = ensure_swift_module_flags(
-          config.build_settings['OTHER_SWIFT_FLAGS'],
-          module_map_flags,
-          :forbidden_flags => [legacy_module_map_flag]
+        updated = sanitize_module_map_settings(
+          config,
+          :header_search_fix => header_search_fix,
+          :module_map_flags => module_map_flags,
+          :module_map_path => module_map_path,
+          :legacy_module_map_flag => legacy_module_map_flag,
+          :force_tokens => true
         )
-        if swift_changed
-          config.build_settings['OTHER_SWIFT_FLAGS'] = swift_tokens
-          project_modified = true
-        end
+
+        project_modified ||= updated
       end
     end
 
@@ -454,6 +444,24 @@ post_install do |installer|
       Pod::UI.puts "[Podfile] Updated #{xcconfig_path} to prefer module.modulemap"
       File.write(xcconfig_path, replaced)
     end
+  end
+
+  if Dir.exist?(target_support_dir)
+    existing_target_support_map = File.exist?(target_support_module_map) ? File.read(target_support_module_map) : nil
+    if existing_target_support_map != desired_module_map
+      Pod::UI.puts "[Podfile] Writing #{target_support_module_map} (target support)"
+      File.write(target_support_module_map, desired_module_map)
+    end
+
+    if File.exist?(legacy_target_support_module_map) || File.symlink?(legacy_target_support_module_map)
+      Pod::UI.puts "[Podfile] Removing legacy module map at #{legacy_target_support_module_map}"
+      FileUtils.rm_f(legacy_target_support_module_map)
+    end
+  end
+
+  Dir.glob(File.join(installer.sandbox.root.to_s, '**', 'RCTDeprecation.modulemap')).each do |stray_module_map|
+    Pod::UI.puts "[Podfile] Removing stray legacy module map at #{stray_module_map}"
+    FileUtils.rm_f(stray_module_map)
   end
 
   mlx_patch_script = File.join(__dir__, 'scripts', 'patch-mlx-metal-cxx17.sh')

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -243,13 +243,14 @@ post_install do |installer|
   legacy_module_map_path_pattern = /(?<!\S)#{Regexp.escape(legacy_module_map_path)}(?!\S)/
   legacy_module_map_flag_quoted_pattern = /"#{Regexp.escape(legacy_module_map_flag)}"/
   legacy_module_map_path_quoted_pattern = /"#{Regexp.escape(legacy_module_map_path)}"/
-  # Keep the legacy module map on disk for older toolchains that still probe for
-  # `RCTDeprecation.modulemap`, but avoid feeding it directly to clang.
-  # Xcode 16's clang treats duplicate `-fmodule-map-file` entries defining the
-  # same module as a hard error ("redefinition of module"), which surfaced in CI.
-  # Limiting the compiler flags to the canonical module map sidesteps the clash
-  # while maintaining the compatibility file for consumers that reference it
-  # directly on disk.
+  # Provide a single canonical module map so clang never has to reconcile two
+  # definitions of the same module. Previous builds shipped both
+  # `module.modulemap` and `RCTDeprecation.modulemap`, which allowed the compiler
+  # to load either file depending on discovery order. When a precompiled header
+  # cached one path and the next build discovered the other, Xcode 16 aborted the
+  # build because the AST referenced a different module map path. Keeping only the
+  # canonical file and updating build settings to point at it ensures every
+  # invocation resolves the module identically.
   module_map_flags = [module_map_flag]
   module_map_dir = File.join(installer.sandbox.root.to_s, 'Headers', 'Public', 'RCTDeprecation')
   module_map_disk = File.join(module_map_dir, 'module.modulemap')
@@ -259,12 +260,15 @@ post_install do |installer|
   desired_module_map = File.read(module_map_template)
 
   FileUtils.mkdir_p(module_map_dir)
-  { module_map_disk => 'primary', legacy_module_map_disk => 'legacy' }.each do |path, label|
-    existing_module_map = File.exist?(path) ? File.read(path) : nil
-    next if existing_module_map == desired_module_map
+  existing_module_map = File.exist?(module_map_disk) ? File.read(module_map_disk) : nil
+  if existing_module_map != desired_module_map
+    Pod::UI.puts "[Podfile] Writing #{module_map_disk} (primary)"
+    File.write(module_map_disk, desired_module_map)
+  end
 
-    Pod::UI.puts "[Podfile] Writing #{path} (#{label})"
-    File.write(path, desired_module_map)
+  if File.exist?(legacy_module_map_disk) || File.symlink?(legacy_module_map_disk)
+    Pod::UI.puts "[Podfile] Removing legacy module map at #{legacy_module_map_disk}"
+    FileUtils.rm_f(legacy_module_map_disk)
   end
 
   pods_project_modified = false

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -456,6 +456,28 @@ post_install do |installer|
     end
   end
 
+  mlx_patch_script = File.join(__dir__, 'scripts', 'patch-mlx-metal-cxx17.sh')
+  if File.exist?(mlx_patch_script)
+    env = { 'PROJECT_DIR' => __dir__, 'SRCROOT' => __dir__ }
+    stdout_str, stderr_str, status = Open3.capture3(env, 'bash', mlx_patch_script)
+
+    stdout_str.each_line do |line|
+      line = line.strip
+      Pod::UI.puts("[Podfile] #{line}") unless line.empty?
+    end
+
+    unless status.success?
+      stderr_str.each_line do |line|
+        line = line.strip
+        Pod::UI.warn("[Podfile] STDERR: #{line}") unless line.empty?
+      end
+      Pod::UI.warn('[Podfile] Failed to patch MLX metal headers; warnings may persist. ' \
+                   'You can re-run ios/scripts/patch-mlx-metal-cxx17.sh manually.')
+    end
+  else
+    Pod::UI.warn('[Podfile] Missing ios/scripts/patch-mlx-metal-cxx17.sh; MLX metal warnings may persist.')
+  end
+
   # Try to apply RN Contacts orientation patch (if repo has the script)
   patch_script = File.join(__dir__, 'scripts', 'patch-react-native-contacts.sh')
   if File.exist?(patch_script)

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -80,6 +80,11 @@ targets:
           DEBUG_INFORMATION_FORMAT: dwarf-with-dsym
 
     scripts:
+      - name: Patch MLX metal headers for C++17 warnings
+        script: |
+          bash "${PROJECT_DIR}/scripts/patch-mlx-metal-cxx17.sh"
+        runOnlyForDeploymentPostprocessing: false
+        alwaysOutOfDate: true
       - name: Create Symlinks to Header Folders
         script: |
           echo "Symlinks handled by CocoaPods"

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -80,6 +80,11 @@ targets:
           DEBUG_INFORMATION_FORMAT: dwarf-with-dsym
 
     scripts:
+      - name: Purge legacy RCTDeprecation caches
+        script: |
+          bash "${PROJECT_DIR}/scripts/purge-rctdeprecation-caches.sh"
+        runOnlyForDeploymentPostprocessing: false
+        alwaysOutOfDate: true
       - name: Patch MLX metal headers for C++17 warnings
         script: |
           bash "${PROJECT_DIR}/scripts/patch-mlx-metal-cxx17.sh"
@@ -97,6 +102,10 @@ targets:
     scheme:
       testTargets: []
       preActions:
+        - name: Purge legacy RCTDeprecation caches
+          settingsTarget: monGARS
+          script: |
+            bash "${PROJECT_DIR}/scripts/purge-rctdeprecation-caches.sh"
         - name: Patch MLX metal headers
           settingsTarget: monGARS
           script: |

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -70,6 +70,7 @@ targets:
         CLANG_CXX_LANGUAGE_STANDARD: c++20
         OTHER_MTLFLAGS:
           - "$(inherited)"
+          - "-std=metal-cpp17"
 
         # Allow CocoaPods header symlink scripts to write in Xcode 15+
         ENABLE_USER_SCRIPT_SANDBOXING: NO

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -96,3 +96,8 @@ targets:
 
     scheme:
       testTargets: []
+      preActions:
+        - name: Patch MLX metal headers
+          settingsTarget: monGARS
+          script: |
+            bash "${PROJECT_DIR}/scripts/patch-mlx-metal-cxx17.sh"

--- a/ios/scripts/patch-mlx-metal-cxx17.sh
+++ b/ios/scripts/patch-mlx-metal-cxx17.sh
@@ -143,6 +143,19 @@ maybe_add_variations() {
   done
 }
 
+array_contains() {
+  local needle="$1"
+  shift || true
+
+  for item in "$@"; do
+    if [ "$item" = "$needle" ]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 declare -a candidate_roots=()
 
 maybe_add_variations "${PROJECT_DIR:-}" 3
@@ -154,17 +167,15 @@ maybe_add_root "$HOME/Library/Developer/Xcode/DerivedData"
 maybe_add_root "$HOME/Library/Developer/Xcode/DerivedData/SourcePackages"
 maybe_add_root "$HOME/Library/Developer/Xcode/DerivedData/SourcePackages/checkouts"
 
-declare -A seen_roots=()
 declare -a roots=()
 
 for candidate in "${candidate_roots[@]}"; do
   if [ -z "$candidate" ]; then
     continue
   fi
-  if [[ -n "${seen_roots[$candidate]:-}" ]]; then
+  if array_contains "$candidate" "${roots[@]}"; then
     continue
   fi
-  seen_roots[$candidate]=1
   roots+=("$candidate")
 done
 

--- a/ios/scripts/patch-mlx-metal-cxx17.sh
+++ b/ios/scripts/patch-mlx-metal-cxx17.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+set -euo pipefail
+
+log() {
+  printf '[patch-mlx-metal-cxx17] %s\n' "$1"
+}
+
+MARKER="offLLM:disable-metal-cxx17-warning"
+
+apply_patch() {
+  local file="$1"
+  if [ ! -f "$file" ]; then
+    return
+  fi
+
+  local status
+  status="$(python3 - "$file" "$MARKER" <<'PY'
+import os
+import sys
+from typing import Tuple
+
+path, marker = sys.argv[1], sys.argv[2]
+try:
+    with open(path, "r", encoding="utf-8") as fh:
+        original = fh.read()
+except FileNotFoundError:
+    print("missing", end="")
+    raise SystemExit(0)
+
+if marker in original:
+    print("already", end="")
+    raise SystemExit(0)
+
+prefix = (
+    f"// {marker}\n"
+    "#if defined(__clang__)\n"
+    "#pragma clang diagnostic push\n"
+    "#pragma clang diagnostic ignored \"-Wc++17-extensions\"\n"
+    "#endif\n"
+)
+
+suffix = (
+    "\n#if defined(__clang__)\n"
+    "#pragma clang diagnostic pop\n"
+    "#endif\n"
+)
+
+content = original
+if not content.endswith("\n"):
+    content += "\n"
+
+patched = prefix + content + suffix
+
+tmp_path = path + ".offllm.tmp"
+with open(tmp_path, "w", encoding="utf-8") as fh:
+    fh.write(patched)
+os.replace(tmp_path, path)
+print("patched", end="")
+PY
+)"
+
+  case "$status" in
+    patched)
+      log "Applied diagnostic guard to ${file}"
+      ;;
+    already)
+      log "Already guarded ${file}"
+      ;;
+    missing)
+      log "File disappeared before patch: ${file}"
+      ;;
+    "")
+      log "No changes required for ${file}"
+      ;;
+    *)
+      log "Unexpected status '${status}' for ${file}"
+      ;;
+  esac
+}
+
+collect_roots() {
+  local candidate
+  for candidate in "$@"; do
+    if [ -d "$candidate" ]; then
+      printf '%s\0' "$candidate"
+    fi
+  done
+}
+
+mapfile -d '' roots < <(collect_roots \
+  "${PROJECT_DIR:-}"/SourcePackages/checkouts \
+  "${PROJECT_DIR:-}"/../SourcePackages/checkouts \
+  "${SRCROOT:-}"/SourcePackages/checkouts \
+  "${DERIVED_DATA_DIR:-}"/SourcePackages/checkouts \
+  "$HOME/Library/Developer/Xcode/DerivedData")
+
+if [ "${#roots[@]}" -eq 0 ]; then
+  log "No SourcePackages directories discovered; nothing to patch"
+  exit 0
+fi
+
+declare -A seen_roots=()
+
+for root in "${roots[@]}"; do
+  if [ -z "$root" ]; then
+    continue
+  fi
+  if [[ -n "${seen_roots[$root]:-}" ]]; then
+    continue
+  fi
+  seen_roots[$root]=1
+
+done
+
+if [ "${#seen_roots[@]}" -eq 0 ]; then
+  log "No unique SourcePackages directories found; exiting"
+  exit 0
+fi
+
+patched_any=false
+
+for root in "${!seen_roots[@]}"; do
+  while IFS= read -r -d '' file; do
+    apply_patch "$file"
+    patched_any=true
+  done < <(find "$root" -maxdepth 15 -path '*/mlx-swift/Source/Cmlx/mlx-generated/metal/steel/attn/kernels/steel_attention.h' -print0 || true)
+done
+
+if [ "$patched_any" = false ]; then
+  log "Did not locate mlx-swift steel_attention.h; nothing to patch"
+fi

--- a/ios/scripts/patch-react-native-contacts.sh
+++ b/ios/scripts/patch-react-native-contacts.sh
@@ -22,7 +22,6 @@ if ! python3 - <<'PY' >/dev/null 2>&1; then
 import sys
 sys.exit(0 if sys.version_info >= (3, 7) else 1)
 PY
-then
   PY_VERSION="$(python3 --version 2>/dev/null || echo 'python3 unavailable')"
   echo "❌ python3 3.7 or newer is required to patch react-native-contacts (detected: $PY_VERSION)."
   exit 1

--- a/ios/scripts/purge-rctdeprecation-caches.sh
+++ b/ios/scripts/purge-rctdeprecation-caches.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${BASH_VERSION:-}" ]; then
+  echo "[purge-rctdeprecation] This script requires bash" >&2
+  exit 1
+fi
+
+if [ "${BASH_VERSINFO[0]}" -lt 3 ]; then
+  echo "[purge-rctdeprecation] Bash 3.0 or newer is required" >&2
+  exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+project_dir_default="$(cd "${script_dir}/.." && pwd -P)"
+PROJECT_DIR="${PROJECT_DIR:-$project_dir_default}"
+PROJECT_DIR="$(cd "${PROJECT_DIR}" && pwd -P)"
+PROJECT_ROOT="$(cd "${PROJECT_DIR}/.." && pwd -P)"
+
+APP_TARGET="${APP_TARGET:-monGARS}"
+MODULE_NAME="${MODULE_NAME:-RCTDeprecation}"
+LEGACY_MODULE_MAP_NAME="${LEGACY_MODULE_MAP_NAME:-RCTDeprecation.modulemap}"
+
+candidate_roots=()
+
+append_candidate() {
+  local raw="$1"
+
+  if [ -z "$raw" ]; then
+    return 0
+  fi
+
+  if [ ! -e "$raw" ]; then
+    return 0
+  fi
+
+  if [ -d "$raw" ]; then
+    :
+  else
+    raw="$(dirname "$raw")"
+    if [ ! -d "$raw" ]; then
+      return 0
+    fi
+  fi
+
+  local canonical
+  canonical="$(cd "$raw" && pwd -P)"
+
+  local existing
+  for existing in "${candidate_roots[@]}"; do
+    if [ "$existing" = "$canonical" ]; then
+      return 0
+    fi
+  done
+
+  candidate_roots+=("$canonical")
+}
+
+append_candidate "${DERIVED_DATA_DIR:-}"
+append_candidate "${OBJROOT:-}"
+append_candidate "${SYMROOT:-}"
+append_candidate "${PROJECT_ROOT}/build/DerivedData"
+append_candidate "${HOME:-}/Library/Developer/Xcode/DerivedData"
+
+if [ "${#candidate_roots[@]}" -eq 0 ]; then
+  echo "[purge-rctdeprecation] No derived data roots to inspect" >&2
+  exit 0
+fi
+
+remove_matches() {
+  local description="$1"
+  local root="$2"
+  shift 2
+
+  if [ ! -d "$root" ]; then
+    return 0
+  fi
+
+  find "$root" "$@" -print0 2>/dev/null | while IFS= read -r -d '' path; do
+    if [ -z "$path" ]; then
+      continue
+    fi
+
+    if [ -d "$path" ]; then
+      echo "[purge-rctdeprecation] Removing $description directory $path"
+      rm -rf "$path"
+    else
+      echo "[purge-rctdeprecation] Removing $description file $path"
+      rm -f "$path"
+    fi
+  done
+}
+
+for root in "${candidate_roots[@]}"; do
+  remove_matches "bridging header cache" "$root" -type f -name "${APP_TARGET}-Bridging-Header-swift*.pch"
+  remove_matches "module cache" "$root" -path "*ModuleCache.noindex*" -name "*${MODULE_NAME}*"
+  remove_matches "legacy module map" "$root" -type f -name "${LEGACY_MODULE_MAP_NAME}"
+done
+
+exit 0

--- a/project.yml
+++ b/project.yml
@@ -81,6 +81,7 @@ targets:
         CLANG_CXX_LANGUAGE_STANDARD: c++20
         OTHER_MTLFLAGS:
           - "$(inherited)"
+          - "-std=metal-cpp17"
 
         # Allow CocoaPods header symlink scripts to write in Xcode 15+
         ENABLE_USER_SCRIPT_SANDBOXING: NO

--- a/project.yml
+++ b/project.yml
@@ -91,6 +91,11 @@ targets:
           DEBUG_INFORMATION_FORMAT: dwarf-with-dsym
 
     scripts:
+      - name: Purge legacy RCTDeprecation caches
+        script: |
+          bash "${PROJECT_DIR}/scripts/purge-rctdeprecation-caches.sh"
+        runOnlyForDeploymentPostprocessing: false
+        alwaysOutOfDate: true
       - name: Patch MLX metal headers for C++17 warnings
         script: |
           bash "${PROJECT_DIR}/scripts/patch-mlx-metal-cxx17.sh"
@@ -108,6 +113,10 @@ targets:
     scheme:
       testTargets: []
       preActions:
+        - name: Purge legacy RCTDeprecation caches
+          settingsTarget: monGARS
+          script: |
+            bash "${PROJECT_DIR}/scripts/purge-rctdeprecation-caches.sh"
         - name: Patch MLX metal headers
           settingsTarget: monGARS
           script: |

--- a/project.yml
+++ b/project.yml
@@ -91,6 +91,11 @@ targets:
           DEBUG_INFORMATION_FORMAT: dwarf-with-dsym
 
     scripts:
+      - name: Patch MLX metal headers for C++17 warnings
+        script: |
+          bash "${PROJECT_DIR}/scripts/patch-mlx-metal-cxx17.sh"
+        runOnlyForDeploymentPostprocessing: false
+        alwaysOutOfDate: true
       - name: Create Symlinks to Header Folders
         script: |
           echo "Symlinks handled by CocoaPods"

--- a/project.yml
+++ b/project.yml
@@ -107,3 +107,8 @@ targets:
 
     scheme:
       testTargets: []
+      preActions:
+        - name: Patch MLX metal headers
+          settingsTarget: monGARS
+          script: |
+            bash "${PROJECT_DIR}/scripts/patch-mlx-metal-cxx17.sh"


### PR DESCRIPTION
## Summary
- add helpers to normalize build-setting flags and strip the legacy RCTDeprecation module map path before appending the canonical module map flag
- update the post-install hook to purge legacy module map references from pod/user targets and rewrite generated xcconfig files so clang always resolves module.modulemap

## Testing
- CI=1 npm test
- npm run lint
- CI=1 npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68ce213e192083338a5fbd21e70342ee

## Summary by Sourcery

Fix RCTDeprecation module map drift by normalizing, removing, and replacing legacy module map flags in CocoaPods build settings and support files

Bug Fixes:
- Remove outdated RCTDeprecation.modulemap references to ensure clang always resolves the correct module.modulemap

Enhancements:
- Introduce normalize_tokens, materialize_tokens, and remove_flag helpers to manage build-setting flags
- Refactor append_flag and append_flags to use token-based normalization
- Enhance ensure_swift_module_flags to drop legacy module map flags and enforce inclusion of the canonical module.modulemap flag
- Update post_install hook to purge legacy -fmodule-map-file flags from C, C++, and Swift build settings across pod and user targets
- Add xcconfig rewriting step to replace legacy RCTDeprecation module map paths and flags with the canonical ones in generated Pod support files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Adds project-level Metal C++17 support and a deployment step that patches Metal headers to suppress C++17 warnings.
  - Introduces a robust flag normalization pipeline enabling targeted flag removal and safer updates to build settings and module map references.

- Bug Fixes
  - Prunes legacy module map flags and updates Xcode pod configs post-install, preventing stale references.
  - Ensures consistent inherited-flag handling and deterministic updates across C/C++/Swift build flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->