### PR TITLE
docs: reinforce session retrospectives in AGENTS guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,6 @@
 - 2025-02 – Swift 6 strict-concurrency failures were neutralised by the annotated patches captured in the native recovery playbook; reuse those edits before chasing new build ghosts.【F:Steps.md†L12-L28】
 - 2025-02 – CI runs stalled on leftover Hermes "Replace Hermes" phases and sandboxed `[CP]` scripts; the doctor workflow now strips those phases and flags deployment-target drift automatically, so keep the heuristics intact when updating build automation.【F:report_agent.md†L6-L10】【F:scripts/dev/doctor.sh†L233-L318】
 - 2025-02 – `commit-reports.sh` enforces clean worktrees and can archive full report folders, preventing teams from losing diagnostics during joint investigations—do not remove those guards when extending the helper.【F:scripts/dev/commit-reports.sh†L22-L77】
+
+### Session reflection
+- Before ending the session, save the current run's successes and errors so the next session can build on what worked and avoid repeating mistakes.

--- a/__tests__/AGENTS.md
+++ b/__tests__/AGENTS.md
@@ -22,4 +22,7 @@
 - 2025-02 – Parser coverage in `toolHandler.test.js` caught malformed argument strings and ensured `_parseArgs` rejects invalid payloads—extend those cases when evolving the prompt grammar.【F:__tests__/toolHandler.test.js†L27-L90】
 - 2025-02 – The persistent memory suite verified encryption-at-rest and migration bumps, preventing plaintext leaks when storage limits tightened.【F:__tests__/vectorMemory.test.js†L19-L43】
 - 2025-02 – Workflow tracer tests confirmed that success and error paths emit structured logs, making orchestration regressions easier to diagnose with saved traces.【F:__tests__/workflowTracer.test.js†L24-L56】
+ 
+### Session reflection
+- Before ending the session, save the current run's successes and errors so the next session can build on what worked and avoid repeating mistakes.
 <!-- prettier-ignore-end -->

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -17,3 +17,6 @@
 - 2025-02 – The architecture guide now captures the orchestrator → plugin → service flow and must be revisited whenever tool registration or plugin overrides shift.【F:docs/agent-architecture.md†L3-L58】
 - 2025-02 – The native recovery playbook documents the Swift 6 concurrency fixes applied to `MLXEvents.swift` and `MLXModule.swift`; reference those annotations before introducing alternative solutions.【F:Steps.md†L12-L28】
 - 2025-02 – Generated doctor reports flagged Hermes replacement scripts and sandboxed `[CP]` phases; the linked remediation steps should stay in sync with future CI adjustments.【F:report_agent.md†L6-L10】
+
+### Session reflection
+- Before ending the session, save the current run's successes and errors so the next session can build on what worked and avoid repeating mistakes.

--- a/reports/AGENTS.md
+++ b/reports/AGENTS.md
@@ -16,3 +16,6 @@
 ### Living history
 - 2025-02 – Recent runs highlighted the need to remove Hermes "Replace Hermes" script phases and disable sandboxing for `[CP]` build steps—leave those notes in place until the underlying pods change.【F:report_agent.md†L6-L10】
 - 2025-02 – The absence of xcresult issues in the latest doctor run confirmed the xcresult parser fallback is working; regenerate diagnostics immediately and update tooling guides if that signal changes.【F:REPORT.md†L1-L13】
+
+### Session reflection
+- Before ending the session, save the current run's successes and errors so the next session can build on what worked and avoid repeating mistakes.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -24,3 +24,6 @@
 - 2025-02 – `ios_doctor.sh` now fails fast when CocoaPods workspaces are missing and exports the workspace path for downstream jobs—preserve that discovery loop when editing pod-install logic.【F:scripts/ios_doctor.sh†L1-L39】
 - 2025-02 – The doctor workflow strips Hermes "Replace Hermes" phases, flags sandboxed `[CP]` scripts, and logs deployment-target drift, which prevented opaque Xcode errors during CI triage; keep those heuristics intact when refactoring.【F:scripts/dev/doctor.sh†L233-L318】【F:report_agent.md†L6-L10】
 - 2025-02 – `commit-reports.sh` enforces clean working trees and can archive entire runs, stopping teams from losing diagnostics during shared investigations—do not relax those guards without a replacement plan.【F:scripts/dev/commit-reports.sh†L22-L77】
+
+### Session reflection
+- Before ending the session, save the current run's successes and errors so the next session can build on what worked and avoid repeating mistakes.

--- a/src/architecture/AGENTS.md
+++ b/src/architecture/AGENTS.md
@@ -20,3 +20,6 @@
 ### Living history
 - 2025-02 – Guarding `_replaceModuleFunction` with dotted module paths prevented accidental overrides of service instances; keep that restriction as you add new patch targets.【F:src/architecture/pluginManager.js†L35-L104】
 - 2025-02 – Tool usage analytics surfaced prompt regressions—continue recording executions in `executionHistory` so adaptive tooling has reliable telemetry.【F:src/architecture/toolSystem.js†L8-L83】
+
+### Session reflection
+- Before ending the session, save the current run's successes and errors so the next session can build on what worked and avoid repeating mistakes.

--- a/src/core/AGENTS.md
+++ b/src/core/AGENTS.md
@@ -21,3 +21,6 @@
 ### Living history
 - 2025-02 – Structured tracing around `executeTools` exposed mis-registered tool names; maintain the tracer hand-offs when refactoring to preserve that signal.【F:src/core/AgentOrchestrator.js†L125-L183】
 - 2025-02 – `_parseArgs` validation prevented silent prompt corruption during prompt experiments—keep new tool syntaxes compatible with the existing parser or expand it with focused tests before rollout.【F:src/core/tools/ToolHandler.js†L31-L109】【F:__tests__/toolHandler.test.js†L27-L90】
+
+### Session reflection
+- Before ending the session, save the current run's successes and errors so the next session can build on what worked and avoid repeating mistakes.

--- a/src/memory/AGENTS.md
+++ b/src/memory/AGENTS.md
@@ -16,3 +16,6 @@
 ### Living history
 - 2025-02 – Development builds previously lost persisted data when the encryption key rotated; setting `MEMORY_ENCRYPTION_KEY` resolved the issue—do not rely on the ephemeral fallback outside local testing.【F:src/memory/VectorMemory.ts†L23-L37】
 - 2025-02 – Tightening `_enforceLimits` to trim the oldest entries kept encrypted blobs under quota without data corruption; retain that LRU-style loop when adjusting limits.【F:src/memory/VectorMemory.ts†L120-L135】
+
+### Session reflection
+- Before ending the session, save the current run's successes and errors so the next session can build on what worked and avoid repeating mistakes.

--- a/src/services/AGENTS.md
+++ b/src/services/AGENTS.md
@@ -23,3 +23,6 @@
 ### Living history
 - 2025-02 – Switching `performSearchWithContentExtraction` to `extractFromUrl` fixed downstream crashes when the deprecated `extract` API was missing—do not regress that call path.【F:src/services/webSearchService.js†L21-L64】
 - 2025-02 – Adaptive quantisation relies on averaged inference time and memory metrics; keep those counters accurate or you lose the self-tuning benefits.【F:src/services/llmService.js†L153-L350】
+
+### Session reflection
+- Before ending the session, save the current run's successes and errors so the next session can build on what worked and avoid repeating mistakes.

--- a/src/tools/AGENTS.md
+++ b/src/tools/AGENTS.md
@@ -19,3 +19,6 @@
 ### Living history
 - 2025-02 – Keeping Android stubs throwing explicit "unsupported" errors prevented silent failures during parity testing—continue matching stub names to their iOS counterparts for clarity.【F:src/tools/androidTools.js†L1-L15】
 - 2025-02 – Returning `{ success: false }` payloads from `webSearchTool` surfaced API key misconfigurations early; preserve that pattern when integrating additional providers.【F:src/tools/webSearchTool.js†L56-L85】
+
+### Session reflection
+- Before ending the session, save the current run's successes and errors so the next session can build on what worked and avoid repeating mistakes.

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -20,3 +20,6 @@
 ### Living history
 - 2025-02 – The xcresult parser’s legacy-flag detection prevented CI regressions when Xcode removed `--legacy` support on certain runners; maintain the retry ordering and failure-selection logic when refactoring.【F:tools/xcresult-parser.js†L22-L133】
 - 2025-02 – Structured shell wrappers in `util.mjs` surfaced non-zero exit codes during earlier investigations—reuse and extend them instead of shelling out ad hoc.【F:tools/util.mjs†L3-L17】
+
+### Session reflection
+- Before ending the session, save the current run's successes and errors so the next session can build on what worked and avoid repeating mistakes.


### PR DESCRIPTION
## Summary
- add a "Session reflection" step to every AGENTS guide so agents record successes and errors for future sessions

## Testing
- CI=1 npm test
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68ce3bcfcb248333b31a4e289134c42d

## Summary by Sourcery

Documentation:
- Introduce a new “Session reflection” section in all AGENTS.md files recommending teams save the current run’s successes and errors before concluding a session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a “Session reflection” subsection across project documentation, guiding users to record each run’s successes and errors before ending a session.
  - Clarifies how to carry learnings forward so subsequent sessions can build on what worked and avoid repeating mistakes, improving workflow continuity.
  - Updates applied consistently across user, architecture, memory, services, tools, and test docs.
  - No functional or behavioral changes; content-only enhancement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->