### PR TITLE
Fix purge script to tolerate find traversal errors

### DIFF
--- a/ios/scripts/purge-rctdeprecation-caches.sh
+++ b/ios/scripts/purge-rctdeprecation-caches.sh
@@ -88,7 +88,7 @@ remove_matches() {
       echo "[purge-rctdeprecation] Removing $description file $path"
       rm -f "$path"
     fi
-  done
+  done || :
 }
 
 for root in "${candidate_roots[@]}"; do


### PR DESCRIPTION
## Summary
- ensure the Purge legacy RCTDeprecation caches build phase ignores benign find traversal errors

## Testing
- npm test -- --runInBand
- npm run lint
- CI=1 npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68ce4774ec3c8333ae4d2a7de8e20f5e