### PR TITLE
fix: normalize module map flags for RCTDeprecation

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -32,8 +32,8 @@ def materialize_tokens(tokens, preference)
   preference == :array ? filtered : filtered.join(' ')
 end
 
-def token_equals?(token, candidate)
-  return false if token.nil? || candidate.nil?
+def normalize_token(token)
+  return nil if token.nil?
 
   normalized = token.to_s.strip
 
@@ -44,7 +44,30 @@ def token_equals?(token, candidate)
     break if normalized == original
   end
 
-  normalized == candidate
+  if normalized.include?('=')
+    prefix, suffix = normalized.split('=', 2)
+    stripped_suffix = suffix.strip
+
+    loop do
+      original_suffix = stripped_suffix
+      stripped_suffix = stripped_suffix.sub(/\A\\?["']/, '')
+      stripped_suffix = stripped_suffix.sub(/\\?["']\z/, '')
+      break if stripped_suffix == original_suffix
+    end
+
+    normalized = "#{prefix}=#{stripped_suffix}"
+  end
+
+  normalized
+end
+
+def token_equals?(token, candidate)
+  normalized_token = normalize_token(token)
+  normalized_candidate = normalize_token(candidate)
+
+  return false if normalized_token.nil? || normalized_candidate.nil?
+
+  normalized_token == normalized_candidate
 end
 
 def tokens_include_flag?(tokens, flag)

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -32,11 +32,30 @@ def materialize_tokens(tokens, preference)
   preference == :array ? filtered : filtered.join(' ')
 end
 
+def token_equals?(token, candidate)
+  return false if token.nil? || candidate.nil?
+
+  normalized = token.to_s.strip
+
+  loop do
+    original = normalized
+    normalized = normalized.sub(/\A\\?["']/, '')
+    normalized = normalized.sub(/\\?["']\z/, '')
+    break if normalized == original
+  end
+
+  normalized == candidate
+end
+
+def tokens_include_flag?(tokens, flag)
+  tokens.any? { |token| token_equals?(token, flag) }
+end
+
 def append_flag(value, flag)
   return ['$(inherited)', flag] if value.nil?
 
   tokens, preference = normalize_tokens(value)
-  return materialize_tokens(tokens, preference) if tokens.include?(flag)
+  return materialize_tokens(tokens, preference) if tokens_include_flag?(tokens, flag)
 
   tokens << flag
   materialize_tokens(tokens, preference)
@@ -49,7 +68,7 @@ end
 def remove_flag(value, flag)
   tokens, preference = normalize_tokens(value)
   original = tokens.dup
-  tokens.reject! { |token| token == flag }
+  tokens.reject! { |token| token_equals?(token, flag) }
   [materialize_tokens(tokens, preference), tokens != original]
 end
 
@@ -57,7 +76,9 @@ def swift_flag_pair?(value, flag)
   return false if flag.nil?
 
   tokens, _ = normalize_tokens(value)
-  tokens.each_cons(2).any? { |first, second| first == '-Xcc' && second == flag }
+  tokens.each_cons(2).any? do |first, second|
+    token_equals?(first, '-Xcc') && token_equals?(second, flag)
+  end
 end
 
 def sanitize_module_map_settings(config, header_search_fix:, module_map_flags:, module_map_path:, legacy_module_map_flag:, force_tokens: false, enforce_module_map: false, enforce_defines_module: false)
@@ -66,13 +87,13 @@ def sanitize_module_map_settings(config, header_search_fix:, module_map_flags:, 
 
   existing_c_flags = config.build_settings['OTHER_CFLAGS']
   c_tokens, _ = normalize_tokens(existing_c_flags)
-  contains_legacy_c_flag = c_tokens.include?(legacy_module_map_flag)
-  contains_canonical_c_flag = module_flag ? c_tokens.include?(module_flag) : false
+  contains_legacy_c_flag = tokens_include_flag?(c_tokens, legacy_module_map_flag)
+  contains_canonical_c_flag = module_flag ? tokens_include_flag?(c_tokens, module_flag) : false
 
   existing_cpp_flags = config.build_settings['OTHER_CPLUSPLUSFLAGS']
   cpp_tokens, _ = normalize_tokens(existing_cpp_flags)
-  contains_legacy_cpp_flag = cpp_tokens.include?(legacy_module_map_flag)
-  contains_canonical_cpp_flag = module_flag ? cpp_tokens.include?(module_flag) : false
+  contains_legacy_cpp_flag = tokens_include_flag?(cpp_tokens, legacy_module_map_flag)
+  contains_canonical_cpp_flag = module_flag ? tokens_include_flag?(cpp_tokens, module_flag) : false
 
   existing_swift_flags = config.build_settings['OTHER_SWIFT_FLAGS']
   contains_legacy_swift = swift_flag_pair?(existing_swift_flags, legacy_module_map_flag)
@@ -157,11 +178,13 @@ def ensure_swift_module_flags(swift_flags, module_map_flags, forbidden_flags: []
 
   forbidden_flags.each do |flag|
     before = tokens.length
-    tokens.reject! { |token| token == flag }
+    tokens.reject! { |token| token_equals?(token, flag) }
     changed ||= tokens.length != before
 
     loop do
-      entry = tokens.each_cons(2).with_index.find { |(first, second), _i| first == '-Xcc' && second == flag }
+      entry = tokens.each_cons(2).with_index.find do |(first, second), _i|
+        token_equals?(first, '-Xcc') && token_equals?(second, flag)
+      end
       break unless entry
 
       _, removal_index = entry
@@ -176,10 +199,10 @@ def ensure_swift_module_flags(swift_flags, module_map_flags, forbidden_flags: []
   while index < tokens.length
     token = tokens[index]
 
-    if token == '-Xcc'
+    if token_equals?(token, '-Xcc')
       next_token = tokens[index + 1]
 
-      if next_token.nil? || next_token == '-Xcc'
+      if next_token.nil? || token_equals?(next_token, '-Xcc')
         changed = true
         index += 1
         next
@@ -201,7 +224,9 @@ def ensure_swift_module_flags(swift_flags, module_map_flags, forbidden_flags: []
   end
 
   module_map_flags.each do |flag|
-    has_pair = tokens.each_cons(2).any? { |first, second| first == '-Xcc' && second == flag }
+    has_pair = tokens.each_cons(2).any? do |first, second|
+      token_equals?(first, '-Xcc') && token_equals?(second, flag)
+    end
     next if has_pair
 
     tokens << '-Xcc'

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -32,36 +32,26 @@ def materialize_tokens(tokens, preference)
   preference == :array ? filtered : filtered.join(' ')
 end
 
+def strip_wrapping_quotes(value)
+  return nil if value.nil?
+
+  value.to_s.strip.gsub(/\A(?:\\?["'])+|(?:\\?["'])+\z/, '')
+end
+
 def normalize_token(token)
   return nil if token.nil?
 
-  normalized = token.to_s.strip
-
-  loop do
-    original = normalized
-    normalized = normalized.sub(/\A\\?["']/, '')
-    normalized = normalized.sub(/\\?["']\z/, '')
-    break if normalized == original
-  end
+  normalized = strip_wrapping_quotes(token)
 
   if normalized.include?('=')
     prefix, suffix = normalized.split('=', 2)
-    stripped_suffix = suffix.strip
-
-    loop do
-      original_suffix = stripped_suffix
-      stripped_suffix = stripped_suffix.sub(/\A\\?["']/, '')
-      stripped_suffix = stripped_suffix.sub(/\\?["']\z/, '')
-      break if stripped_suffix == original_suffix
-    end
-
-    normalized = "#{prefix}=#{stripped_suffix}"
+    normalized = "#{prefix}=#{strip_wrapping_quotes(suffix)}"
   end
 
   normalized
 end
 
-def token_equals?(token, candidate)
+def normalized_flag_equals?(token, candidate)
   normalized_token = normalize_token(token)
   normalized_candidate = normalize_token(candidate)
 
@@ -71,7 +61,7 @@ def token_equals?(token, candidate)
 end
 
 def tokens_include_flag?(tokens, flag)
-  tokens.any? { |token| token_equals?(token, flag) }
+  tokens.any? { |token| normalized_flag_equals?(token, flag) }
 end
 
 def append_flag(value, flag)
@@ -91,17 +81,40 @@ end
 def remove_flag(value, flag)
   tokens, preference = normalize_tokens(value)
   original = tokens.dup
-  tokens.reject! { |token| token_equals?(token, flag) }
+  tokens.reject! { |token| normalized_flag_equals?(token, flag) }
   [materialize_tokens(tokens, preference), tokens != original]
+end
+
+def find_flag_pair_index(tokens, first_flag, second_flag)
+  return nil if first_flag.nil? || second_flag.nil?
+
+  tokens.each_cons(2).with_index do |(first, second), index|
+    next unless normalized_flag_equals?(first, first_flag)
+    return index if normalized_flag_equals?(second, second_flag)
+  end
+  nil
+end
+
+def tokens_include_flag_pair?(tokens, first_flag, second_flag)
+  !find_flag_pair_index(tokens, first_flag, second_flag).nil?
+end
+
+def remove_flag_pair!(tokens, first_flag, second_flag)
+  return false if first_flag.nil? || second_flag.nil?
+
+  removed = false
+  while (index = find_flag_pair_index(tokens, first_flag, second_flag))
+    tokens.slice!(index, 2)
+    removed = true
+  end
+  removed
 end
 
 def swift_flag_pair?(value, flag)
   return false if flag.nil?
 
   tokens, _ = normalize_tokens(value)
-  tokens.each_cons(2).any? do |first, second|
-    token_equals?(first, '-Xcc') && token_equals?(second, flag)
-  end
+  tokens_include_flag_pair?(tokens, '-Xcc', flag)
 end
 
 def sanitize_module_map_settings(config, header_search_fix:, module_map_flags:, module_map_path:, legacy_module_map_flag:, force_tokens: false, enforce_module_map: false, enforce_defines_module: false)
@@ -200,20 +213,13 @@ def ensure_swift_module_flags(swift_flags, module_map_flags, forbidden_flags: []
   end
 
   forbidden_flags.each do |flag|
+    next if flag.nil?
+
     before = tokens.length
-    tokens.reject! { |token| token_equals?(token, flag) }
+    tokens.reject! { |token| normalized_flag_equals?(token, flag) }
     changed ||= tokens.length != before
 
-    loop do
-      entry = tokens.each_cons(2).with_index.find do |(first, second), _i|
-        token_equals?(first, '-Xcc') && token_equals?(second, flag)
-      end
-      break unless entry
-
-      _, removal_index = entry
-      tokens.slice!(removal_index, 2)
-      changed = true
-    end
+    changed ||= remove_flag_pair!(tokens, '-Xcc', flag)
   end
 
   original_tokens = tokens.dup
@@ -222,10 +228,10 @@ def ensure_swift_module_flags(swift_flags, module_map_flags, forbidden_flags: []
   while index < tokens.length
     token = tokens[index]
 
-    if token_equals?(token, '-Xcc')
+    if normalized_flag_equals?(token, '-Xcc')
       next_token = tokens[index + 1]
 
-      if next_token.nil? || token_equals?(next_token, '-Xcc')
+      if next_token.nil? || normalized_flag_equals?(next_token, '-Xcc')
         changed = true
         index += 1
         next
@@ -247,10 +253,7 @@ def ensure_swift_module_flags(swift_flags, module_map_flags, forbidden_flags: []
   end
 
   module_map_flags.each do |flag|
-    has_pair = tokens.each_cons(2).any? do |first, second|
-      token_equals?(first, '-Xcc') && token_equals?(second, flag)
-    end
-    next if has_pair
+    next if tokens_include_flag_pair?(tokens, '-Xcc', flag)
 
     tokens << '-Xcc'
     tokens << flag


### PR DESCRIPTION
## Summary
- add helper utilities in the Podfile to ignore surrounding quotes when evaluating module map flags
- update C/C++ and Swift flag sanitizers so legacy RCTDeprecation module map references are reliably stripped

## Testing
- CI=1 npm test
- npm run lint
- npx prettier --check . --log-level warn
- npm run build:ios *(fails: `xcodegen` not found in the Linux container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5b67600c83338e77ce82df9aa064

## Summary by Sourcery

Introduce quote-insensitive token comparison utilities in the Podfile and update all module map flag handling functions to use these helpers, ensuring legacy RCTDeprecation flags are consistently detected and removed.

New Features:
- Add token_equals? and tokens_include_flag? helpers to ignore surrounding quotes when comparing flags

Enhancements:
- Replace direct token equality checks with quote-insensitive comparisons in append_flag, remove_flag, and swift_flag_pair?
- Update C, C++, and Swift module map flag sanitizers to use the new helpers for reliable stripping of legacy flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of compiler flag detection and removal, handling quoted and whitespace variations.
  * Ensures consistent module map settings for C/C++/Swift, reducing misconfigurations and duplicate flags.
  * More robust pairing logic for Swift and -Xcc flags to prevent build inconsistencies.

* **Refactor**
  * Standardized flag comparisons using token-aware normalization, improving consistency and reducing edge-case errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->