### PR TITLE
fix: restore RCTDeprecation modulemap compatibility

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -418,6 +418,14 @@ post_install do |installer|
     FileUtils.rm_f(legacy_module_map_disk)
   end
 
+  begin
+    FileUtils.ln_sf(module_map_disk, legacy_module_map_disk)
+    Pod::UI.puts "[Podfile] Linked legacy module map to #{legacy_module_map_disk}"
+  rescue => e
+    FileUtils.cp(module_map_disk, legacy_module_map_disk)
+    Pod::UI.warn "[Podfile] Symlink failed (#{e}); copied canonical module map to legacy path"
+  end
+
   pods_project_modified = false
   installer.pods_project.targets.each do |target|
     removed = remove_hermes_phase.call(target, 'pods')

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -529,7 +529,10 @@ post_install do |installer|
     end
   end
 
+  preserved_legacy_module_maps = [legacy_module_map_disk].compact
   Dir.glob(File.join(installer.sandbox.root.to_s, '**', 'RCTDeprecation.modulemap')).each do |stray_module_map|
+    next if preserved_legacy_module_maps.include?(stray_module_map)
+
     Pod::UI.puts "[Podfile] Removing stray legacy module map at #{stray_module_map}"
     FileUtils.rm_f(stray_module_map)
   end


### PR DESCRIPTION
## Summary
- ensure the Podfile recreates a legacy RCTDeprecation.modulemap symlink that points at the canonical module.modulemap
- fall back to copying the file when the CI environment disallows symlink creation, keeping dependent pods working

## Testing
- CI=1 npm test
- npm run lint
- CI=1 npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68ce6ff81f448333a79d59ccaced5270

## Summary by Sourcery

Bug Fixes:
- Restore legacy RCTDeprecation.modulemap compatibility by creating a symlink in the Podfile and copying the file on symlink failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Reduced intermittent iOS build failures by ensuring legacy module maps are preserved and available via resilient linking with a safe copy fallback.

- Chores
  - Improved iOS dependency installation robustness and logging to prevent accidental removal of legacy maps and to make CI/app updates more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->