### PR TITLE
fix: align AppDelegate with updated RCTAppSetupPrepareApp signature

### DIFF
--- a/ios/MyOfflineLLMApp/AppDelegate.mm
+++ b/ios/MyOfflineLLMApp/AppDelegate.mm
@@ -1,18 +1,46 @@
 #import "AppDelegate.h"
 
-#if __has_include(<React/RCTAppSetupUtils.h>)
+#if __has_include(<React-RCTAppDelegate/RCTAppSetupUtils.h>)
+#import <React-RCTAppDelegate/RCTAppSetupUtils.h>
+#define CR_RCT_APPSETUPUTILS_AVAILABLE 1
+#elif __has_include(<React/RCTAppSetupUtils.h>)
 #import <React/RCTAppSetupUtils.h>
-#elif __has_include(<React_RCTAppDelegate/RCTAppSetupUtils.h>)
-#import <React_RCTAppDelegate/RCTAppSetupUtils.h>
+#define CR_RCT_APPSETUPUTILS_AVAILABLE 1
 #elif __has_include("RCTAppSetupUtils.h")
 #import "RCTAppSetupUtils.h"
+#define CR_RCT_APPSETUPUTILS_AVAILABLE 1
 #else
-#warning "RCTAppSetupUtils header not found. The app will skip RCTAppSetupPrepareApp; ensure Pods are installed if you rely on it."
+#define CR_RCT_APPSETUPUTILS_AVAILABLE 0
+#endif
+
+#if CR_RCT_APPSETUPUTILS_AVAILABLE
+
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_types_compatible_p)
+#define CR_RCT_APPSETUP_HAS_TURBO_PARAM                                                    \
+  __builtin_types_compatible_p(__typeof__(&RCTAppSetupPrepareApp), void (*)(id, BOOL))
+#endif
+#endif
+
+#ifndef CR_RCT_APPSETUP_HAS_TURBO_PARAM
+#define CR_RCT_APPSETUP_HAS_TURBO_PARAM 1
+#endif
+
+#if CR_RCT_APPSETUP_HAS_TURBO_PARAM
+#define CR_RCT_PREPARE_APP(APP, TURBO) RCTAppSetupPrepareApp(APP, TURBO)
+#else
+#define CR_RCT_PREPARE_APP(APP, TURBO) RCTAppSetupPrepareApp(APP)
+#endif
+
+#else
+#warning \
+    "RCTAppSetupUtils header not found. The app will skip RCTAppSetupPrepareApp; ensure Pods are installed if you rely on it."
 static inline void RCTAppSetupPrepareApp(id application, BOOL turboModuleEnabled)
 {
   (void)application;
   (void)turboModuleEnabled;
 }
+#define CR_RCT_PREPARE_APP(APP, TURBO) RCTAppSetupPrepareApp(APP, TURBO)
 #endif
 
 @implementation AppDelegate
@@ -21,7 +49,7 @@ static inline void RCTAppSetupPrepareApp(id application, BOOL turboModuleEnabled
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   // Prepare the React Native environment.
-  RCTAppSetupPrepareApp(application, [self turboModuleEnabled]);
+  CR_RCT_PREPARE_APP(application, [self turboModuleEnabled]);
   // Name must match the "name" field in app.json.
   self.moduleName = @"monGARS";
   return [super application:application didFinishLaunchingWithOptions:launchOptions];

--- a/ios/MyOfflineLLMApp/AppDelegate.mm
+++ b/ios/MyOfflineLLMApp/AppDelegate.mm
@@ -8,7 +8,11 @@
 #import "RCTAppSetupUtils.h"
 #else
 #warning "RCTAppSetupUtils header not found. The app will skip RCTAppSetupPrepareApp; ensure Pods are installed if you rely on it."
-static inline void RCTAppSetupPrepareApp(id application) {}
+static inline void RCTAppSetupPrepareApp(id application, BOOL turboModuleEnabled)
+{
+  (void)application;
+  (void)turboModuleEnabled;
+}
 #endif
 
 @implementation AppDelegate
@@ -17,7 +21,7 @@ static inline void RCTAppSetupPrepareApp(id application) {}
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   // Prepare the React Native environment.
-  RCTAppSetupPrepareApp(application);
+  RCTAppSetupPrepareApp(application, [self turboModuleEnabled]);
   // Name must match the "name" field in app.json.
   self.moduleName = @"monGARS";
   return [super application:application didFinishLaunchingWithOptions:launchOptions];

--- a/ios/MyOfflineLLMApp/MLX/MLXModule.swift
+++ b/ios/MyOfflineLLMApp/MLX/MLXModule.swift
@@ -11,7 +11,8 @@ import React
 @preconcurrency import MLXLLM
 @preconcurrency import MLXLMCommon
 
-// MARK: - Actor that owns ChatSession (off-main, concurrency-safe)
+// MARK: - Actor that owns ChatSession (main actor to satisfy MLX isolation)
+@MainActor
 private actor ChatSessionActor {
   private var container: ModelContainer
   private var isResponding = false

--- a/ios/MyOfflineLLMApp/MLX/MLXModule.swift
+++ b/ios/MyOfflineLLMApp/MLX/MLXModule.swift
@@ -11,9 +11,9 @@ import React
 @preconcurrency import MLXLLM
 @preconcurrency import MLXLMCommon
 
-// MARK: - Actor that owns ChatSession (main actor to satisfy MLX isolation)
+// MARK: - Main-actor session owner that serializes ChatSession access
 @MainActor
-private actor ChatSessionActor {
+private final class ChatSessionActor {
   private var container: ModelContainer
   private var isResponding = false
   private var shouldStop = false

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -50,6 +50,9 @@ targets:
         product: MLXLMCommon
       # - package: mlx-swift-examples
       #   product: Tokenizers
+      # System frameworks required by custom native modules
+      - framework: EventKit.framework
+      - framework: CoreAudioTypes.framework
 
     settings:
       base:

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -51,8 +51,8 @@ targets:
       # - package: mlx-swift-examples
       #   product: Tokenizers
       # System frameworks required by custom native modules
-      - framework: EventKit.framework
-      - framework: CoreAudioTypes.framework
+      - sdk: EventKit.framework
+      - sdk: CoreAudioTypes.framework
 
     settings:
       base:

--- a/project.yml
+++ b/project.yml
@@ -47,8 +47,8 @@ targets:
       # - package: mlx-swift-examples
       #   product: Tokenizers
       # System frameworks required by custom native modules
-      - framework: EventKit.framework
-      - framework: CoreAudioTypes.framework
+      - sdk: EventKit.framework
+      - sdk: CoreAudioTypes.framework
 
     settings:
       base:

--- a/project.yml
+++ b/project.yml
@@ -46,6 +46,9 @@ targets:
         product: MLXLMCommon
       # - package: mlx-swift-examples
       #   product: Tokenizers
+      # System frameworks required by custom native modules
+      - framework: EventKit.framework
+      - framework: CoreAudioTypes.framework
 
     settings:
       base:


### PR DESCRIPTION
## Summary
- call `RCTAppSetupPrepareApp` with the turbo module flag exposed by `RCTAppDelegate`
- update the local fallback stub to match the new signature so projects still compile when the header is missing

## Testing
- CI=1 npm test
- npm run lint
- npm run format:check
- npm run build:ios *(fails: `xcodegen` is not available in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb6dbe2388333b3305d165eac3165

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/offLLM/194)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * App startup now supports an additional Turbo Modules readiness flag.
  * MLX concurrency moved to main-thread execution to satisfy platform isolation.

* **Chores**
  * Added compile-time guards around app initialization and a runtime warning when native setup is missing.
  * Added iOS system frameworks: EventKit and CoreAudioTypes.

* **User Impact**
  * No immediate UI changes; improves stability and native compatibility for future features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->