### PR TITLE
fix: repair ios unsigned workflow steps

### DIFF
--- a/.github/workflows/ios-unsigned-archive-unsigned-ipa.yml
+++ b/.github/workflows/ios-unsigned-archive-unsigned-ipa.yml
@@ -28,6 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Ensure legacy RCTDeprecation.modulemap exists
+        run: |
+          bash ios/scripts/ensure-rctdeprecation-legacy.sh
+
       - name: Select Xcode ${{ env.XCODE_VERSION }}
         run: |
           sudo xcode-select -s "/Applications/Xcode_${XCODE_VERSION}.app"
@@ -38,8 +42,62 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
 
-      - name: Install JS deps
-        run: npm ci
+      - name: Yarn/NPM install
+        run: |
+          if [ -f yarn.lock ]; then
+            corepack enable || true
+            yarn install --frozen-lockfile
+          else
+            npm ci
+          fi
+
+      - name: Clean caches (global + repo-local) and set fresh module cache
+        run: |
+          set -euo pipefail
+          rm -rf ~/Library/Developer/Xcode/DerivedData
+          rm -rf ~/Library/Caches/com.apple.dt.Xcode
+          rm -rf build/DerivedData
+          rm -rf build/DerivedData/ModuleCache.noindex
+          rm -rf build/DerivedData/Build/Intermediates.noindex/ArchiveIntermediates
+          rm -rf build/DerivedData/Build/Intermediates.noindex/PrecompiledHeaders
+          MODULE_CACHE_DIR="$(mktemp -d)"
+          echo "CLANG_MODULE_CACHE_PATH=${MODULE_CACHE_DIR}" >> $GITHUB_ENV
+
+      - name: Force fresh Pods (ensures Podfile post_install runs)
+        run: |
+          set -euo pipefail
+          rm -rf ios/Pods ios/Podfile.lock
+          cd ios
+          bundle install || true
+          bundle exec pod repo update
+          bundle exec pod install --repo-update --clean-install
+
+      - name: React Native Codegen (generate specs)
+        run: |
+          set -euo pipefail
+          npx react-native --version || true
+          npx react-native codegen || true
+
+      - name: Validate Codegen headers exist (FBReactNativeSpec & LLMSpec)
+        run: |
+          set -euo pipefail
+          FOUND=0
+          for H in \
+            "ios/Pods/Headers/Public/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec.h" \
+            "ios/Pods/Headers/Public/FBReactNativeSpec/FBReactNativeSpec.h" \
+            "ios/Pods/Headers/Public/FBReactNativeSpec/AppSpec.h" \
+            "ios/Pods/Headers/Public/AppSpec/LLMSpec.h" \
+            "ios/Pods/Headers/Public/AppSpecs/LLMSpec.h" \
+            "ios/Pods/Headers/Public/LLMSpec.h"; do
+            if [ -f "$H" ]; then
+              echo "found: $H"
+              FOUND=1
+            fi
+          done
+          if [ "$FOUND" -eq 0 ]; then
+            echo "::error::No codegen spec headers found. Did 'pod install' run and RN codegen execute?"
+            exit 64
+          fi
 
       - name: Install xcresultparser
         run: |
@@ -78,6 +136,7 @@ jobs:
             -resultBundlePath "${RESULT_BUNDLE_DEV}" \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
+            OTHER_LDFLAGS="-v" \
             clean archive | xcpretty && exit ${PIPESTATUS[0]}
 
       - name: Summarize xcresult bundle

--- a/.github/workflows/ios-unsigned-archive-unsigned-ipa.yml
+++ b/.github/workflows/ios-unsigned-archive-unsigned-ipa.yml
@@ -28,10 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Ensure legacy RCTDeprecation.modulemap exists
-        run: |
-          bash ios/scripts/ensure-rctdeprecation-legacy.sh
-
       - name: Select Xcode ${{ env.XCODE_VERSION }}
         run: |
           sudo xcode-select -s "/Applications/Xcode_${XCODE_VERSION}.app"
@@ -68,9 +64,18 @@ jobs:
           set -euo pipefail
           rm -rf ios/Pods ios/Podfile.lock
           cd ios
-          bundle install || true
-          bundle exec pod repo update
-          bundle exec pod install --repo-update --clean-install
+          if [ -f Gemfile ]; then
+            bundle install
+            bundle exec pod repo update
+            bundle exec pod install --repo-update --clean-install
+          else
+            pod repo update
+            pod install --repo-update --clean-install
+          fi
+
+      - name: Ensure legacy RCTDeprecation.modulemap exists
+        run: |
+          bash ios/scripts/ensure-rctdeprecation-legacy.sh
 
       - name: React Native Codegen (generate specs)
         run: |

--- a/ios/MyOfflineLLMApp/Info.plist
+++ b/ios/MyOfflineLLMApp/Info.plist
@@ -20,8 +20,8 @@
 	<string>Microphone access is required for voice features.</string>
 	<key>NSMotionUsageDescription</key>
 	<string>Motion data helps with sensor-based tools.</string>
-	<key>NSMusicUsageDescription</key>
-	<string>Music access allows controlling playback.</string>
+        <key>NSAppleMusicUsageDescription</key>
+        <string>Apple Music access allows controlling playback.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Photo library access lets you share images.</string>
 	<key>RCTNewArchEnabled</key>

--- a/ios/MyOfflineLLMApp/Info.plist
+++ b/ios/MyOfflineLLMApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+        <key>CFBundleIdentifier</key>
+        <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
         <key>CFBundleDisplayName</key>
         <string>monGARS</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -34,6 +34,13 @@ targets:
         # MLXCompat.swift has been removed; the app now uses the new MLX API via LanguageModel
 
     dependencies:
+      - sdk: Contacts.framework
+      - sdk: CoreLocation.framework
+      - sdk: CoreMotion.framework
+      - sdk: MapKit.framework
+      - sdk: MediaPlayer.framework
+      - sdk: MessageUI.framework
+      - sdk: Photos.framework
       - package: mlx-swift-examples
         product: MLXLLM
       # If your code imports additional MLX products, keep them here:


### PR DESCRIPTION
## Summary
- add the requested iOS system frameworks to the Xcode project dependencies
- fix the unsigned archive workflow by restoring the workflow name, inserting the legacy modulemap step, and wiring the Yarn/Pods/codegen setup steps with their run commands

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68cee466d4c08333a2e1478badb579cb

## Summary by Sourcery

Repair the unsigned iOS archive workflow, ensure legacy RCTDeprecation.modulemap, wire up JS dependency installation, cache cleanup, CocoaPods install, React Native codegen and spec validation; add missing system frameworks and enable verbose linker flags

New Features:
- Add React Native codegen step with validation of generated spec headers in CI workflow
- Include Contacts, CoreLocation, CoreMotion, MapKit, MediaPlayer, MessageUI, and Photos frameworks in the iOS project dependencies

Bug Fixes:
- Fix the unsigned archive workflow by restoring the legacy modulemap step and proper wiring of Yarn/Pods/codegen steps

Enhancements:
- Augment the CI workflow with conditional Yarn/NPM install, Xcode cache cleanup, and fresh CocoaPods installation
- Enable verbose linker flags (OTHER_LDFLAGS="-v") in the xcodebuild archive command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Improved iOS build reliability: conditional package installation, clean environment setup, fresh CocoaPods installation, React Native codegen validation, and verbose linker output during archive.
  - Maintained artifact packaging and upload steps.
  - Updated iOS project to link additional system frameworks (Contacts, CoreLocation, CoreMotion, MapKit, MediaPlayer, MessageUI, Photos) for broader platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->