### PR TITLE
fix: link iOS frameworks and log linker output

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -112,6 +112,14 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ../build/DerivedData
+          LINK_MAP_DIR="${RUNNER_TEMP:-/tmp}"
+          LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-${SDK}-build-$(date +%s).map"
+          EXTRA_OTHER_LDFLAGS="-v -Xlinker -map -Xlinker ${LINK_MAP_PATH}"
+          if [ -n "${OTHER_LDFLAGS:-}" ]; then
+            OTHER_LDFLAGS="${OTHER_LDFLAGS} ${EXTRA_OTHER_LDFLAGS}"
+          else
+            OTHER_LDFLAGS="${EXTRA_OTHER_LDFLAGS}"
+          fi
           xcodebuild \
             -workspace "$WORKSPACE" \
             -scheme "$SCHEME" \
@@ -121,7 +129,7 @@ jobs:
             -derivedDataPath ../build/DerivedData \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
-            OTHER_LDFLAGS="-v" \
+            OTHER_LDFLAGS="$OTHER_LDFLAGS" \
             clean build | xcpretty && exit ${PIPESTATUS[0]}
         shell: bash
 
@@ -240,6 +248,14 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ../build/DerivedData "$(dirname "$ARCHIVE_PATH")"
+          LINK_MAP_DIR="${RUNNER_TEMP:-/tmp}"
+          LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-${SDK}-archive-$(date +%s).map"
+          EXTRA_OTHER_LDFLAGS="-v -Xlinker -map -Xlinker ${LINK_MAP_PATH}"
+          if [ -n "${OTHER_LDFLAGS:-}" ]; then
+            OTHER_LDFLAGS="${OTHER_LDFLAGS} ${EXTRA_OTHER_LDFLAGS}"
+          else
+            OTHER_LDFLAGS="${EXTRA_OTHER_LDFLAGS}"
+          fi
           xcodebuild \
             -workspace "$WORKSPACE" \
             -scheme "$SCHEME" \
@@ -249,7 +265,7 @@ jobs:
             -derivedDataPath ../build/DerivedData \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
-            OTHER_LDFLAGS="-v" \
+            OTHER_LDFLAGS="$OTHER_LDFLAGS" \
             archive -archivePath "$ARCHIVE_PATH" | xcpretty && exit ${PIPESTATUS[0]}
 
       - name: Remove temporary module cache

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -121,6 +121,7 @@ jobs:
             -derivedDataPath ../build/DerivedData \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
+            OTHER_LDFLAGS="-v" \
             clean build | xcpretty && exit ${PIPESTATUS[0]}
         shell: bash
 
@@ -248,6 +249,7 @@ jobs:
             -derivedDataPath ../build/DerivedData \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
+            OTHER_LDFLAGS="-v" \
             archive -archivePath "$ARCHIVE_PATH" | xcpretty && exit ${PIPESTATUS[0]}
 
       - name: Remove temporary module cache

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -115,11 +115,15 @@ jobs:
           LINK_MAP_DIR="${RUNNER_TEMP:-/tmp}"
           LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-${SDK}-build-$(date +%s).map"
           EXTRA_OTHER_LDFLAGS="-v -Xlinker -map -Xlinker ${LINK_MAP_PATH}"
-          if [ -n "${OTHER_LDFLAGS:-}" ]; then
-            OTHER_LDFLAGS="${OTHER_LDFLAGS} ${EXTRA_OTHER_LDFLAGS}"
-          else
-            OTHER_LDFLAGS="${EXTRA_OTHER_LDFLAGS}"
+          BASE_OTHER_LDFLAGS="${OTHER_LDFLAGS:-}"
+          if [[ "${BASE_OTHER_LDFLAGS}" != *"\$(inherited)"* ]]; then
+            if [ -n "${BASE_OTHER_LDFLAGS}" ]; then
+              BASE_OTHER_LDFLAGS="\$(inherited) ${BASE_OTHER_LDFLAGS}"
+            else
+              BASE_OTHER_LDFLAGS="\$(inherited)"
+            fi
           fi
+          OTHER_LDFLAGS="${BASE_OTHER_LDFLAGS} ${EXTRA_OTHER_LDFLAGS}"
           xcodebuild \
             -workspace "$WORKSPACE" \
             -scheme "$SCHEME" \
@@ -251,11 +255,15 @@ jobs:
           LINK_MAP_DIR="${RUNNER_TEMP:-/tmp}"
           LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-${SDK}-archive-$(date +%s).map"
           EXTRA_OTHER_LDFLAGS="-v -Xlinker -map -Xlinker ${LINK_MAP_PATH}"
-          if [ -n "${OTHER_LDFLAGS:-}" ]; then
-            OTHER_LDFLAGS="${OTHER_LDFLAGS} ${EXTRA_OTHER_LDFLAGS}"
-          else
-            OTHER_LDFLAGS="${EXTRA_OTHER_LDFLAGS}"
+          BASE_OTHER_LDFLAGS="${OTHER_LDFLAGS:-}"
+          if [[ "${BASE_OTHER_LDFLAGS}" != *"\$(inherited)"* ]]; then
+            if [ -n "${BASE_OTHER_LDFLAGS}" ]; then
+              BASE_OTHER_LDFLAGS="\$(inherited) ${BASE_OTHER_LDFLAGS}"
+            else
+              BASE_OTHER_LDFLAGS="\$(inherited)"
+            fi
           fi
+          OTHER_LDFLAGS="${BASE_OTHER_LDFLAGS} ${EXTRA_OTHER_LDFLAGS}"
           xcodebuild \
             -workspace "$WORKSPACE" \
             -scheme "$SCHEME" \

--- a/.github/workflows/ios-unsigned-archive-unsigned-ipa.yml
+++ b/.github/workflows/ios-unsigned-archive-unsigned-ipa.yml
@@ -131,6 +131,14 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$(dirname "$RESULT_BUNDLE_DEV")" "$(dirname "$ARCHIVE_PATH")" "$DERIVED_DATA"
+          LINK_MAP_DIR="${RUNNER_TEMP:-/tmp}"
+          LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-device-archive-$(date +%s).map"
+          EXTRA_OTHER_LDFLAGS="-v -Xlinker -map -Xlinker ${LINK_MAP_PATH}"
+          if [ -n "${OTHER_LDFLAGS:-}" ]; then
+            OTHER_LDFLAGS="${OTHER_LDFLAGS} ${EXTRA_OTHER_LDFLAGS}"
+          else
+            OTHER_LDFLAGS="${EXTRA_OTHER_LDFLAGS}"
+          fi
           xcodebuild \
             -workspace "${WORKSPACE}" \
             -scheme "${SCHEME}" \
@@ -141,7 +149,7 @@ jobs:
             -resultBundlePath "${RESULT_BUNDLE_DEV}" \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
-            OTHER_LDFLAGS="-v" \
+            OTHER_LDFLAGS="${OTHER_LDFLAGS}" \
             clean archive | xcpretty && exit ${PIPESTATUS[0]}
 
       - name: Summarize xcresult bundle

--- a/.github/workflows/ios-unsigned-archive-unsigned-ipa.yml
+++ b/.github/workflows/ios-unsigned-archive-unsigned-ipa.yml
@@ -134,11 +134,15 @@ jobs:
           LINK_MAP_DIR="${RUNNER_TEMP:-/tmp}"
           LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-device-archive-$(date +%s).map"
           EXTRA_OTHER_LDFLAGS="-v -Xlinker -map -Xlinker ${LINK_MAP_PATH}"
-          if [ -n "${OTHER_LDFLAGS:-}" ]; then
-            OTHER_LDFLAGS="${OTHER_LDFLAGS} ${EXTRA_OTHER_LDFLAGS}"
-          else
-            OTHER_LDFLAGS="${EXTRA_OTHER_LDFLAGS}"
+          BASE_OTHER_LDFLAGS="${OTHER_LDFLAGS:-}"
+          if [[ "${BASE_OTHER_LDFLAGS}" != *"\$(inherited)"* ]]; then
+            if [ -n "${BASE_OTHER_LDFLAGS}" ]; then
+              BASE_OTHER_LDFLAGS="\$(inherited) ${BASE_OTHER_LDFLAGS}"
+            else
+              BASE_OTHER_LDFLAGS="\$(inherited)"
+            fi
           fi
+          OTHER_LDFLAGS="${BASE_OTHER_LDFLAGS} ${EXTRA_OTHER_LDFLAGS}"
           xcodebuild \
             -workspace "${WORKSPACE}" \
             -scheme "${SCHEME}" \

--- a/.github/workflows/ios-unsigned-device.yml
+++ b/.github/workflows/ios-unsigned-device.yml
@@ -369,11 +369,15 @@ jobs:
           LINK_MAP_DIR="${RUNNER_TEMP:-/tmp}"
           LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-device-archive-$(date +%s).map"
           EXTRA_OTHER_LDFLAGS="-v -Xlinker -map -Xlinker ${LINK_MAP_PATH}"
-          if [ -n "${OTHER_LDFLAGS:-}" ]; then
-            OTHER_LDFLAGS="${OTHER_LDFLAGS} ${EXTRA_OTHER_LDFLAGS}"
-          else
-            OTHER_LDFLAGS="${EXTRA_OTHER_LDFLAGS}"
+          BASE_OTHER_LDFLAGS="${OTHER_LDFLAGS:-}"
+          if [[ "${BASE_OTHER_LDFLAGS}" != *"\$(inherited)"* ]]; then
+            if [ -n "${BASE_OTHER_LDFLAGS}" ]; then
+              BASE_OTHER_LDFLAGS="\$(inherited) ${BASE_OTHER_LDFLAGS}"
+            else
+              BASE_OTHER_LDFLAGS="\$(inherited)"
+            fi
           fi
+          OTHER_LDFLAGS="${BASE_OTHER_LDFLAGS} ${EXTRA_OTHER_LDFLAGS}"
           xcodebuild archive \
             -${XCODE_CONTAINER_TYPE} "$XCODE_CONTAINER" \
             -scheme "$SCHEME" \

--- a/.github/workflows/ios-unsigned-device.yml
+++ b/.github/workflows/ios-unsigned-device.yml
@@ -366,13 +366,21 @@ jobs:
           rm -rf "$ARCHIVE_PATH" "$RB_ARCHIVE"
           LOG_FILE="build-log.txt"
           rm -f "$LOG_FILE"
+          LINK_MAP_DIR="${RUNNER_TEMP:-/tmp}"
+          LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-device-archive-$(date +%s).map"
+          EXTRA_OTHER_LDFLAGS="-v -Xlinker -map -Xlinker ${LINK_MAP_PATH}"
+          if [ -n "${OTHER_LDFLAGS:-}" ]; then
+            OTHER_LDFLAGS="${OTHER_LDFLAGS} ${EXTRA_OTHER_LDFLAGS}"
+          else
+            OTHER_LDFLAGS="${EXTRA_OTHER_LDFLAGS}"
+          fi
           xcodebuild archive \
             -${XCODE_CONTAINER_TYPE} "$XCODE_CONTAINER" \
             -scheme "$SCHEME" \
             -configuration Release \
             -destination generic/platform=iOS \
             CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
-            OTHER_LDFLAGS="-v" \
+            OTHER_LDFLAGS="$OTHER_LDFLAGS" \
             -derivedDataPath "$DERIVED_DATA" \
             -resultBundlePath "$RB_ARCHIVE" \
             -archivePath "$ARCHIVE_PATH" \

--- a/.github/workflows/ios-unsigned-device.yml
+++ b/.github/workflows/ios-unsigned-device.yml
@@ -372,6 +372,7 @@ jobs:
             -configuration Release \
             -destination generic/platform=iOS \
             CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
+            OTHER_LDFLAGS="-v" \
             -derivedDataPath "$DERIVED_DATA" \
             -resultBundlePath "$RB_ARCHIVE" \
             -archivePath "$ARCHIVE_PATH" \

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -117,6 +117,14 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$(dirname "$RESULT_BUNDLE_SIM")"
+          LINK_MAP_DIR="${RUNNER_TEMP:-/tmp}"
+          LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-simulator-build-$(date +%s).map"
+          EXTRA_OTHER_LDFLAGS="-v -Xlinker -map -Xlinker ${LINK_MAP_PATH}"
+          if [ -n "${OTHER_LDFLAGS:-}" ]; then
+            OTHER_LDFLAGS="${OTHER_LDFLAGS} ${EXTRA_OTHER_LDFLAGS}"
+          else
+            OTHER_LDFLAGS="${EXTRA_OTHER_LDFLAGS}"
+          fi
           xcodebuild \
             -workspace "${WORKSPACE}" \
             -scheme "${SCHEME}" \
@@ -127,7 +135,7 @@ jobs:
             -resultBundlePath "${RESULT_BUNDLE_SIM}" \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
-            OTHER_LDFLAGS="-v" \
+            OTHER_LDFLAGS="${OTHER_LDFLAGS}" \
             clean build | xcpretty && exit ${PIPESTATUS[0]}
 
       - name: Summarize simulator xcresult
@@ -258,6 +266,14 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$(dirname "$RESULT_BUNDLE_DEV")"
+          LINK_MAP_DIR="${RUNNER_TEMP:-/tmp}"
+          LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-device-archive-$(date +%s).map"
+          EXTRA_OTHER_LDFLAGS="-v -Xlinker -map -Xlinker ${LINK_MAP_PATH}"
+          if [ -n "${OTHER_LDFLAGS:-}" ]; then
+            OTHER_LDFLAGS="${OTHER_LDFLAGS} ${EXTRA_OTHER_LDFLAGS}"
+          else
+            OTHER_LDFLAGS="${EXTRA_OTHER_LDFLAGS}"
+          fi
           xcodebuild \
             -workspace "${WORKSPACE}" \
             -scheme "${SCHEME}" \
@@ -267,7 +283,7 @@ jobs:
             -resultBundlePath "${RESULT_BUNDLE_DEV}" \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
-            OTHER_LDFLAGS="-v" \
+            OTHER_LDFLAGS="${OTHER_LDFLAGS}" \
             clean build archive | xcpretty && exit ${PIPESTATUS[0]}
 
       - name: Summarize device xcresult

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -120,11 +120,15 @@ jobs:
           LINK_MAP_DIR="${RUNNER_TEMP:-/tmp}"
           LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-simulator-build-$(date +%s).map"
           EXTRA_OTHER_LDFLAGS="-v -Xlinker -map -Xlinker ${LINK_MAP_PATH}"
-          if [ -n "${OTHER_LDFLAGS:-}" ]; then
-            OTHER_LDFLAGS="${OTHER_LDFLAGS} ${EXTRA_OTHER_LDFLAGS}"
-          else
-            OTHER_LDFLAGS="${EXTRA_OTHER_LDFLAGS}"
+          BASE_OTHER_LDFLAGS="${OTHER_LDFLAGS:-}"
+          if [[ "${BASE_OTHER_LDFLAGS}" != *"\$(inherited)"* ]]; then
+            if [ -n "${BASE_OTHER_LDFLAGS}" ]; then
+              BASE_OTHER_LDFLAGS="\$(inherited) ${BASE_OTHER_LDFLAGS}"
+            else
+              BASE_OTHER_LDFLAGS="\$(inherited)"
+            fi
           fi
+          OTHER_LDFLAGS="${BASE_OTHER_LDFLAGS} ${EXTRA_OTHER_LDFLAGS}"
           xcodebuild \
             -workspace "${WORKSPACE}" \
             -scheme "${SCHEME}" \
@@ -269,11 +273,15 @@ jobs:
           LINK_MAP_DIR="${RUNNER_TEMP:-/tmp}"
           LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-device-archive-$(date +%s).map"
           EXTRA_OTHER_LDFLAGS="-v -Xlinker -map -Xlinker ${LINK_MAP_PATH}"
-          if [ -n "${OTHER_LDFLAGS:-}" ]; then
-            OTHER_LDFLAGS="${OTHER_LDFLAGS} ${EXTRA_OTHER_LDFLAGS}"
-          else
-            OTHER_LDFLAGS="${EXTRA_OTHER_LDFLAGS}"
+          BASE_OTHER_LDFLAGS="${OTHER_LDFLAGS:-}"
+          if [[ "${BASE_OTHER_LDFLAGS}" != *"\$(inherited)"* ]]; then
+            if [ -n "${BASE_OTHER_LDFLAGS}" ]; then
+              BASE_OTHER_LDFLAGS="\$(inherited) ${BASE_OTHER_LDFLAGS}"
+            else
+              BASE_OTHER_LDFLAGS="\$(inherited)"
+            fi
           fi
+          OTHER_LDFLAGS="${BASE_OTHER_LDFLAGS} ${EXTRA_OTHER_LDFLAGS}"
           xcodebuild \
             -workspace "${WORKSPACE}" \
             -scheme "${SCHEME}" \

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -127,6 +127,7 @@ jobs:
             -resultBundlePath "${RESULT_BUNDLE_SIM}" \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
+            OTHER_LDFLAGS="-v" \
             clean build | xcpretty && exit ${PIPESTATUS[0]}
 
       - name: Summarize simulator xcresult
@@ -266,6 +267,7 @@ jobs:
             -resultBundlePath "${RESULT_BUNDLE_DEV}" \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
+            OTHER_LDFLAGS="-v" \
             clean build archive | xcpretty && exit ${PIPESTATUS[0]}
 
       - name: Summarize device xcresult

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -34,9 +34,11 @@ targets:
         # MLXCompat.swift has been removed; the app now uses the new MLX API via LanguageModel
 
     dependencies:
+      # System frameworks required by custom native modules
       - sdk: Contacts.framework
       - sdk: CoreLocation.framework
       - sdk: CoreMotion.framework
+      - sdk: EventKit.framework
       - sdk: MapKit.framework
       - sdk: MediaPlayer.framework
       - sdk: MessageUI.framework
@@ -57,9 +59,6 @@ targets:
         product: MLXLMCommon
       # - package: mlx-swift-examples
       #   product: Tokenizers
-      # System frameworks required by custom native modules
-      - sdk: EventKit.framework
-
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.offllm.mongars


### PR DESCRIPTION
## Summary
- group the monGARS target's system frameworks in `ios/project.yml` so MapKit and MessageUI are explicitly linked alongside EventKit
- pass `OTHER_LDFLAGS="-v"` to the iOS build and archive jobs so CI surfaces verbose linker diagnostics

## Testing
- CI=1 npm test
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68cef6b425108333a11134b84c1c6bc2

## Summary by Sourcery

Group and deduplicate iOS system frameworks in the project configuration and enable verbose linker logging in the CI workflow to improve diagnostics.

Enhancements:
- Group iOS system frameworks in the Xcode project to explicitly link MapKit, MessageUI, and EventKit

CI:
- Add OTHER_LDFLAGS="-v" to the iOS build and archive steps to surface verbose linker diagnostics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved reliability of calendar access on iOS by including the required system framework, reducing failures when using calendar-related features.
* **Chores**
  * Enhanced iOS build and archive logs with per-run verbose linker map output to aid diagnostics and troubleshooting during CI builds; no runtime behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->