### PR TITLE
fix: add missing CFBundleName for sideloaded builds

### DIFF
--- a/ios/MyOfflineLLMApp/Info.plist
+++ b/ios/MyOfflineLLMApp/Info.plist
@@ -6,6 +6,8 @@
         <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
         <key>CFBundleDisplayName</key>
         <string>monGARS</string>
+        <key>CFBundleName</key>
+        <string>monGARS</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Bluetooth is used for device connectivity.</string>
 	<key>NSCalendarsUsageDescription</key>


### PR DESCRIPTION
## Summary
- add a CFBundleName entry to the iOS Info.plist so sideloaded builds include the name metadata
- keep the plist formatting consistent with the surrounding keys

## Testing
- CI=1 npm test
- npm run lint
- npm run format:check


------
https://chatgpt.com/codex/tasks/task_e_68cf1977c2108333b4a0dfba8f8db87d