### PR TITLE
Fix iOS sideloader failure by restoring bundle metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@
 - 2025-02 – Swift 6 strict-concurrency failures were neutralised by the annotated patches captured in the native recovery playbook; reuse those edits before chasing new build ghosts.【F:Steps.md†L12-L28】
 - 2025-02 – CI runs stalled on leftover Hermes "Replace Hermes" phases and sandboxed `[CP]` scripts; the doctor workflow now strips those phases and flags deployment-target drift automatically, so keep the heuristics intact when updating build automation.【F:report_agent.md†L6-L10】【F:scripts/dev/doctor.sh†L233-L318】
 - 2025-02 – `commit-reports.sh` enforces clean worktrees and can archive full report folders, preventing teams from losing diagnostics during joint investigations—do not remove those guards when extending the helper.【F:scripts/dev/commit-reports.sh†L22-L77】
+- 2025-09-20 – Sideloading builds failed when the Info.plist missed `CFBundleExecutable`; populate the core bundle metadata (`CFBundleExecutable`, version strings, package type) so export tools accept the archive.【F:ios/MyOfflineLLMApp/Info.plist†L1-L44】
 
 ### Session reflection
 - Before ending the session, save the current run's successes and errors so the next session can build on what worked and avoid repeating mistakes.

--- a/ios/AGENTS.md
+++ b/ios/AGENTS.md
@@ -1,0 +1,4 @@
+# iOS Workspace Guidelines
+
+- Keep `MyOfflineLLMApp/Info.plist` populated with the core bundle keys (`CFBundleExecutable`, `CFBundlePackageType`, `CFBundleShortVersionString`, `CFBundleVersion`) so archives pass App Store and sideloader validation. Do not strip them when regenerating the plist from templates.【F:ios/MyOfflineLLMApp/Info.plist†L1-L34】
+- Coordinate any future plist migrations with the XcodeGen `project.yml` so the build settings continue to inject `PRODUCT_BUNDLE_IDENTIFIER` and other substitutions correctly.【F:ios/project.yml†L21-L83】

--- a/ios/MyOfflineLLMApp/Info.plist
+++ b/ios/MyOfflineLLMApp/Info.plist
@@ -9,9 +9,9 @@
         <key>CFBundleIdentifier</key>
         <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
         <key>CFBundleDisplayName</key>
-        <string>monGARS</string>
+        <string>$(PRODUCT_NAME)</string>
         <key>CFBundleName</key>
-        <string>monGARS</string>
+        <string>$(PRODUCT_NAME)</string>
         <key>CFBundleInfoDictionaryVersion</key>
         <string>6.0</string>
         <key>CFBundlePackageType</key>

--- a/ios/MyOfflineLLMApp/Info.plist
+++ b/ios/MyOfflineLLMApp/Info.plist
@@ -2,16 +2,43 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>$(DEVELOPMENT_LANGUAGE)</string>
+        <key>CFBundleExecutable</key>
+        <string>$(EXECUTABLE_NAME)</string>
         <key>CFBundleIdentifier</key>
         <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
         <key>CFBundleDisplayName</key>
         <string>monGARS</string>
         <key>CFBundleName</key>
         <string>monGARS</string>
-	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>Bluetooth is used for device connectivity.</string>
-	<key>NSCalendarsUsageDescription</key>
-	<string>We need access to your calendar to sync and display events.</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundlePackageType</key>
+        <string>APPL</string>
+        <key>CFBundleShortVersionString</key>
+        <string>1.0</string>
+        <key>CFBundleVersion</key>
+        <string>1</string>
+        <key>LSRequiresIPhoneOS</key>
+        <true/>
+        <key>UISupportedInterfaceOrientations</key>
+        <array>
+                <string>UIInterfaceOrientationPortrait</string>
+                <string>UIInterfaceOrientationLandscapeLeft</string>
+                <string>UIInterfaceOrientationLandscapeRight</string>
+        </array>
+        <key>UISupportedInterfaceOrientations~ipad</key>
+        <array>
+                <string>UIInterfaceOrientationPortrait</string>
+                <string>UIInterfaceOrientationPortraitUpsideDown</string>
+                <string>UIInterfaceOrientationLandscapeLeft</string>
+                <string>UIInterfaceOrientationLandscapeRight</string>
+        </array>
+        <key>NSBluetoothAlwaysUsageDescription</key>
+        <string>Bluetooth is used for device connectivity.</string>
+        <key>NSCalendarsUsageDescription</key>
+        <string>We need access to your calendar to sync and display events.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Camera access is required to take photos.</string>
 	<key>NSContactsUsageDescription</key>
@@ -25,8 +52,8 @@
         <key>NSAppleMusicUsageDescription</key>
         <string>Apple Music access allows controlling playback.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Photo library access lets you share images.</string>
-	<key>RCTNewArchEnabled</key>
-	<true/>
+        <string>Photo library access lets you share images.</string>
+        <key>RCTNewArchEnabled</key>
+        <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- populate `MyOfflineLLMApp`'s Info.plist with the missing bundle executable and version keys so sideloaded exports validate
- record the sideloading remediation in the repository living history and add iOS-specific guidance for maintaining the plist

## Testing
- npm test
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68cf1f863ad08333994aff27a29c0f70

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/offLLM/200)
<!-- GitContextEnd -->

## Summary by Sourcery

Restore required bundle metadata in the iOS app’s Info.plist to fix sideloading validation failures, and update the repository’s AGENTS documentation with the sideload remediation and new iOS workspace guidelines for maintaining the plist.

Bug Fixes:
- Restore missing bundle metadata keys in MyOfflineLLMApp Info.plist to enable valid sideloaded iOS exports.

Documentation:
- Record the sideloading remediation in AGENTS.md history and add a new iOS workspace guidelines file for Info.plist upkeep and XcodeGen migration coordination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved iOS app metadata to pass App Store and sideloading validation.
  - Restored missing permission descriptions for system prompts.
  - Standardized supported interface orientations on iPhone and iPad.

- Documentation
  - Added iOS workspace guidelines for maintaining build settings and configuration consistency.
  - Updated change log with notes on the metadata fix and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->