### PR TITLE
fix: dedupe link map outputs per target

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -116,7 +116,7 @@ jobs:
           sanitize_xcode_env
           mkdir -p ../build/DerivedData
           LINK_MAP_DIR="${RUNNER_TEMP:-/tmp}"
-          LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-${SDK}-build-$(date +%s).map"
+          LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-${SDK}-build-$(date +%s)-\$(TARGET_NAME)-\$(CURRENT_ARCH).map"
           EXTRA_OTHER_LDFLAGS="-v -Xlinker -map -Xlinker ${LINK_MAP_PATH}"
           BASE_OTHER_LDFLAGS="${OTHER_LDFLAGS:-}"
           if [[ "${BASE_OTHER_LDFLAGS}" != *"\$(inherited)"* ]]; then
@@ -259,7 +259,7 @@ jobs:
           sanitize_xcode_env
           mkdir -p ../build/DerivedData "$(dirname "$ARCHIVE_PATH")"
           LINK_MAP_DIR="${RUNNER_TEMP:-/tmp}"
-          LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-${SDK}-archive-$(date +%s).map"
+          LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-${SDK}-archive-$(date +%s)-\$(TARGET_NAME)-\$(CURRENT_ARCH).map"
           EXTRA_OTHER_LDFLAGS="-v -Xlinker -map -Xlinker ${LINK_MAP_PATH}"
           BASE_OTHER_LDFLAGS="${OTHER_LDFLAGS:-}"
           if [[ "${BASE_OTHER_LDFLAGS}" != *"\$(inherited)"* ]]; then

--- a/.github/workflows/ios-unsigned-archive-unsigned-ipa.yml
+++ b/.github/workflows/ios-unsigned-archive-unsigned-ipa.yml
@@ -132,7 +132,7 @@ jobs:
           set -euo pipefail
           mkdir -p "$(dirname "$RESULT_BUNDLE_DEV")" "$(dirname "$ARCHIVE_PATH")" "$DERIVED_DATA"
           LINK_MAP_DIR="${RUNNER_TEMP:-/tmp}"
-          LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-device-archive-$(date +%s).map"
+          LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-device-archive-$(date +%s)-\$(TARGET_NAME)-\$(CURRENT_ARCH).map"
           EXTRA_OTHER_LDFLAGS="-v -Xlinker -map -Xlinker ${LINK_MAP_PATH}"
           BASE_OTHER_LDFLAGS="${OTHER_LDFLAGS:-}"
           if [[ "${BASE_OTHER_LDFLAGS}" != *"\$(inherited)"* ]]; then

--- a/.github/workflows/ios-unsigned-device.yml
+++ b/.github/workflows/ios-unsigned-device.yml
@@ -367,7 +367,7 @@ jobs:
           LOG_FILE="build-log.txt"
           rm -f "$LOG_FILE"
           LINK_MAP_DIR="${RUNNER_TEMP:-/tmp}"
-          LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-device-archive-$(date +%s).map"
+          LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-device-archive-$(date +%s)-\$(TARGET_NAME)-\$(CURRENT_ARCH).map"
           EXTRA_OTHER_LDFLAGS="-v -Xlinker -map -Xlinker ${LINK_MAP_PATH}"
           BASE_OTHER_LDFLAGS="${OTHER_LDFLAGS:-}"
           if [[ "${BASE_OTHER_LDFLAGS}" != *"\$(inherited)"* ]]; then

--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -118,7 +118,7 @@ jobs:
           set -euo pipefail
           mkdir -p "$(dirname "$RESULT_BUNDLE_SIM")"
           LINK_MAP_DIR="${RUNNER_TEMP:-/tmp}"
-          LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-simulator-build-$(date +%s).map"
+          LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-simulator-build-$(date +%s)-\$(TARGET_NAME)-\$(CURRENT_ARCH).map"
           EXTRA_OTHER_LDFLAGS="-v -Xlinker -map -Xlinker ${LINK_MAP_PATH}"
           BASE_OTHER_LDFLAGS="${OTHER_LDFLAGS:-}"
           if [[ "${BASE_OTHER_LDFLAGS}" != *"\$(inherited)"* ]]; then
@@ -271,7 +271,7 @@ jobs:
           set -euo pipefail
           mkdir -p "$(dirname "$RESULT_BUNDLE_DEV")"
           LINK_MAP_DIR="${RUNNER_TEMP:-/tmp}"
-          LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-device-archive-$(date +%s).map"
+          LINK_MAP_PATH="${LINK_MAP_DIR}/link-map-device-archive-$(date +%s)-\$(TARGET_NAME)-\$(CURRENT_ARCH).map"
           EXTRA_OTHER_LDFLAGS="-v -Xlinker -map -Xlinker ${LINK_MAP_PATH}"
           BASE_OTHER_LDFLAGS="${OTHER_LDFLAGS:-}"
           if [[ "${BASE_OTHER_LDFLAGS}" != *"\$(inherited)"* ]]; then


### PR DESCRIPTION
## Summary
- ensure all iOS workflows write link-map files with target and arch suffixes to avoid duplicate outputs during multi-arch builds

## Testing
- CI=1 npm test
- npm run lint
- CI=1 npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68cf2f9faf748333ad689afa26ed5962

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/offLLM/201)
<!-- GitContextEnd -->