### PR TITLE
feat: implement web search and file system tools

### DIFF
--- a/src/architecture/toolSystem.js
+++ b/src/architecture/toolSystem.js
@@ -1,3 +1,336 @@
+import { searchService } from "../services/webSearchService";
+import { validate as validateSearchApiKeys } from "../services/utils/apiKeys";
+
+const DEFAULT_PROVIDER = "google";
+const DEFAULT_TIME_RANGE = "any";
+const DEFAULT_MAX_RESULTS = 5;
+const MAX_RESULTS_CAP = 20;
+const DEFAULT_SAFE_SEARCH = true;
+const SUPPORTED_PROVIDERS = new Set(["google", "bing", "duckduckgo", "brave"]);
+const SUPPORTED_TIME_RANGES = new Set(["day", "week", "month", "year", "any"]);
+
+const isReactNative =
+  typeof navigator !== "undefined" && navigator.product === "ReactNative";
+
+let RNFS = null;
+let nodeFs = null;
+let nodePath = null;
+
+if (isReactNative) {
+  try {
+    RNFS = require("react-native-fs");
+  } catch (error) {
+    console.warn(
+      "[toolSystem] Failed to load react-native-fs; file system operations will be limited.",
+      error,
+    );
+    RNFS = null;
+  }
+} else {
+  try {
+    nodeFs = require("fs").promises;
+  } catch (error) {
+    nodeFs = null;
+    console.warn(
+      "[toolSystem] Node fs.promises is unavailable; file system tool cannot access the local disk.",
+      error,
+    );
+  }
+
+  try {
+    nodePath = require("path");
+  } catch {
+    nodePath = null;
+  }
+}
+
+const hasOwn = (object, key) =>
+  object != null && Object.prototype.hasOwnProperty.call(object, key);
+
+const toTrimmedString = (value) =>
+  typeof value === "string" ? value.trim() : "";
+
+const toIsoDateString = (value) => {
+  if (!value) {
+    return null;
+  }
+  const date =
+    value instanceof Date
+      ? value
+      : typeof value === "number" || typeof value === "string"
+        ? new Date(value)
+        : null;
+  if (date && !Number.isNaN(date.getTime())) {
+    return date.toISOString();
+  }
+  return null;
+};
+
+const pathDirname = (targetPath) => {
+  if (!targetPath) {
+    return "";
+  }
+  if (nodePath) {
+    return nodePath.dirname(targetPath);
+  }
+  const normalised = targetPath.replace(/\\+/g, "/");
+  const index = normalised.lastIndexOf("/");
+  if (index <= 0) {
+    return normalised.startsWith("/") ? "/" : "";
+  }
+  return normalised.slice(0, index);
+};
+
+const joinPath = (base, segment) => {
+  if (nodePath) {
+    return nodePath.join(base, segment);
+  }
+  if (!base) {
+    return segment;
+  }
+  const trimmed = base.replace(/[\\/]+$/, "");
+  return `${trimmed}/${segment}`;
+};
+
+const ensureDirectoryExists = async (filePath) => {
+  const directory = pathDirname(filePath);
+  if (
+    !directory ||
+    directory === "." ||
+    directory === filePath ||
+    directory === "/"
+  ) {
+    return;
+  }
+  if (RNFS) {
+    const exists = await RNFS.exists(directory);
+    if (!exists) {
+      await RNFS.mkdir(directory);
+    }
+    return;
+  }
+  if (nodeFs) {
+    await nodeFs.mkdir(directory, { recursive: true });
+  }
+};
+
+const getPathStats = async (targetPath) => {
+  if (RNFS) {
+    try {
+      return await RNFS.stat(targetPath);
+    } catch {
+      return null;
+    }
+  }
+
+  if (nodeFs) {
+    try {
+      return await nodeFs.stat(targetPath);
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+};
+
+const pathExists = async (targetPath) =>
+  Boolean(await getPathStats(targetPath));
+
+const isDirectoryStat = (stats) => {
+  if (!stats) {
+    return false;
+  }
+  if (typeof stats.isDirectory === "function") {
+    return stats.isDirectory();
+  }
+  if (typeof stats.isDirectory === "boolean") {
+    return stats.isDirectory;
+  }
+  return false;
+};
+
+const resolveOptionValue = (
+  key,
+  {
+    originalParameters = {},
+    contextOptions = {},
+    parameterValues = {},
+    fallback,
+  },
+) => {
+  if (hasOwn(originalParameters, key)) {
+    return originalParameters[key];
+  }
+  if (hasOwn(contextOptions, key)) {
+    return contextOptions[key];
+  }
+  if (hasOwn(parameterValues, key)) {
+    return parameterValues[key];
+  }
+  return fallback;
+};
+
+const matchesType = (expectedType, value) => {
+  switch (expectedType) {
+    case "string":
+      return typeof value === "string";
+    case "number":
+      return typeof value === "number" && !Number.isNaN(value);
+    case "boolean":
+      return typeof value === "boolean";
+    case "array":
+      return Array.isArray(value);
+    case "object":
+      return (
+        value !== null && typeof value === "object" && !Array.isArray(value)
+      );
+    default:
+      return true;
+  }
+};
+
+const normalizeProvider = (value) => {
+  if (typeof value !== "string") {
+    return DEFAULT_PROVIDER;
+  }
+  const normalised = value.trim().toLowerCase();
+  if (SUPPORTED_PROVIDERS.has(normalised)) {
+    return normalised;
+  }
+  return DEFAULT_PROVIDER;
+};
+
+const normalizeTimeRange = (value) => {
+  if (typeof value !== "string") {
+    return DEFAULT_TIME_RANGE;
+  }
+  const normalised = value.trim().toLowerCase();
+  if (SUPPORTED_TIME_RANGES.has(normalised)) {
+    return normalised;
+  }
+  return DEFAULT_TIME_RANGE;
+};
+
+const normalizeSafeSearch = (value) => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim().toLowerCase();
+    if (trimmed === "true") {
+      return true;
+    }
+    if (trimmed === "false") {
+      return false;
+    }
+  }
+  if (typeof value === "number") {
+    return value !== 0;
+  }
+  return DEFAULT_SAFE_SEARCH;
+};
+
+const normalizeMaxResults = (value) => {
+  const numeric =
+    typeof value === "number" && !Number.isNaN(value)
+      ? value
+      : typeof value === "string" && value.trim() !== ""
+        ? Number(value)
+        : DEFAULT_MAX_RESULTS;
+  if (!Number.isFinite(numeric)) {
+    return DEFAULT_MAX_RESULTS;
+  }
+  const integer = Math.floor(numeric);
+  if (integer < 1) {
+    return 1;
+  }
+  if (integer > MAX_RESULTS_CAP) {
+    return MAX_RESULTS_CAP;
+  }
+  return integer;
+};
+
+const normalizeSearchResults = (results, limit) => {
+  if (!Array.isArray(results)) {
+    return [];
+  }
+
+  return results
+    .map((item) => {
+      if (!item || typeof item !== "object") {
+        return null;
+      }
+      const title =
+        toTrimmedString(item.title) ||
+        toTrimmedString(item.name) ||
+        toTrimmedString(item.url);
+      const url = toTrimmedString(item.url);
+      const snippet =
+        toTrimmedString(item.snippet) ||
+        toTrimmedString(item.description) ||
+        toTrimmedString(item.content);
+
+      if (!title && !url && !snippet) {
+        return null;
+      }
+
+      return {
+        title,
+        url,
+        snippet,
+      };
+    })
+    .filter(Boolean)
+    .slice(0, limit);
+};
+
+const normalizeDirectoryEntriesFromRN = (entries) =>
+  entries.map((entry) => ({
+    name: entry.name,
+    path: entry.path,
+    isFile:
+      typeof entry.isFile === "function"
+        ? entry.isFile()
+        : Boolean(entry.isFile),
+    isDirectory:
+      typeof entry.isDirectory === "function"
+        ? entry.isDirectory()
+        : Boolean(entry.isDirectory),
+    size:
+      typeof entry.size === "number" && Number.isFinite(entry.size)
+        ? entry.size
+        : null,
+    modifiedAt: toIsoDateString(entry.mtime),
+  }));
+
+const listNodeDirectory = async (directoryPath) => {
+  if (!nodeFs) {
+    throw new Error("Node file system is not available");
+  }
+  const dirents = await nodeFs.readdir(directoryPath, { withFileTypes: true });
+  const entries = await Promise.all(
+    dirents.map(async (dirent) => {
+      const entryPath = joinPath(directoryPath, dirent.name);
+      let stats = null;
+      try {
+        stats = await nodeFs.stat(entryPath);
+      } catch {
+        stats = null;
+      }
+      return {
+        name: dirent.name,
+        path: entryPath,
+        isFile: dirent.isFile(),
+        isDirectory: dirent.isDirectory(),
+        size: stats ? stats.size : null,
+        modifiedAt: stats ? toIsoDateString(stats.mtime) : null,
+      };
+    }),
+  );
+  return entries;
+};
+
 export class ToolRegistry {
   constructor() {
     this.tools = new Map();
@@ -26,12 +359,24 @@ export class ToolRegistry {
       throw new Error(`Tool ${toolName} not found`);
     }
 
+    const normalizedParameters = this.applyParameterDefaults(
+      tool,
+      parameters && typeof parameters === "object" ? parameters : {},
+    );
+
     try {
       // Validate parameters
-      this.validateParameters(tool, parameters);
+      this.validateParameters(tool, normalizedParameters);
 
       // Execute the tool
-      const result = await tool.execute(parameters, context);
+      const executionContext =
+        context && typeof context === "object" ? { ...context } : {};
+      if (!hasOwn(executionContext, "originalParameters")) {
+        executionContext.originalParameters =
+          parameters && typeof parameters === "object" ? parameters : {};
+      }
+
+      const result = await tool.execute(normalizedParameters, executionContext);
 
       // Update tool usage statistics
       tool.lastUsed = new Date();
@@ -40,17 +385,18 @@ export class ToolRegistry {
       // Log execution
       this.executionHistory.push({
         tool: toolName,
-        parameters,
+        parameters: normalizedParameters,
         result,
         timestamp: new Date(),
         success: true,
+        ...(this.extractResultAnalytics(result) || {}),
       });
 
       return result;
     } catch (error) {
       this.executionHistory.push({
         tool: toolName,
-        parameters,
+        parameters: normalizedParameters,
         error: error.message,
         timestamp: new Date(),
         success: false,
@@ -60,17 +406,64 @@ export class ToolRegistry {
     }
   }
 
-  validateParameters(tool, parameters) {
+  applyParameterDefaults(tool, parameters = {}) {
+    if (!tool.parameters) {
+      return { ...parameters };
+    }
+
+    const resolved = { ...parameters };
+    for (const [paramName, paramConfig] of Object.entries(tool.parameters)) {
+      if (resolved[paramName] === undefined && hasOwn(paramConfig, "default")) {
+        resolved[paramName] =
+          typeof paramConfig.default === "function"
+            ? paramConfig.default()
+            : paramConfig.default;
+      }
+    }
+    return resolved;
+  }
+
+  extractResultAnalytics(result) {
+    if (!result || typeof result !== "object") {
+      return null;
+    }
+    if (Array.isArray(result.results)) {
+      return { resultCount: result.results.length };
+    }
+    if (Array.isArray(result.entries)) {
+      return { resultCount: result.entries.length };
+    }
+    return null;
+  }
+
+  validateParameters(tool, parameters = {}) {
     if (tool.parameters) {
       for (const [paramName, paramConfig] of Object.entries(tool.parameters)) {
-        if (paramConfig.required && !(paramName in parameters)) {
+        const hasValue = hasOwn(parameters, paramName);
+        if (paramConfig.required && !hasValue) {
           throw new Error(`Missing required parameter: ${paramName}`);
         }
 
-        if (parameters[paramName] !== undefined && paramConfig.validate) {
-          if (!paramConfig.validate(parameters[paramName])) {
-            throw new Error(`Invalid value for parameter: ${paramName}`);
-          }
+        if (!hasValue) {
+          continue;
+        }
+
+        const value = parameters[paramName];
+
+        if (paramConfig.type && !matchesType(paramConfig.type, value)) {
+          throw new Error(
+            `Invalid type for parameter ${paramName}: expected ${paramConfig.type}`,
+          );
+        }
+
+        if (paramConfig.enum && !paramConfig.enum.includes(value)) {
+          throw new Error(
+            `Invalid value for parameter: ${paramName}. Expected one of ${paramConfig.enum.join(", ")}`,
+          );
+        }
+
+        if (paramConfig.validate && !paramConfig.validate(value)) {
+          throw new Error(`Invalid value for parameter: ${paramName}`);
         }
       }
     }
@@ -339,27 +732,113 @@ export const builtInTools = {
         type: "number",
         required: false,
         description: "Maximum number of results to return",
-        default: 5,
+        default: DEFAULT_MAX_RESULTS,
+        validate: (value) =>
+          Number.isInteger(value) && value > 0 && value <= MAX_RESULTS_CAP,
+      },
+      provider: {
+        type: "string",
+        required: false,
+        description: "Search provider to use",
+        enum: Array.from(SUPPORTED_PROVIDERS),
+      },
+      timeRange: {
+        type: "string",
+        required: false,
+        description: "Time range for results",
+        enum: Array.from(SUPPORTED_TIME_RANGES),
+      },
+      safeSearch: {
+        type: "boolean",
+        required: false,
+        description: "Enable safe search filtering",
       },
     },
-    execute: async (_parameters, _context) => {
-      // Implementation would depend on the search API
-      // This is a placeholder implementation
-      return {
-        results: [
-          {
-            title: "Result 1",
-            url: "https://example.com/1",
-            snippet: "Snippet 1",
-          },
-          {
-            title: "Result 2",
-            url: "https://example.com/2",
-            snippet: "Snippet 2",
-          },
-        ],
-        success: true,
-      };
+    execute: async (parameters, context = {}) => {
+      const originalParameters =
+        context && typeof context.originalParameters === "object"
+          ? context.originalParameters
+          : {};
+      const contextOptions =
+        context && typeof context.webSearch === "object"
+          ? context.webSearch
+          : {};
+
+      const provider = normalizeProvider(
+        resolveOptionValue("provider", {
+          originalParameters,
+          contextOptions,
+          parameterValues: parameters,
+          fallback: DEFAULT_PROVIDER,
+        }),
+      );
+
+      const timeRange = normalizeTimeRange(
+        resolveOptionValue("timeRange", {
+          originalParameters,
+          contextOptions,
+          parameterValues: parameters,
+          fallback: DEFAULT_TIME_RANGE,
+        }),
+      );
+
+      const safeSearch = normalizeSafeSearch(
+        resolveOptionValue("safeSearch", {
+          originalParameters,
+          contextOptions,
+          parameterValues: parameters,
+          fallback: DEFAULT_SAFE_SEARCH,
+        }),
+      );
+
+      const maxResults = normalizeMaxResults(
+        resolveOptionValue("maxResults", {
+          originalParameters,
+          contextOptions,
+          parameterValues: parameters,
+          fallback: DEFAULT_MAX_RESULTS,
+        }),
+      );
+
+      try {
+        const hasValidKey = await validateSearchApiKeys(provider);
+        if (!hasValidKey) {
+          throw new Error(`API key not configured for ${provider} search`);
+        }
+
+        const searchResults = await searchService.performSearch(
+          provider,
+          parameters.query,
+          maxResults,
+          timeRange,
+          safeSearch,
+        );
+
+        const normalizedResults = normalizeSearchResults(
+          searchResults,
+          maxResults,
+        );
+
+        return {
+          success: true,
+          provider,
+          query: parameters.query,
+          timeRange,
+          safeSearch,
+          resultCount: normalizedResults.length,
+          results: normalizedResults,
+        };
+      } catch (error) {
+        console.error("Web search failed:", error);
+        return {
+          success: false,
+          provider,
+          query: parameters.query,
+          timeRange,
+          safeSearch,
+          error: error.message,
+        };
+      }
     },
   },
 
@@ -383,10 +862,119 @@ export const builtInTools = {
         description: "Content to write (for write operations )",
       },
     },
-    execute: async (_parameters) => {
-      // Implementation would use react-native-fs or similar
-      // This is a placeholder implementation
-      return { success: true, message: "File operation completed" };
+    execute: async (parameters) => {
+      const { operation, path: targetPath, content } = parameters;
+
+      try {
+        if (!targetPath || typeof targetPath !== "string") {
+          throw new Error(
+            "A valid path is required for file system operations",
+          );
+        }
+
+        switch (operation) {
+          case "read": {
+            if (!(await pathExists(targetPath))) {
+              throw new Error(`File not found at ${targetPath}`);
+            }
+
+            if (RNFS) {
+              const data = await RNFS.readFile(targetPath, "utf8");
+              return {
+                success: true,
+                operation,
+                path: targetPath,
+                content: data,
+                bytesRead: typeof data === "string" ? data.length : undefined,
+              };
+            }
+
+            if (nodeFs) {
+              const data = await nodeFs.readFile(targetPath, "utf8");
+              return {
+                success: true,
+                operation,
+                path: targetPath,
+                content: data,
+                bytesRead: typeof data === "string" ? data.length : undefined,
+              };
+            }
+
+            throw new Error("No file system implementation available");
+          }
+          case "write": {
+            if (content === undefined || content === null) {
+              throw new Error("Content is required for write operations");
+            }
+
+            const dataToWrite =
+              typeof content === "string"
+                ? content
+                : JSON.stringify(content, null, 2);
+
+            await ensureDirectoryExists(targetPath);
+
+            if (RNFS) {
+              await RNFS.writeFile(targetPath, dataToWrite, "utf8");
+            } else if (nodeFs) {
+              await nodeFs.writeFile(targetPath, dataToWrite, "utf8");
+            } else {
+              throw new Error("No file system implementation available");
+            }
+
+            return {
+              success: true,
+              operation,
+              path: targetPath,
+              bytesWritten:
+                typeof dataToWrite === "string"
+                  ? dataToWrite.length
+                  : undefined,
+            };
+          }
+          case "list": {
+            const stats = await getPathStats(targetPath);
+            if (!stats) {
+              throw new Error(`Path not found at ${targetPath}`);
+            }
+            if (!isDirectoryStat(stats)) {
+              throw new Error(`Path is not a directory: ${targetPath}`);
+            }
+
+            if (RNFS) {
+              const entries = await RNFS.readDir(targetPath);
+              return {
+                success: true,
+                operation,
+                path: targetPath,
+                entries: normalizeDirectoryEntriesFromRN(entries),
+              };
+            }
+
+            if (nodeFs) {
+              const entries = await listNodeDirectory(targetPath);
+              return {
+                success: true,
+                operation,
+                path: targetPath,
+                entries,
+              };
+            }
+
+            throw new Error("No file system implementation available");
+          }
+          default:
+            throw new Error(`Unsupported file system operation: ${operation}`);
+        }
+      } catch (error) {
+        console.error("File system operation failed:", error);
+        return {
+          success: false,
+          operation,
+          path: targetPath,
+          error: error.message,
+        };
+      }
     },
   },
 };


### PR DESCRIPTION
## Summary
- integrate the built-in `webSearch` tool with `SearchService`, validating provider configuration and normalising API responses
- add full read/write/list support to the `fileSystem` tool using RNFS on React Native or Node's fs polyfill with defensive error handling
- enhance `ToolRegistry` to apply parameter defaults, enforce validation (including enums), and capture execution analytics to reflect new result payloads

## Testing
- CI=1 npm test
- npm run lint
- npm run format:check


------
https://chatgpt.com/codex/tasks/task_e_68cf317edec083338977976319cdc49f