### PR TITLE
feat: integrate MLX runtime into iOS Turbo module

### DIFF
--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -46,7 +46,7 @@
 - `LLMService` prefers the generated TurboModule surface (`NativeLLM`) and falls back to legacy `NativeModules`, enabling the same agent loop to run on web, iOS, or Android without code changes while still routing through plugin management and KV-cache bookkeeping.【F:src/services/llmService.js†L1-L187】
 - `registerTurboModules.ts` invokes `TurboModuleRegistry.get` so React Native codegen keeps the LLM interface active, and `MLXModule.ts` wraps the iOS bridge with explicit error messages when the Swift/ObjC implementation is missing.【F:src/registerTurboModules.ts†L1-L15】【F:src/native/MLXModule.ts†L1-L25】
 - On Android, `MonGarsPackage` registers every TurboModule with the bridge, `LlamaTurboModule` exposes the llama.cpp controls to JavaScript, and the JNI layer in `llama_jni.cpp` enforces context/thread limits while providing generation, embedding, and cache maintenance hooks.【F:android/app/src/main/java/com/mongars/MonGarsPackage.java†L11-L45】【F:android/app/src/main/java/com/mongars/LlamaTurboModule.java†L14-L199】【F:android/app/src/main/cpp/llama_jni.cpp†L241-L404】
-- iOS mirrors the pattern: `LLM.swift` defines the TurboModule protocol and implementation, ensuring every method the JS agent expects—model lifecycle, inference, embeddings, cache control—bridges cleanly into Swift.【F:ios/MyOfflineLLMApp/Turbo/LLM.swift†L6-L200】
+- iOS mirrors the pattern: `LLM.swift` now drives an MLX-backed runtime that loads model containers, streams tokens through `MLXEvents`, surfaces embeddings, reports CPU/memory metrics, and manages KV-cache boundaries so the TurboModule matches Android’s surface while staying fully on-device.【F:ios/MyOfflineLLMApp/Turbo/LLM.swift†L53-L610】
 
 ## Extending the Agent
 

--- a/ios/MyOfflineLLMApp/Turbo/LLM.swift
+++ b/ios/MyOfflineLLMApp/Turbo/LLM.swift
@@ -1,110 +1,377 @@
 import Foundation
 import Darwin
-// React types are exposed via the bridging header; no Swift module import
-// is required here.
+import os
+@preconcurrency import MLX
+@preconcurrency import MLXLLM
+@preconcurrency import MLXLMCommon
 
-/// A lightweight protocol that describes the surface area of our LLM
-/// TurboModule.  In the original project this protocol is generated
-/// automatically by the React Native codegen and lives in a separate
-/// file (`LLMSpec`).  When the generated file is missing or fails to
-/// build the compiler will emit an error like
-/// “cannot find type `LLMSpec` in scope”.  Defining the protocol
-/// ourselves ensures the module still compiles and provides a clear
-/// contract for the methods we expose to JavaScript.  If a generated
-/// version exists it will override this one at compile time.
-@objc public protocol LLMSpec {
-  @objc(loadModel:options:resolve:reject:)
-  func loadModel(_ path: String,
-                 options: [AnyHashable : Any]?,
-                 resolve: @escaping RCTPromiseResolveBlock,
-                 reject: @escaping RCTPromiseRejectBlock)
+// React types are exposed via the bridging header; no explicit import is required.
 
-  @objc(unloadModel:reject:)
-  func unloadModel(_ resolve: @escaping RCTPromiseResolveBlock,
-                   reject: @escaping RCTPromiseRejectBlock)
+private enum NativeLLMError: LocalizedError {
+  case modelNotLoaded
+  case modelNotFound
+  case embeddingUnavailable(String)
 
-  @objc(generate:options:resolve:reject:)
-  func generate(_ prompt: String,
-                options: [AnyHashable : Any]?,
-                resolve: @escaping RCTPromiseResolveBlock,
-                reject: @escaping RCTPromiseRejectBlock)
+  var errorDescription: String? {
+    switch self {
+    case .modelNotLoaded:
+      return "No model has been loaded"
+    case .modelNotFound:
+      return "Unable to locate a compatible model configuration"
+    case .embeddingUnavailable(let reason):
+      return "Embedding unavailable: \(reason)"
+    }
+  }
 
-  @objc(embed:resolve:reject:)
-  func embed(_ text: String,
-             resolve: @escaping RCTPromiseResolveBlock,
-             reject: @escaping RCTPromiseRejectBlock)
-
-  @objc(getPerformanceMetrics:reject:)
-  func getPerformanceMetrics(_ resolve: @escaping RCTPromiseResolveBlock,
-                             reject: @escaping RCTPromiseRejectBlock)
-
-  @objc(getKVCacheSize:reject:)
-  func getKVCacheSize(_ resolve: @escaping RCTPromiseResolveBlock,
-                      reject: @escaping RCTPromiseRejectBlock)
-
-  @objc(getKVCacheMaxSize:reject:)
-  func getKVCacheMaxSize(_ resolve: @escaping RCTPromiseResolveBlock,
-                         reject: @escaping RCTPromiseRejectBlock)
-
-  @objc(clearKVCache:reject:)
-  func clearKVCache(_ resolve: @escaping RCTPromiseResolveBlock,
-                    reject: @escaping RCTPromiseRejectBlock)
-
-  @objc(addMessageBoundary:reject:)
-  func addMessageBoundary(_ resolve: @escaping RCTPromiseResolveBlock,
-                          reject: @escaping RCTPromiseRejectBlock)
-
-  @objc(adjustPerformanceMode:resolve:reject:)
-  func adjustPerformanceMode(_ mode: String,
-                             resolve: @escaping RCTPromiseResolveBlock,
-                             reject: @escaping RCTPromiseRejectBlock)
+  var code: String {
+    switch self {
+    case .modelNotLoaded:
+      return "NO_MODEL"
+    case .modelNotFound:
+      return "ENOENT"
+    case .embeddingUnavailable:
+      return "EMBED_UNAVAILABLE"
+    }
+  }
 }
 
-/// The concrete implementation of our LLM TurboModule.  This class
-/// conforms to the `LLMSpec` protocol defined above and exposes
-/// asynchronous methods to JavaScript.  The methods here are
-/// intentionally simple placeholders: `loadModel` checks that a
-/// directory exists on disk, `generate` echoes its prompt back, and
-/// various getter methods return stubbed metrics.  The real
-/// functionality can be filled in later once the native ML model
-/// integration is ready.
-@objc(LLM)
-public final class LLM: NSObject, LLMSpec {
-  /// Path to the currently loaded model, if any.  Loading a model
-  /// simply records the folder’s existence; no heavy parsing is
-  /// performed.  When this property is `nil` the module behaves as
-  /// though no model is loaded.
-  private var modelPath: String? = nil
+private struct LoadDetails: Sendable {
+  let identifier: String
+  let contextLength: Int?
+}
 
-  /// Simple in-memory key/value cache used by the `generate` method to
-  /// memoise prompts and their outputs.  This illustrates a robust
-  /// implementation of caching without relying on external ML
-  /// libraries.
-  private var kvCache: [String: String] = [:]
+private struct GenerationSummary: Sendable {
+  let text: String
+  let promptTokens: Int
+  let generatedTokens: Int
+  let duration: TimeInterval
+  let kvCacheSize: Int
+  let kvCacheMax: Int?
+  let toolCalls: [[String: Any]]
+}
+
+private actor NativeLLMRuntime {
+  private let fallbackModelIDs: [String]
+  private var container: ModelContainer?
+  private var configuration: ModelConfiguration?
+  private var conversation: [Chat.Message] = []
+  private var cache: [KVCache] = []
+  private var messageBoundaries: [Int] = []
+  private var currentMaxKV: Int?
+  private var lastCompletion: GenerateCompletionInfo?
+
+  init(fallbackModelIDs: [String]) {
+    self.fallbackModelIDs = fallbackModelIDs
+  }
+
+  var isLoaded: Bool { container != nil }
+
+  func loadModel(path: String?, options: [String: Any]) async throws -> LoadDetails {
+    let candidates = configurations(for: path, options: options)
+    guard !candidates.isEmpty else { throw NativeLLMError.modelNotFound }
+
+    var lastError: Error?
+    for configuration in candidates {
+      do {
+        let container = try await LLMModelFactory.shared.loadContainer(configuration: configuration)
+        self.container = container
+        self.configuration = configuration
+        conversation.removeAll()
+        cache.removeAll()
+        messageBoundaries.removeAll()
+        lastCompletion = nil
+
+        let requestedContext = options["contextLength"] as? NSNumber
+        let defaultContext = requestedContext.map { Int(truncating: $0) }
+        self.currentMaxKV = defaultContext ?? self.currentMaxKV ?? 4096
+
+        return LoadDetails(identifier: configuration.name, contextLength: currentMaxKV)
+      } catch {
+        lastError = error
+      }
+    }
+
+    throw lastError ?? NativeLLMError.modelNotFound
+  }
+
+  func unload() {
+    container = nil
+    configuration = nil
+    conversation.removeAll()
+    cache.removeAll()
+    messageBoundaries.removeAll()
+    lastCompletion = nil
+  }
+
+  func clearCache() {
+    cache.removeAll()
+    conversation.removeAll()
+    messageBoundaries.removeAll()
+    lastCompletion = nil
+  }
+
+  func setMaxKVCache(_ value: Int?) {
+    currentMaxKV = value
+    cache.removeAll()
+  }
+
+  func addBoundary() {
+    messageBoundaries.append(conversation.count)
+    if messageBoundaries.count > 8 {
+      messageBoundaries.removeFirst(messageBoundaries.count - 8)
+    }
+  }
+
+  func kvCacheSize() -> Int {
+    cache.first?.offset ?? 0
+  }
+
+  func kvCacheMaxSize() -> Int {
+    currentMaxKV ?? 0
+  }
+
+  func latestCompletion() -> GenerateCompletionInfo? {
+    lastCompletion
+  }
+
+  func generate(prompt: String,
+                options: [String: Any],
+                onChunk: (@Sendable (String) -> Void)?) async throws -> GenerationSummary {
+    guard let container else { throw NativeLLMError.modelNotLoaded }
+
+    var parameters = parameters(from: options)
+    parameters.maxKVSize = currentMaxKV
+
+    var collectedText = ""
+    var completionInfo: GenerateCompletionInfo?
+    var collectedToolCalls: [[String: Any]] = []
+    let messages = conversation + [.user(prompt)]
+
+    try await container.perform { context in
+      let userInput = UserInput(chat: messages)
+      let input = try await context.processor.prepare(input: userInput)
+
+      if cache.isEmpty {
+        cache = context.model.newCache(parameters: parameters)
+      }
+
+      let stream = try MLXLMCommon.generate(input: input,
+                                            cache: cache,
+                                            parameters: parameters,
+                                            context: context)
+
+      for await event in stream {
+        if let chunk = event.chunk, !chunk.isEmpty {
+          collectedText.append(chunk)
+          onChunk?(chunk)
+        }
+        if let info = event.info {
+          completionInfo = info
+        }
+        if let call = event.toolCall {
+          let arguments = call.function.arguments.mapValues { $0.anyValue }
+          collectedToolCalls.append(["name": call.function.name, "arguments": arguments])
+        }
+      }
+    }
+
+    conversation = messages + [.assistant(collectedText)]
+    pruneConversationIfNeeded()
+    lastCompletion = completionInfo
+
+    let summary = GenerationSummary(
+      text: collectedText,
+      promptTokens: completionInfo?.promptTokenCount ?? 0,
+      generatedTokens: completionInfo?.generationTokenCount ?? 0,
+      duration: (completionInfo?.promptTime ?? 0) + (completionInfo?.generateTime ?? 0),
+      kvCacheSize: cache.first?.offset ?? 0,
+      kvCacheMax: currentMaxKV,
+      toolCalls: collectedToolCalls
+    )
+
+    return summary
+  }
+
+  func embedding(for text: String) async throws -> [Double] {
+    guard let container else { throw NativeLLMError.modelNotLoaded }
+
+    return try await container.perform { context -> [Double] in
+      let userInput = UserInput(chat: [.user(text)])
+      let input = try await context.processor.prepare(input: userInput)
+
+      var caches = context.model.newCache(parameters: nil)
+      let prepared = try context.model.prepare(input, cache: caches, windowSize: nil)
+
+      let output: LMOutput
+      switch prepared {
+      case .logits(let logits):
+        output = logits
+      case .tokens(let tokens):
+        output = context.model(tokens, cache: caches, state: nil)
+      }
+
+      var logits = output.logits
+      if logits.ndim >= 2 {
+        logits = logits[0, -1, 0...]
+      }
+
+      let evaluated = logits.asType(.float32)
+      let values = evaluated.asArray(Float.self)
+      return values.map { Double($0) }
+    }
+  }
+
+  private func configurations(for path: String?, options: [String: Any]) -> [ModelConfiguration] {
+    var results: [ModelConfiguration] = []
+    if let explicit = options["modelId"] as? String,
+       !explicit.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      results.append(ModelConfiguration(id: explicit))
+    }
+
+    if let rawPath = path?.trimmingCharacters(in: .whitespacesAndNewlines), !rawPath.isEmpty {
+      var isDirectory: ObjCBool = false
+      if FileManager.default.fileExists(atPath: rawPath, isDirectory: &isDirectory) {
+        if isDirectory.boolValue {
+          results.append(ModelConfiguration(directory: URL(fileURLWithPath: rawPath)))
+        } else {
+          let parent = URL(fileURLWithPath: rawPath).deletingLastPathComponent()
+          if FileManager.default.fileExists(atPath: parent.path, isDirectory: &isDirectory),
+             isDirectory.boolValue {
+            results.append(ModelConfiguration(directory: parent))
+          }
+        }
+      }
+
+      if rawPath.contains("/") && !rawPath.hasPrefix("/") {
+        results.append(ModelConfiguration(id: rawPath))
+      }
+    }
+
+    for fallback in fallbackModelIDs {
+      results.append(ModelConfiguration(id: fallback))
+    }
+
+    var seen: Set<String> = []
+    return results.filter { config in
+      let key: String
+      switch config.id {
+      case .id(let id, let revision):
+        key = "id:\(id)#\(revision)"
+      case .directory(let url):
+        key = "dir:\(url.path)"
+      }
+      if seen.contains(key) {
+        return false
+      }
+      seen.insert(key)
+      return true
+    }
+  }
+
+  private func parameters(from options: [String: Any]) -> GenerateParameters {
+    var parameters = GenerateParameters()
+
+    if let maxTokens = options["maxTokens"] as? NSNumber {
+      parameters.maxTokens = max(0, Int(truncating: maxTokens))
+    }
+
+    if let temperature = options["temperature"] as? NSNumber {
+      parameters.temperature = Float(truncating: temperature)
+    }
+
+    if let topP = options["topP"] as? NSNumber {
+      parameters.topP = min(max(Float(truncating: topP), 0.01), 1.0)
+    } else if let topK = options["topK"] as? NSNumber {
+      parameters.topP = topPValue(for: Int(truncating: topK))
+    }
+
+    if let kvBits = options["kvBits"] as? NSNumber {
+      parameters.kvBits = Int(truncating: kvBits)
+    }
+
+    if let kvGroupSize = options["kvGroupSize"] as? NSNumber {
+      parameters.kvGroupSize = Int(truncating: kvGroupSize)
+    }
+
+    if let kvStart = options["quantizedKVStart"] as? NSNumber {
+      parameters.quantizedKVStart = Int(truncating: kvStart)
+    }
+
+    if let repetitionPenalty = options["repetitionPenalty"] as? NSNumber {
+      parameters.repetitionPenalty = Float(truncating: repetitionPenalty)
+    }
+
+    if let repetitionContext = options["repetitionContext"] as? NSNumber {
+      parameters.repetitionContextSize = max(0, Int(truncating: repetitionContext))
+    }
+
+    return parameters
+  }
+
+  private func topPValue(for topK: Int) -> Float {
+    guard topK > 0 else { return 0.99 }
+    let normalized = min(max(Float(topK), 1), 400)
+    let baseline: Float = 40
+    let mapped = normalized / baseline
+    return max(0.1, min(mapped, 0.99))
+  }
+
+  private func pruneConversationIfNeeded() {
+    let maxMessages = 32
+    guard conversation.count > maxMessages else { return }
+
+    let dropCount: Int
+    if let boundary = messageBoundaries.first(where: { $0 >= conversation.count - maxMessages }) {
+      dropCount = boundary
+    } else {
+      dropCount = conversation.count - maxMessages
+    }
+
+    guard dropCount > 0, dropCount <= conversation.count else { return }
+    conversation.removeFirst(dropCount)
+    messageBoundaries = messageBoundaries.map { $0 - dropCount }.filter { $0 >= 0 }
+  }
+}
+
+@objc(LLM)
+@MainActor
+public final class LLM: NSObject, LLMSpec {
+  private let runtime: NativeLLMRuntime
+  private var lastCPUSampleTime: CFAbsoluteTime?
+  private var lastCPUTime: Double = 0
+  private let logger = Logger(subsystem: "com.27pm.monGARS", category: "LLM")
+
+  override public init() {
+    runtime = NativeLLMRuntime(fallbackModelIDs: Self.loadFallbackModels())
+    super.init()
+  }
+
+  // MARK: - LLMSpec
 
   public func loadModel(_ path: String,
                         options: [AnyHashable : Any]?,
                         resolve: @escaping RCTPromiseResolveBlock,
                         reject: @escaping RCTPromiseRejectBlock) {
-    // Check that the directory exists on disk.  If it does, record the
-    // path as the current model.  You could extend this to read
-    // configuration files or model metadata from within the folder.
-    let exists = FileManager.default.fileExists(atPath: path)
-    if exists {
-      self.modelPath = path
-      self.kvCache.removeAll()
-      resolve(true)
-    } else {
-      self.modelPath = nil
-      resolve(false)
+    let normalized = normalize(options)
+    Task(priority: .userInitiated) {
+      do {
+        let details = try await runtime.loadModel(path: path, options: normalized)
+        var payload: [String: Any] = [
+          "status": "loaded",
+          "model": details.identifier
+        ]
+        payload["contextLength"] = boxOptional(details.contextLength)
+        payload["kvCacheMax"] = boxOptional(details.contextLength)
+        resolveOnMainThread(resolve, payload)
+      } catch {
+        rejectOnMainThread(reject, error)
+      }
     }
   }
 
   public func unloadModel(_ resolve: @escaping RCTPromiseResolveBlock,
                           reject: @escaping RCTPromiseRejectBlock) {
-    // Clear the loaded model and any cached state.
-    self.modelPath = nil
-    self.kvCache.removeAll()
+    runtime.unload()
     resolve(true)
   }
 
@@ -112,94 +379,232 @@ public final class LLM: NSObject, LLMSpec {
                        options: [AnyHashable : Any]?,
                        resolve: @escaping RCTPromiseResolveBlock,
                        reject: @escaping RCTPromiseRejectBlock) {
-    guard let _ = self.modelPath else {
-      // When no model is loaded return an empty string.  This avoids
-      // undefined behaviour and aligns with the Android implementation.
-      resolve("")
-      return
+    Task(priority: .userInitiated) {
+      guard await runtime.isLoaded else {
+        rejectOnMainThread(reject, NativeLLMError.modelNotLoaded)
+        return
+      }
+
+      let normalized = normalize(options)
+      do {
+        let summary = try await runtime.generate(prompt: prompt, options: normalized) { chunk in
+          Task { @MainActor in MLXEvents.shared?.emitToken(chunk) }
+        }
+        Task { @MainActor in MLXEvents.shared?.emitCompleted() }
+
+        var payload: [String: Any] = [
+          "text": summary.text,
+          "promptTokens": summary.promptTokens,
+          "completionTokens": summary.generatedTokens,
+          "duration": summary.duration,
+          "kvCacheSize": summary.kvCacheSize
+        ]
+        payload["kvCacheMax"] = boxOptional(summary.kvCacheMax)
+        if !summary.toolCalls.isEmpty {
+          payload["toolCalls"] = summary.toolCalls
+        }
+        resolveOnMainThread(resolve, payload)
+      } catch {
+        Task { @MainActor in
+          MLXEvents.shared?.emitError("EGEN", message: error.localizedDescription)
+        }
+        rejectOnMainThread(reject, error)
+      }
     }
-    // If we’ve already generated a response for this prompt return
-    // the cached result immediately.  This prevents repeated
-    // computation for identical inputs.
-    if let cached = kvCache[prompt] {
-      resolve(cached)
-      return
-    }
-    // A very simple generation algorithm: reverse the prompt and
-    // prefix it with a descriptive string.  In a real implementation
-    // you would call into your ML model here.
-    let reply = "Echo: " + String(prompt.reversed())
-    // Cache the result for future calls and return it.
-    kvCache[prompt] = reply
-    resolve(reply)
   }
 
   public func embed(_ text: String,
                     resolve: @escaping RCTPromiseResolveBlock,
                     reject: @escaping RCTPromiseRejectBlock) {
-    // Produce a simple embedding by converting the first 64 UTF‑8 code
-    // points of the string into double values and normalising them.
-    let scalars = text.unicodeScalars.prefix(64)
-    let maxCode = Double(0x10FFFF)
-    let vector = scalars.map { Double($0.value) / maxCode }
-    resolve(vector)
+    Task(priority: .userInitiated) {
+      do {
+        let vector = try await runtime.embedding(for: text)
+        resolveOnMainThread(resolve, vector)
+      } catch {
+        rejectOnMainThread(reject, error)
+      }
+    }
   }
 
   public func getPerformanceMetrics(_ resolve: @escaping RCTPromiseResolveBlock,
                                     reject: @escaping RCTPromiseRejectBlock) {
-    // Compute memory usage ratio using mach APIs.  This returns the
-    // fraction of physical memory currently used by the process.
-    var info = mach_task_basic_info()
-    var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4
-    let kerr = withUnsafeMutablePointer(to: &info) {
-      $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
-        task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
-      }
+    Task {
+      let info = await runtime.latestCompletion()
+      let metrics: [String: Any] = [
+        "memoryUsage": sampleMemoryUsage(),
+        "cpuUsage": sampleCPUUsage(),
+        "promptTokens": boxOptional(info?.promptTokenCount),
+        "completionTokens": boxOptional(info?.generationTokenCount),
+        "promptTime": boxOptional(info?.promptTime),
+        "generationTime": boxOptional(info?.generateTime),
+        "tokensPerSecond": boxOptional(info?.tokensPerSecond),
+        "promptTokensPerSecond": boxOptional(info?.promptTokensPerSecond)
+      ]
+      resolve(metrics)
     }
-    let memoryUsageRatio: Double
-    if kerr == KERN_SUCCESS {
-      let usedBytes = Double(info.resident_size)
-      let totalBytes = Double(ProcessInfo.processInfo.physicalMemory)
-      memoryUsageRatio = totalBytes > 0 ? usedBytes / totalBytes : 0.0
-    } else {
-      memoryUsageRatio = 0.0
-    }
-    // CPU usage is not trivial to compute precisely without private
-    // APIs.  For robustness we return `0` here.  You could replace
-    // this with a more sophisticated implementation if needed.
-    let cpuUsageRatio: Double = 0.0
-    resolve(["memoryUsage": memoryUsageRatio, "cpuUsage": cpuUsageRatio])
   }
 
   public func getKVCacheSize(_ resolve: @escaping RCTPromiseResolveBlock,
                              reject: @escaping RCTPromiseRejectBlock) {
-    resolve(kvCache.count)
+    Task {
+      let size = await runtime.kvCacheSize()
+      resolve(size)
+    }
   }
 
   public func getKVCacheMaxSize(_ resolve: @escaping RCTPromiseResolveBlock,
                                 reject: @escaping RCTPromiseRejectBlock) {
-    // For this simple implementation we don’t enforce a maximum size.
-    resolve(Int.max)
+    Task {
+      let size = await runtime.kvCacheMaxSize()
+      resolve(size)
+    }
   }
 
   public func clearKVCache(_ resolve: @escaping RCTPromiseResolveBlock,
                            reject: @escaping RCTPromiseRejectBlock) {
-    kvCache.removeAll()
-    resolve(true)
+    Task {
+      await runtime.clearCache()
+      resolve(NSNull())
+    }
   }
 
   public func addMessageBoundary(_ resolve: @escaping RCTPromiseResolveBlock,
                                  reject: @escaping RCTPromiseRejectBlock) {
-    // In a real chat model you might use this to separate messages.
-    // Here it does nothing but return true.
-    resolve(true)
+    Task {
+      await runtime.addBoundary()
+      resolve(NSNull())
+    }
   }
 
   public func adjustPerformanceMode(_ mode: String,
                                     resolve: @escaping RCTPromiseResolveBlock,
                                     reject: @escaping RCTPromiseRejectBlock) {
-    // Accept one of a handful of predefined strings and ignore the rest.
-    let validModes: Set<String> = ["high_quality", "balanced", "low_power"]
-    resolve(validModes.contains(mode))
+    Task {
+      switch mode {
+      case "low-memory", "power-saving":
+        await runtime.setMaxKVCache(2048)
+        resolve(true)
+      case "balanced":
+        await runtime.setMaxKVCache(4096)
+        resolve(true)
+      case "performance", "high_quality":
+        await runtime.setMaxKVCache(8192)
+        resolve(true)
+      default:
+        resolve(false)
+      }
+    }
+  }
+
+  // MARK: - Helpers
+
+  private func normalize(_ options: [AnyHashable: Any]?) -> [String: Any] {
+    guard let options else { return [:] }
+    var result: [String: Any] = [:]
+    for (key, value) in options {
+      guard let stringKey = key as? String else { continue }
+      result[stringKey] = value
+    }
+    return result
+  }
+
+  private func resolveOnMainThread(_ resolve: @escaping RCTPromiseResolveBlock, _ value: Any) {
+    if Thread.isMainThread {
+      resolve(value)
+    } else {
+      DispatchQueue.main.async { resolve(value) }
+    }
+  }
+
+  private func boxOptional<T>(_ value: T?) -> Any {
+    if let wrapped = value {
+      return wrapped
+    }
+    return NSNull()
+  }
+
+  private func rejectOnMainThread(_ reject: @escaping RCTPromiseRejectBlock, _ error: Error) {
+    let nsError = error as NSError
+    let code: String
+    if let nativeError = error as? NativeLLMError {
+      code = nativeError.code
+    } else {
+      code = nsError.domain
+    }
+
+    let description = error.localizedDescription
+    if Thread.isMainThread {
+      reject(code, description, error)
+    } else {
+      DispatchQueue.main.async {
+        reject(code, description, error)
+      }
+    }
+  }
+
+  private func sampleMemoryUsage() -> Double {
+    var info = mach_task_basic_info()
+    var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4
+    let result = withUnsafeMutablePointer(to: &info) {
+      $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+        task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+      }
+    }
+
+    guard result == KERN_SUCCESS else { return 0.0 }
+    let usedBytes = Double(info.resident_size)
+    let totalBytes = Double(ProcessInfo.processInfo.physicalMemory)
+    guard totalBytes > 0 else { return 0.0 }
+    return min(max(usedBytes / totalBytes, 0.0), 1.0)
+  }
+
+  private func sampleCPUUsage() -> Double {
+    var threadInfo = task_thread_times_info_data_t()
+    var count = mach_msg_type_number_t(MemoryLayout<task_thread_times_info_data_t>.size) / 4
+    let result = withUnsafeMutablePointer(to: &threadInfo) {
+      $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+        task_info(mach_task_self_, task_flavor_t(TASK_THREAD_TIMES_INFO), $0, &count)
+      }
+    }
+
+    guard result == KERN_SUCCESS else { return 0.0 }
+
+    let user = Double(threadInfo.user_time.seconds) + Double(threadInfo.user_time.microseconds) / 1_000_000
+    let system = Double(threadInfo.system_time.seconds) + Double(threadInfo.system_time.microseconds) / 1_000_000
+    let total = user + system
+    let now = CFAbsoluteTimeGetCurrent()
+
+    defer {
+      lastCPUSampleTime = now
+      lastCPUTime = total
+    }
+
+    guard let previous = lastCPUSampleTime else { return 0.0 }
+    let deltaTime = now - previous
+    guard deltaTime > 0 else { return 0.0 }
+
+    let deltaCPU = total - lastCPUTime
+    guard deltaCPU > 0 else { return 0.0 }
+
+    let cores = max(1.0, Double(ProcessInfo.processInfo.activeProcessorCount))
+    let usage = deltaCPU / deltaTime / cores
+    return min(max(usage, 0.0), 1.0)
+  }
+
+  private static func loadFallbackModels() -> [String] {
+    if let url = Bundle.main.url(forResource: "fallback_models", withExtension: "json"),
+       let data = try? Data(contentsOf: url),
+       let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+       let models = json["fallback_models"] as? [String],
+       !models.isEmpty {
+      return models
+    }
+
+    return [
+      "mlx-community/gemma-2-2b-it",
+      "mlx-community/llama-3.1-instruct-8b",
+      "mlx-community/phi-3-mini-4k-instruct",
+      "openaccess-ai-collective/tiny-mistral"
+    ]
   }
 }

--- a/src/specs/NativeLLM.ts
+++ b/src/specs/NativeLLM.ts
@@ -7,20 +7,54 @@ export interface GenerateOptions {
   topK?: number;
   topP?: number;
   stop?: string[] | null;
+  kvBits?: number | null;
+  kvGroupSize?: number | null;
+  quantizedKVStart?: number | null;
+  repetitionPenalty?: number | null;
+  repetitionContext?: number | null;
 }
 export interface LoadOptions {
   quantization?: string | null;
   contextLength?: number | null;
+  modelId?: string | null;
+}
+export interface LoadResult {
+  status: string;
+  model: string;
+  contextLength?: number | null;
+  kvCacheMax?: number | null;
+}
+export interface ToolCallPayload {
+  name: string;
+  arguments: Record<string, unknown>;
+}
+export interface GenerateResponse {
+  text: string;
+  promptTokens?: number;
+  completionTokens?: number;
+  duration?: number;
+  kvCacheSize?: number;
+  kvCacheMax?: number | null;
+  toolCalls?: ToolCallPayload[];
 }
 export interface PerfMetrics {
   memoryUsage?: number;
   cpuUsage?: number;
+  promptTokens?: number;
+  completionTokens?: number;
+  promptTime?: number;
+  generationTime?: number;
+  tokensPerSecond?: number;
+  promptTokensPerSecond?: number;
 }
 
 export interface Spec extends TurboModule {
-  loadModel(_path: string, _options?: LoadOptions | null): Promise<boolean>;
+  loadModel(_path: string, _options?: LoadOptions | null): Promise<LoadResult>;
   unloadModel(): Promise<boolean>;
-  generate(_prompt: string, _options?: GenerateOptions | null): Promise<string>;
+  generate(
+    _prompt: string,
+    _options?: GenerateOptions | null,
+  ): Promise<GenerateResponse | string>;
   embed(_text: string): Promise<number[]>;
   getPerformanceMetrics(): Promise<PerfMetrics>;
   getKVCacheSize(): Promise<number>;


### PR DESCRIPTION
## Summary
- replace the iOS TurboModule stub with an MLX-backed runtime that streams tokens, manages cache state, and reports metrics
- extend the NativeLLM TypeScript spec with richer load/generate responses and new generation options
- refresh the architecture docs to describe the MLX-powered iOS bridge

## Testing
- npm test -- --watch=false
- npm run lint
- npm run format:check
- npm run build:ios *(fails: xcodegen not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf31a82ef88333a293d087f0d3c95c