### PR TITLE
fix: stabilize Swift concurrency in native runtime

### DIFF
--- a/ios/MyOfflineLLMApp/Turbo/LLM.swift
+++ b/ios/MyOfflineLLMApp/Turbo/LLM.swift
@@ -2,7 +2,6 @@ import Foundation
 import Darwin
 import os
 import React
-import ReactCommon
 @preconcurrency import MLX
 @preconcurrency import MLXLLM
 @preconcurrency import MLXLMCommon
@@ -14,7 +13,13 @@ public typealias LLMSpec = NativeLLMSpec
 import AppSpecs
 public typealias LLMSpec = NativeLLMSpec
 #else
-@objc public protocol LLMSpec: RCTTurboModule {
+// The Objective-C++ shim in `LLM+Turbo.mm` declares the concrete module's
+// `RCTTurboModule` conformance. Keeping the Swift fallback tied to
+// `NSObjectProtocol` avoids importing ReactCommon—which pulls heavy C++
+// headers Swift cannot parse in our build settings—while still exposing the
+// promise-based surface expected by React Native when codegen specs are
+// unavailable.
+@objc public protocol LLMSpec: NSObjectProtocol {
   func loadModel(_ path: String,
                  options: [AnyHashable: Any]?,
                  resolve: @escaping RCTPromiseResolveBlock,

--- a/ios/MyOfflineLLMApp/Turbo/LLM.swift
+++ b/ios/MyOfflineLLMApp/Turbo/LLM.swift
@@ -510,7 +510,7 @@ public final class LLM: NSObject, LLMSpec {
 
   public func unloadModel(_ resolve: @escaping RCTPromiseResolveBlock,
                           reject: @escaping RCTPromiseRejectBlock) {
-    Task {
+    Task { @MainActor in
       await runtime.unload()
       resolveOnMainThread(resolve, true)
     }


### PR DESCRIPTION
## Summary
- add a React fallback definition for `LLMSpec` so the Swift bridge builds even when codegen headers are missing
- refactor the native generation loop to use Sendable wrappers for tool calls, caches, and completion info while preserving cache updates
- normalize tool-call payload marshalling and call `unload` asynchronously from the main actor wrapper

## Testing
- CI=1 npm test
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68d093e6b79c8333918218b594ed0f5c

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/offLLM/205)
<!-- GitContextEnd -->

## Summary by Sourcery

Stabilize Swift concurrency in the native runtime by introducing Sendable wrappers, refactoring the generation loop, normalizing payload marshalling, and making model unloading asynchronous.

Enhancements:
- Provide a React fallback LLMSpec protocol when codegen headers are missing
- Introduce Sendable ToolCallSummary, JSONValue, GenerationOutput, and CacheBox for concurrency-safe data handling
- Refactor the generation loop to return a GenerationOutput from container.perform and update cache and conversation outside the actor
- Normalize tool-call payload marshalling by converting JSONValue to foundation types before resolving
- Make unloadModel asynchronous by wrapping runtime.unload in a Task and resolving on the main actor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming now emits chunks as they arrive and returns a richer, streaming-aware result.
  * Tool calls in responses are consistently provided as an array of structured dictionaries.

* **Bug Fixes**
  * Safer model load/unload and concurrency handling to reduce race conditions.
  * More robust handling of tool-call arguments and completion metadata.

* **Refactor**
  * Generation pipeline and cache handling reworked for more reliable summaries (text, tokens, duration).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->