### PR TITLE
Fix LLM options conversion isolation

### DIFF
--- a/ios/MyOfflineLLMApp/Turbo/LLM.swift
+++ b/ios/MyOfflineLLMApp/Turbo/LLM.swift
@@ -632,7 +632,7 @@ public final class LLM: NSObject, LLMSpec {
   }
 
   /// Convert arbitrary RN options into a Sendable JSONValue map.
-  private func toJSONOptions(_ raw: [AnyHashable: Any]?) -> [String: JSONValue] {
+  nonisolated private func toJSONOptions(_ raw: [AnyHashable: Any]?) -> [String: JSONValue] {
     guard let raw else { return [:] }
     var out: [String: JSONValue] = [:]
     for (k, v) in raw {


### PR DESCRIPTION
## Summary
- mark the LLM options conversion helper as nonisolated so promise entry points can call it from nonisolated contexts without violating actor isolation

## Testing
- CI=1 npm test
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68d0b364986c8333af3e15675fecee3d

## Summary by Sourcery

Bug Fixes:
- Mark the private toJSONOptions method as nonisolated to allow calls from nonisolated contexts without violating actor isolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * Optimized internal concurrency handling to streamline background processing. This may reduce occasional stalls and improve responsiveness in edge cases. No changes to app behavior or UI. This update is transparent to users and requires no action. All features continue to work as before, with improved stability under heavy load.
* Chores
  * Internal maintenance with no impact on public APIs or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->