### PR TITLE
feat: add Mach-O universal binary utilities

### DIFF
--- a/__tests__/machoFatBinary.test.js
+++ b/__tests__/machoFatBinary.test.js
@@ -1,0 +1,138 @@
+import {
+  FAT_MAGIC,
+  FAT_MAGIC_64,
+  FAT_CIGAM,
+  parseFatHeader,
+  parseUniversalBinary,
+  extractMachO,
+  createUniversalBinary,
+} from "../src/utils/machoFatBinary";
+
+const CPU_TYPE_X86_64 = 0x01000007;
+const CPU_SUBTYPE_X86_64_ALL = 0x00000003;
+const CPU_TYPE_ARM64 = 0x0100000c;
+const CPU_SUBTYPE_ARM64_ALL = 0x00000002;
+const HEADER_SIZE = 8;
+const FAT_ARCH_SIZE = 20;
+
+const bufferToHex = (buffer) => Buffer.from(buffer).toString("hex");
+
+describe("machoFatBinary utilities", () => {
+  test("createUniversalBinary builds and parseUniversalBinary reads 32-bit fat binaries", () => {
+    const x86 = Buffer.from("Test x86_64\n", "utf8");
+    const arm = Buffer.from("Test arm64\n", "utf8");
+
+    const universal = createUniversalBinary([
+      {
+        cpuType: CPU_TYPE_X86_64,
+        cpuSubtype: CPU_SUBTYPE_X86_64_ALL,
+        data: x86,
+        align: 2,
+      },
+      {
+        cpuType: CPU_TYPE_ARM64,
+        cpuSubtype: CPU_SUBTYPE_ARM64_ALL,
+        data: arm,
+        align: 2,
+      },
+    ]);
+
+    const header = parseFatHeader(universal);
+    expect(header.magic).toBe(FAT_MAGIC);
+    expect(header.architectureCount).toBe(2);
+    expect(header.is64Bit).toBe(false);
+
+    const parsed = parseUniversalBinary(universal);
+    expect(parsed.architectures).toHaveLength(2);
+
+    const [x86Arch, armArch] = parsed.architectures;
+    expect(x86Arch.cpuType).toBe(CPU_TYPE_X86_64);
+    expect(x86Arch.cpuSubtype).toBe(CPU_SUBTYPE_X86_64_ALL);
+    expect(x86Arch.size).toBe(x86.length);
+    expect(bufferToHex(x86Arch.data)).toBe(bufferToHex(x86));
+
+    expect(armArch.cpuType).toBe(CPU_TYPE_ARM64);
+    expect(armArch.cpuSubtype).toBe(CPU_SUBTYPE_ARM64_ALL);
+    expect(armArch.size).toBe(arm.length);
+    expect(bufferToHex(armArch.data)).toBe(bufferToHex(arm));
+  });
+
+  test("extractMachO returns the requested architecture buffer", () => {
+    const x86 = Buffer.from("x86_64", "utf8");
+    const arm = Buffer.from("arm64", "utf8");
+
+    const universal = createUniversalBinary([
+      { cpuType: CPU_TYPE_X86_64, cpuSubtype: 1, data: x86, align: 2 },
+      { cpuType: CPU_TYPE_X86_64, cpuSubtype: 2, data: arm, align: 2 },
+    ]);
+
+    const first = extractMachO(universal, {
+      cpuType: CPU_TYPE_X86_64,
+      cpuSubtype: 1,
+    });
+    expect(bufferToHex(first)).toBe(bufferToHex(x86));
+
+    const second = extractMachO(universal, {
+      cpuType: CPU_TYPE_X86_64,
+      cpuSubtype: 2,
+    });
+    expect(bufferToHex(second)).toBe(bufferToHex(arm));
+
+    expect(() => extractMachO(universal, CPU_TYPE_X86_64)).toThrow(
+      /specify cpuSubtype to disambiguate/,
+    );
+  });
+
+  test("createUniversalBinary supports fat_arch_64 layouts when forced", () => {
+    const payload = Buffer.from("arm64 only", "utf8");
+    const universal64 = createUniversalBinary(
+      [
+        {
+          cpuType: CPU_TYPE_ARM64,
+          cpuSubtype: CPU_SUBTYPE_ARM64_ALL,
+          data: payload,
+          align: 3,
+        },
+      ],
+      { forceFat64: true },
+    );
+
+    const header = parseFatHeader(universal64);
+    expect(header.magic).toBe(FAT_MAGIC_64);
+    expect(header.is64Bit).toBe(true);
+
+    const parsed = parseUniversalBinary(universal64);
+    expect(parsed.architectures[0].align).toBe(3);
+    expect(bufferToHex(parsed.architectures[0].data)).toBe(
+      bufferToHex(payload),
+    );
+  });
+
+  test("parser recognises byte-swapped FAT_CIGAM headers", () => {
+    const data = Uint8Array.from([0xaa, 0xbb, 0xcc, 0xdd]);
+    const offset = HEADER_SIZE + FAT_ARCH_SIZE;
+    const totalLength = offset + data.length;
+    const array = new Uint8Array(totalLength);
+    const view = new DataView(array.buffer);
+
+    view.setUint32(0, FAT_MAGIC, true); // store little-endian to produce FAT_CIGAM bytes
+    view.setUint32(4, 1, true);
+
+    const tableOffset = HEADER_SIZE;
+    view.setInt32(tableOffset, CPU_TYPE_ARM64, true);
+    view.setInt32(tableOffset + 4, CPU_SUBTYPE_ARM64_ALL, true);
+    view.setUint32(tableOffset + 8, offset, true);
+    view.setUint32(tableOffset + 12, data.length, true);
+    view.setUint32(tableOffset + 16, 2, true);
+
+    array.set(data, offset);
+
+    const header = parseFatHeader(array);
+    expect(header.rawMagic).toBe(FAT_CIGAM);
+    expect(header.isSwapped).toBe(true);
+
+    const parsed = parseUniversalBinary(array);
+    expect(parsed.architectures).toHaveLength(1);
+    expect(bufferToHex(parsed.architectures[0].data)).toBe(bufferToHex(data));
+  });
+});

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$SCRIPT_DIR"
 XCODE_ENV_HELPER="$ROOT_DIR/scripts/lib/xcode_env.sh"
+NPM_ENV_HELPER="$ROOT_DIR/scripts/lib/npm_env.sh"
 ENV_FILE="$ROOT_DIR/.env"
 DEFAULT_ENV_FILE="$ROOT_DIR/.env.default"
 
@@ -19,6 +20,11 @@ elif [ -f "$DEFAULT_ENV_FILE" ]; then
   source "$DEFAULT_ENV_FILE"
   set +a
 fi
+
+# shellcheck source=scripts/lib/npm_env.sh
+source "$NPM_ENV_HELPER"
+# Normalize deprecated npm proxy environment variables before invoking npm.
+sanitize_npm_proxy_env
 
 # shellcheck source=scripts/lib/xcode_env.sh
 source "$XCODE_ENV_HELPER"

--- a/scripts/build-ios-unsigned.sh
+++ b/scripts/build-ios-unsigned.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 XCODE_ENV_HELPER="$ROOT_DIR/scripts/lib/xcode_env.sh"
+NPM_ENV_HELPER="$ROOT_DIR/scripts/lib/npm_env.sh"
+# shellcheck source=lib/npm_env.sh
+source "$NPM_ENV_HELPER"
+# Normalize deprecated npm proxy environment variables before invoking npm.
+sanitize_npm_proxy_env
 # shellcheck source=lib/xcode_env.sh
 source "$XCODE_ENV_HELPER"
 sanitize_xcode_env

--- a/scripts/ci/bootstrap-build.sh
+++ b/scripts/ci/bootstrap-build.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 XCODE_ENV_HELPER="$ROOT_DIR/scripts/lib/xcode_env.sh"
+NPM_ENV_HELPER="$ROOT_DIR/scripts/lib/npm_env.sh"
 ENV_FILE="$ROOT_DIR/.env"
 DEFAULT_ENV_FILE="$ROOT_DIR/.env.default"
 
@@ -19,6 +20,11 @@ elif [ -f "$DEFAULT_ENV_FILE" ]; then
   source "$DEFAULT_ENV_FILE"
   set +a
 fi
+
+# shellcheck source=../lib/npm_env.sh
+source "$NPM_ENV_HELPER"
+# Normalize deprecated npm proxy environment variables before invoking npm.
+sanitize_npm_proxy_env
 
 # shellcheck source=../lib/xcode_env.sh
 source "$XCODE_ENV_HELPER"

--- a/scripts/clean-build-ios.sh
+++ b/scripts/clean-build-ios.sh
@@ -5,9 +5,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 NPM_ENV_HELPER="$ROOT_DIR/scripts/lib/npm_env.sh"
 # shellcheck source=lib/npm_env.sh
-source "$NPM_ENV_HELPER"
+if [ -f "$NPM_ENV_HELPER" ]; then
+  source "$NPM_ENV_HELPER"
+else
+  echo "❌ Missing helper: $NPM_ENV_HELPER" >&2
+  exit 1
+fi
 # Normalize deprecated npm proxy environment variables before invoking npm.
-sanitize_npm_proxy_env
+sanitize_npm_proxy_env --include-lowercase
 
 echo "Starting clean iOS build process..."
 
@@ -20,7 +25,7 @@ rm -rf Pods Podfile.lock build
 popd >/dev/null
 
 # Step 3: Reinstall all dependencies
-npm install
+npm ci
 pushd ios >/dev/null
 bundle install
 xcodegen generate
@@ -29,14 +34,27 @@ bundle exec pod install --repo-update
 popd >/dev/null
 
 # Step 4: Reset the React Native bundler cache
-npx react-native start --reset-cache &
+npx react-native start --reset-cache >/dev/null 2>&1 &
 BUNDLER_PID=$!
-sleep 10
+trap 'kill "$BUNDLER_PID" 2>/dev/null || true' EXIT INT TERM
+# Wait up to 30s for Metro on 8081
+for i in {1..30}; do
+  if command -v nc >/dev/null 2>&1; then
+    if nc -z localhost 8081 2>/dev/null; then
+      break
+    fi
+  elif command -v curl >/dev/null 2>&1; then
+    if curl -fsS "http://127.0.0.1:8081/status" >/dev/null 2>&1; then
+      break
+    fi
+  fi
+  sleep 1
+done
 
 # Step 5: Build the iOS application
 npx react-native build-ios --mode Release
 
 # Step 6: Kill the bundler process
-kill $BUNDLER_PID
+kill "$BUNDLER_PID" 2>/dev/null || true
 
 echo "✅ Clean iOS build process completed successfully."

--- a/scripts/clean-build-ios.sh
+++ b/scripts/clean-build-ios.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+NPM_ENV_HELPER="$ROOT_DIR/scripts/lib/npm_env.sh"
+# shellcheck source=lib/npm_env.sh
+source "$NPM_ENV_HELPER"
+# Normalize deprecated npm proxy environment variables before invoking npm.
+sanitize_npm_proxy_env
+
 echo "Starting clean iOS build process..."
 
 # Step 1: Clean JavaScript dependencies

--- a/scripts/lib/npm_env.sh
+++ b/scripts/lib/npm_env.sh
@@ -1,0 +1,54 @@
+# shellcheck shell=bash
+
+# Normalizes proxy-related npm environment variables so newer npm releases
+# stop warning about the deprecated `npm_config_http_proxy` name. The helper
+# prefers the modern `npm_config_proxy` key and reuses any standard HTTP(S)
+# proxy variables that may already be exported.
+sanitize_npm_proxy_env() {
+  local http_proxy_val=""
+  if [ -n "${npm_config_http_proxy:-}" ]; then
+    http_proxy_val="${npm_config_http_proxy}"
+  elif [ -n "${NPM_CONFIG_HTTP_PROXY:-}" ]; then
+    http_proxy_val="${NPM_CONFIG_HTTP_PROXY}"
+  elif [ -n "${HTTP_PROXY:-}" ]; then
+    http_proxy_val="${HTTP_PROXY}"
+  fi
+
+  local https_proxy_val=""
+  if [ -n "${npm_config_https_proxy:-}" ]; then
+    https_proxy_val="${npm_config_https_proxy}"
+  elif [ -n "${NPM_CONFIG_HTTPS_PROXY:-}" ]; then
+    https_proxy_val="${NPM_CONFIG_HTTPS_PROXY}"
+  elif [ -n "${HTTPS_PROXY:-}" ]; then
+    https_proxy_val="${HTTPS_PROXY}"
+  fi
+
+  local normalized=0
+
+  if [ -n "$http_proxy_val" ]; then
+    if [ "${npm_config_proxy:-}" != "$http_proxy_val" ]; then
+      export npm_config_proxy="$http_proxy_val"
+    fi
+    if [ "${NPM_CONFIG_PROXY:-}" != "$http_proxy_val" ]; then
+      export NPM_CONFIG_PROXY="$http_proxy_val"
+    fi
+    unset npm_config_http_proxy
+    unset NPM_CONFIG_HTTP_PROXY
+    normalized=1
+  fi
+
+  if [ -n "$https_proxy_val" ]; then
+    if [ "${npm_config_https_proxy:-}" != "$https_proxy_val" ]; then
+      export npm_config_https_proxy="$https_proxy_val"
+    fi
+    if [ "${NPM_CONFIG_HTTPS_PROXY:-}" != "$https_proxy_val" ]; then
+      export NPM_CONFIG_HTTPS_PROXY="$https_proxy_val"
+    fi
+  fi
+
+  if [ "$normalized" -eq 1 ] && [ -z "${OFFLLM_NPM_PROXY_WARNED:-}" ]; then
+    printf 'ℹ️  Normalized npm proxy environment for future npm compatibility.\n' >&2
+    export OFFLLM_NPM_PROXY_WARNED=1
+  fi
+}
+

--- a/src/utils/machoFatBinary.js
+++ b/src/utils/machoFatBinary.js
@@ -1,0 +1,533 @@
+/*
+ * Utilities for working with Mach-O universal (fat) binaries. The module can
+ * parse the fat header/architecture table, extract individual Mach-O objects,
+ * and build new universal binaries from architecture-specific Mach-O buffers.
+ *
+ * The implementation mirrors the structures defined in mach-o/fat.h:
+ *   struct fat_header { uint32_t magic; uint32_t nfat_arch; };
+ *   struct fat_arch { cpu_type_t cputype; cpu_subtype_t cpusubtype;
+ *                     uint32_t offset; uint32_t size; uint32_t align; };
+ *   struct fat_arch_64 { ... uint64_t offset; uint64_t size; ... };
+ *
+ * Apple stores these structures in big-endian order (`FAT_MAGIC`) or the
+ * byte-swapped variant (`FAT_CIGAM`). The helper functions below transparently
+ * handle both encodings and surface typed architecture metadata to callers.
+ */
+
+const hasBuffer =
+  typeof Buffer !== "undefined" && typeof Buffer.isBuffer === "function";
+
+export const FAT_MAGIC = 0xcafebabe;
+export const FAT_CIGAM = 0xbebafeca;
+export const FAT_MAGIC_64 = 0xcafebabf;
+export const FAT_CIGAM_64 = 0xbfbafeca;
+
+const MAX_UINT32 = 0xffffffffn;
+const HEADER_SIZE = 8;
+const FAT_ARCH_SIZE = 20;
+const FAT_ARCH64_SIZE = 32;
+
+const toUint8Array = (value, label) => {
+  if (value == null) {
+    throw new TypeError(
+      `${label} must be a Buffer, Uint8Array, or ArrayBuffer`,
+    );
+  }
+
+  if (hasBuffer && Buffer.isBuffer(value)) {
+    return value;
+  }
+
+  if (value instanceof Uint8Array) {
+    return value;
+  }
+
+  if (value instanceof ArrayBuffer) {
+    return new Uint8Array(value);
+  }
+
+  throw new TypeError(`${label} must be a Buffer, Uint8Array, or ArrayBuffer`);
+};
+
+const toBinaryView = (value, label) => {
+  const array = toUint8Array(value, label);
+  return {
+    array,
+    view: new DataView(array.buffer, array.byteOffset, array.byteLength),
+  };
+};
+
+const readUInt32 = (view, offset, swapped) => view.getUint32(offset, swapped);
+const readInt32 = (view, offset, swapped) => view.getInt32(offset, swapped);
+
+const readUInt64 = (view, offset, swapped) => {
+  if (typeof view.getBigUint64 !== "function") {
+    throw new Error(
+      "BigInt DataView helpers are not available in this environment",
+    );
+  }
+  return view.getBigUint64(offset, swapped);
+};
+
+const writeUInt32 = (view, offset, value, swapped) =>
+  view.setUint32(offset, value, swapped);
+const writeInt32 = (view, offset, value, swapped) =>
+  view.setInt32(offset, value, swapped);
+
+const writeUInt64 = (view, offset, value, swapped) => {
+  if (typeof view.setBigUint64 !== "function") {
+    throw new Error(
+      "BigInt DataView helpers are not available in this environment",
+    );
+  }
+  view.setBigUint64(offset, value, swapped);
+};
+
+const toSafeNumber = (value, label) => {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || value < 0) {
+      throw new RangeError(`${label} must be a finite positive integer`);
+    }
+    if (!Number.isInteger(value)) {
+      throw new RangeError(`${label} must be an integer value`);
+    }
+    return value;
+  }
+
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new RangeError(
+      `${label} does not fit within JavaScript's safe integer range`,
+    );
+  }
+
+  return Number(value);
+};
+
+const normaliseAlignment = (align) => {
+  if (!Number.isInteger(align) || align < 0) {
+    throw new RangeError(
+      `Alignment exponent must be a non-negative integer, received ${align}`,
+    );
+  }
+  return align;
+};
+
+const alignmentExponentFromBytes = (alignment, label) => {
+  if (typeof alignment === "bigint") {
+    if (alignment <= 0n || (alignment & (alignment - 1n)) !== 0n) {
+      throw new RangeError(`${label} must be a positive power of two`);
+    }
+    let exponent = 0;
+    let value = alignment;
+    while (value > 1n) {
+      value >>= 1n;
+      exponent += 1;
+    }
+    return exponent;
+  }
+
+  if (!Number.isInteger(alignment) || alignment <= 0) {
+    throw new RangeError(`${label} must be a positive power of two`);
+  }
+
+  if ((alignment & (alignment - 1)) !== 0) {
+    throw new RangeError(`${label} must be a power of two`);
+  }
+
+  let exponent = 0;
+  let value = alignment >>> 0;
+  while (value > 1) {
+    value >>>= 1;
+    exponent += 1;
+  }
+  return exponent;
+};
+
+const computeAlignmentBytes = (align) => {
+  const alignment = 1n << BigInt(align);
+  if (alignment <= BigInt(Number.MAX_SAFE_INTEGER)) {
+    return Number(alignment);
+  }
+  return alignment;
+};
+
+const alignBigInt = (value, alignment) => {
+  if (alignment <= 1n) {
+    return value;
+  }
+  const remainder = value % alignment;
+  if (remainder === 0n) {
+    return value;
+  }
+  return value + (alignment - remainder);
+};
+
+const bigIntLengthToNumber = (value, label) => {
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new RangeError(
+      `${label} is too large to represent as a JavaScript number`,
+    );
+  }
+  return Number(value);
+};
+
+const assertUniqueArchitectures = (architectures) => {
+  const seen = new Set();
+  for (const { cpuType, cpuSubtype } of architectures) {
+    const key = `${cpuType}:${cpuSubtype}`;
+    if (seen.has(key)) {
+      throw new Error(
+        `Duplicate architecture entry detected for cpuType=${cpuType} cpuSubtype=${cpuSubtype}`,
+      );
+    }
+    seen.add(key);
+  }
+};
+
+const parseHeaderFromView = (view) => {
+  if (view.byteLength < HEADER_SIZE) {
+    throw new Error("Buffer is too small to contain a fat header");
+  }
+
+  const rawMagic = readUInt32(view, 0, false);
+  let isSwapped = false;
+  let is64Bit = false;
+  let canonicalMagic = rawMagic;
+
+  switch (rawMagic) {
+    case FAT_MAGIC:
+      canonicalMagic = FAT_MAGIC;
+      break;
+    case FAT_MAGIC_64:
+      canonicalMagic = FAT_MAGIC_64;
+      is64Bit = true;
+      break;
+    case FAT_CIGAM:
+      canonicalMagic = FAT_MAGIC;
+      isSwapped = true;
+      break;
+    case FAT_CIGAM_64:
+      canonicalMagic = FAT_MAGIC_64;
+      is64Bit = true;
+      isSwapped = true;
+      break;
+    default:
+      throw new Error(
+        `Unrecognised Mach-O universal binary magic: 0x${rawMagic.toString(16)}`,
+      );
+  }
+
+  const architectureCount = readUInt32(view, 4, isSwapped);
+
+  return {
+    magic: canonicalMagic,
+    rawMagic,
+    architectureCount,
+    is64Bit,
+    isSwapped,
+  };
+};
+
+export const parseFatHeader = (buffer) => {
+  const { view } = toBinaryView(buffer, "buffer");
+  return parseHeaderFromView(view);
+};
+
+export const parseUniversalBinary = (buffer) => {
+  const { array, view } = toBinaryView(buffer, "buffer");
+  const header = parseHeaderFromView(view);
+
+  const entrySize = header.is64Bit ? FAT_ARCH64_SIZE : FAT_ARCH_SIZE;
+  const requiredSize = HEADER_SIZE + header.architectureCount * entrySize;
+  if (view.byteLength < requiredSize) {
+    throw new Error(
+      `Fat binary header declares ${header.architectureCount} architectures but the buffer is too small`,
+    );
+  }
+
+  const architectures = [];
+  let tableOffset = HEADER_SIZE;
+
+  for (let index = 0; index < header.architectureCount; index += 1) {
+    const cpuType = readInt32(view, tableOffset, header.isSwapped);
+    const cpuSubtype = readInt32(view, tableOffset + 4, header.isSwapped);
+
+    let offsetValue;
+    let sizeValue;
+    let cursor = tableOffset + 8;
+
+    if (header.is64Bit) {
+      offsetValue = readUInt64(view, cursor, header.isSwapped);
+      sizeValue = readUInt64(view, cursor + 8, header.isSwapped);
+      cursor += 16;
+    } else {
+      offsetValue = BigInt(readUInt32(view, cursor, header.isSwapped));
+      sizeValue = BigInt(readUInt32(view, cursor + 4, header.isSwapped));
+      cursor += 8;
+    }
+
+    const align = readUInt32(view, cursor, header.isSwapped);
+    cursor += 4;
+
+    if (header.is64Bit) {
+      cursor += 4; // reserved field
+    }
+
+    tableOffset += entrySize;
+
+    const offset = toSafeNumber(offsetValue, "offset");
+    const size = toSafeNumber(sizeValue, "size");
+
+    if (offset + size > array.byteLength) {
+      throw new Error(
+        `Fat binary architecture index ${index} exceeds buffer bounds (offset=${offset} size=${size})`,
+      );
+    }
+
+    const alignmentExponent = normaliseAlignment(align);
+    const alignmentBytes = computeAlignmentBytes(alignmentExponent);
+
+    const offsetBigInt = BigInt(offset);
+    const alignmentBigInt = 1n << BigInt(alignmentExponent);
+    if (alignmentBigInt !== 0n && offsetBigInt % alignmentBigInt !== 0n) {
+      throw new Error(
+        `Architecture index ${index} offset ${offset} does not respect 2^${alignmentExponent} alignment`,
+      );
+    }
+
+    architectures.push({
+      cpuType,
+      cpuSubtype,
+      offset,
+      size,
+      align: alignmentExponent,
+      alignmentBytes,
+      data: array.subarray(offset, offset + size),
+    });
+  }
+
+  assertUniqueArchitectures(architectures);
+
+  return {
+    ...header,
+    architectures,
+  };
+};
+
+const resolveArchitectureSpec = (spec, maybeSubtype) => {
+  if (typeof spec === "number") {
+    return {
+      cpuType: spec,
+      cpuSubtype: typeof maybeSubtype === "number" ? maybeSubtype : undefined,
+    };
+  }
+
+  if (typeof spec === "object" && spec !== null) {
+    return {
+      cpuType: typeof spec.cpuType === "number" ? spec.cpuType : undefined,
+      cpuSubtype:
+        typeof spec.cpuSubtype === "number" ? spec.cpuSubtype : undefined,
+      index:
+        typeof spec.index === "number" && Number.isInteger(spec.index)
+          ? spec.index
+          : undefined,
+    };
+  }
+
+  throw new TypeError(
+    "Architecture spec must be a cpuType number, { cpuType, cpuSubtype }, or { index } object",
+  );
+};
+
+export const extractMachO = (buffer, spec, maybeSubtype) => {
+  const parsed = parseUniversalBinary(buffer);
+  const criteria = resolveArchitectureSpec(spec, maybeSubtype);
+
+  if (typeof criteria.index === "number") {
+    const { index } = criteria;
+    if (index < 0 || index >= parsed.architectures.length) {
+      throw new RangeError(
+        `Requested architecture index ${index} is out of bounds`,
+      );
+    }
+    return parsed.architectures[index].data;
+  }
+
+  if (typeof criteria.cpuType !== "number") {
+    throw new TypeError(
+      "Architecture spec must include a cpuType when index is not provided",
+    );
+  }
+
+  const matches = parsed.architectures.filter(
+    (arch) => arch.cpuType === criteria.cpuType,
+  );
+
+  if (matches.length === 0) {
+    throw new Error(`No Mach-O object found for cpuType=${criteria.cpuType}`);
+  }
+
+  if (typeof criteria.cpuSubtype === "number") {
+    const match = matches.find(
+      (arch) => arch.cpuSubtype === criteria.cpuSubtype,
+    );
+    if (!match) {
+      throw new Error(
+        `No Mach-O object found for cpuType=${criteria.cpuType} cpuSubtype=${criteria.cpuSubtype}`,
+      );
+    }
+    return match.data;
+  }
+
+  if (matches.length > 1) {
+    throw new Error(
+      `Multiple Mach-O objects share cpuType=${criteria.cpuType}; specify cpuSubtype to disambiguate`,
+    );
+  }
+
+  return matches[0].data;
+};
+
+const computeLayout = (entries, entrySize) => {
+  let offset = BigInt(HEADER_SIZE + entrySize * entries.length);
+  const layout = [];
+
+  for (const entry of entries) {
+    const alignment = 1n << BigInt(entry.align);
+    offset = alignBigInt(offset, alignment);
+
+    const size = BigInt(entry.data.byteLength ?? entry.data.length);
+
+    layout.push({
+      offset,
+      size,
+      align: entry.align,
+      data: entry.data,
+      cpuType: entry.cpuType,
+      cpuSubtype: entry.cpuSubtype,
+    });
+
+    offset += size;
+  }
+
+  return { layout, totalSize: offset };
+};
+
+const normaliseEntry = (entry, index, defaultAlign) => {
+  if (!entry || typeof entry !== "object") {
+    throw new TypeError(
+      `Architecture entry at index ${index} must be an object`,
+    );
+  }
+
+  const data = toUint8Array(entry.data, `architectures[${index}].data`);
+  const cpuType = toSafeNumber(
+    entry.cpuType,
+    `architectures[${index}].cpuType`,
+  );
+  const cpuSubtype = toSafeNumber(
+    entry.cpuSubtype,
+    `architectures[${index}].cpuSubtype`,
+  );
+
+  let align = entry.align;
+  if (align == null && entry.alignmentBytes != null) {
+    align = alignmentExponentFromBytes(
+      entry.alignmentBytes,
+      `architectures[${index}].alignmentBytes`,
+    );
+  } else if (align == null && entry.alignment != null) {
+    align = alignmentExponentFromBytes(
+      entry.alignment,
+      `architectures[${index}].alignment`,
+    );
+  }
+
+  if (align == null) {
+    align = normaliseAlignment(defaultAlign);
+  } else {
+    align = normaliseAlignment(align);
+  }
+
+  return { data, cpuType, cpuSubtype, align };
+};
+
+const createResultBuffer = (array) => {
+  if (hasBuffer) {
+    return Buffer.from(array.buffer, array.byteOffset, array.byteLength);
+  }
+  return array;
+};
+
+export const createUniversalBinary = (architectures, options = {}) => {
+  if (!Array.isArray(architectures) || architectures.length === 0) {
+    throw new TypeError(
+      "createUniversalBinary expects a non-empty array of architectures",
+    );
+  }
+
+  const defaultAlign = options.defaultAlign != null ? options.defaultAlign : 14;
+  const entries = architectures.map((entry, index) =>
+    normaliseEntry(entry, index, defaultAlign),
+  );
+
+  assertUniqueArchitectures(entries);
+
+  const entrySize32 = FAT_ARCH_SIZE;
+  const entrySize64 = FAT_ARCH64_SIZE;
+
+  let use64Bit = options.forceFat64 === true;
+  let { layout, totalSize } = computeLayout(
+    entries,
+    use64Bit ? entrySize64 : entrySize32,
+  );
+
+  if (!use64Bit) {
+    const needs64 = layout.some(
+      (item) => item.offset > MAX_UINT32 || item.size > MAX_UINT32,
+    );
+    if (needs64) {
+      use64Bit = true;
+      ({ layout, totalSize } = computeLayout(entries, entrySize64));
+    }
+  }
+
+  const totalSizeNumber = bigIntLengthToNumber(totalSize, "fat binary size");
+  const array = new Uint8Array(totalSizeNumber);
+  const view = new DataView(array.buffer, array.byteOffset, array.byteLength);
+
+  const magic = use64Bit ? FAT_MAGIC_64 : FAT_MAGIC;
+  writeUInt32(view, 0, magic, false);
+  writeUInt32(view, 4, entries.length, false);
+
+  const entrySize = use64Bit ? entrySize64 : entrySize32;
+  let cursor = HEADER_SIZE;
+
+  layout.forEach((entry) => {
+    writeInt32(view, cursor, entry.cpuType, false);
+    writeInt32(view, cursor + 4, entry.cpuSubtype, false);
+
+    if (use64Bit) {
+      writeUInt64(view, cursor + 8, entry.offset, false);
+      writeUInt64(view, cursor + 16, entry.size, false);
+      writeUInt32(view, cursor + 24, entry.align, false);
+      writeUInt32(view, cursor + 28, 0, false);
+    } else {
+      writeUInt32(view, cursor + 8, Number(entry.offset), false);
+      writeUInt32(view, cursor + 12, Number(entry.size), false);
+      writeUInt32(view, cursor + 16, entry.align, false);
+    }
+
+    cursor += entrySize;
+  });
+
+  layout.forEach((entry) => {
+    const destinationOffset = bigIntLengthToNumber(
+      entry.offset,
+      "architecture offset",
+    );
+    array.set(entry.data, destinationOffset);
+  });
+
+  return createResultBuffer(array);
+};


### PR DESCRIPTION
## Summary
- add reusable helpers for parsing Mach-O fat headers, validating architecture tables, and extracting embedded Mach-O slices
- support building new universal binaries with automatic alignment, fat_arch/fat_arch_64 selection, and duplicate architecture protection
- cover utilities with Jest tests for 32-bit, 64-bit, and byte-swapped FAT_CIGAM binaries

## Testing
- CI=1 npm test
- npm run lint
- CI=1 npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68d0dbc0df188333b6173252cf425b83

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/offLLM/210)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds utilities to parse/create Mach-O universal (fat) binaries with 32/64-bit and byte-swapped support; extract specific architectures and enforce 64-bit layout.

* **Tests**
  * Adds comprehensive tests covering creation, parsing, extraction, swapped headers, alignment, and error handling.

* **Chores**
  * Adds npm proxy normalization helper and integrates it into iOS build/CI scripts to sanitize environment variables early.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->