### PR TITLE
Refactor AppDelegate to bootstrap with RCTReactNativeFactory

### DIFF
--- a/ios/MyOfflineLLMApp/AppDelegate.h
+++ b/ios/MyOfflineLLMApp/AppDelegate.h
@@ -1,14 +1,17 @@
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
-#if __has_include(<React/RCTAppDelegate.h>)
-#import <React/RCTAppDelegate.h>
-#elif __has_include(<React_RCTAppDelegate/RCTAppDelegate.h>)
-#import <React_RCTAppDelegate/RCTAppDelegate.h>
-#elif __has_include("RCTAppDelegate.h")
-#import "RCTAppDelegate.h"
+#if __has_include(<React-RCTAppDelegate/RCTDefaultReactNativeFactoryDelegate.h>)
+#import <React-RCTAppDelegate/RCTDefaultReactNativeFactoryDelegate.h>
+#elif __has_include(<React/RCTDefaultReactNativeFactoryDelegate.h>)
+#import <React/RCTDefaultReactNativeFactoryDelegate.h>
+#elif __has_include("RCTDefaultReactNativeFactoryDelegate.h")
+#import "RCTDefaultReactNativeFactoryDelegate.h"
 #else
-#error "RCTAppDelegate header not found. Run 'bundle exec pod install' to generate React-RCTAppDelegate"
+#error "RCTDefaultReactNativeFactoryDelegate header not found. Run 'bundle exec pod install' to generate React-RCTAppDelegate"
 #endif
 
-@interface AppDelegate : RCTAppDelegate
+@interface AppDelegate : RCTDefaultReactNativeFactoryDelegate <UIApplicationDelegate>
+
+@property (nonatomic, strong) UIWindow *window;
+
 @end


### PR DESCRIPTION
## Summary
- replace the RCTAppDelegate inheritance with RCTDefaultReactNativeFactoryDelegate and add a UIWindow property
- bootstrap React Native via RCTReactNativeFactory, wiring the module name, window setup, and bundle URL handling

## Testing
- npm test
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68d1158e49388333be2292c1ef05e143

## Summary by Sourcery

Refactor AppDelegate to use RCTReactNativeFactory and RCTDefaultReactNativeFactoryDelegate for React Native setup, including manual window handling and custom bundle URL resolution

Enhancements:
- Migrate AppDelegate to inherit from RCTDefaultReactNativeFactoryDelegate and add a UIWindow property
- Bootstrap React Native in application:didFinishLaunchingWithOptions: via RCTReactNativeFactory to create and display the root view and view controller
- Implement sourceURLForBridge to return development and production JavaScript bundle URLs
- Add init method to configure the default module name and initial properties

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Ensures the JavaScript bundle loads correctly in both development and production, reducing startup failures and blank screens.
  - More reliable app window and root view initialization for consistent launch behavior.

- Refactor
  - Modernized app startup to a factory-based flow for improved stability and compatibility with newer platform versions.
  - Streamlined bundle resolution logic and improved error messaging during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->