### PR TITLE
Add workflow for AdHoc signed iOS IPA

### DIFF
--- a/.github/workflows/ios-adhoc-export.yml
+++ b/.github/workflows/ios-adhoc-export.yml
@@ -4,15 +4,24 @@ on:
   workflow_dispatch:
   push:
     branches: [main, master]
-  pull_request:
 
 jobs:
   build-adhoc:
-    runs-on: macos-15
+    permissions:
+      contents: read
+    runs-on: macos-latest
+    timeout-minutes: 60
+    concurrency:
+      group: ios-adhoc-${{ github.ref }}
+      cancel-in-progress: true
 
     env:
+      NODE_VERSION: "20"
+      RUBY_VERSION: "3.2"
+      XCODE_VERSION: "16.4"
       SCHEME: monGARS
       CONFIGURATION: Release
+      WORKSPACE: ios/monGARS.xcworkspace
       ARCHIVE_PATH: build/monGARS.xcarchive
       DERIVED_DATA: build/DerivedData
       RESULT_BUNDLE: build/DerivedData/ResultBundle_build.xcresult
@@ -32,66 +41,88 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Prepare scripts
-        run: |
-          mkdir -p scripts signing
-          cat > scripts/import_signing.sh <<'BASH'
-          #!/usr/bin/env bash
-          set -euo pipefail
-          P12_PATH="$1"; P12_PASSWORD="$2"; MP_PATH="$3"; KC_NAME="$4"; KC_PASS="$5"
-          security create-keychain -p "$KC_PASS" "$KC_NAME"
-          security set-keychain-settings -lut 21600 "$KC_NAME"
-          security unlock-keychain -p "$KC_PASS" "$KC_NAME"
-          security import "$P12_PATH" -k "$KC_NAME" -P "$P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$KC_PASS" "$KC_NAME" || true
-          security list-keychains -d user -s "$KC_NAME"
-          security default-keychain -s "$KC_NAME"
-          PP_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"; mkdir -p "$PP_DIR"
-          PLIST_TMP=$(mktemp); security cms -D -i "$MP_PATH" > "$PLIST_TMP"
-          UUID=$(/usr/libexec/PlistBuddy -c 'Print UUID' "$PLIST_TMP")
-          cp "$MP_PATH" "$PP_DIR/$UUID.mobileprovision"
-          echo "PROFILE_UUID=$UUID" >> "$GITHUB_ENV"
-          BASH
-          chmod +x scripts/import_signing.sh
+      - name: Select Xcode ${{ env.XCODE_VERSION }}
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
 
-          cat > scripts/export_ipa.sh <<'BASH'
-          #!/usr/bin/env bash
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Setup Ruby ${{ env.RUBY_VERSION }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+        working-directory: ios
+
+      - name: Install XcodeGen
+        run: |
+          if ! command -v xcodegen >/dev/null 2>&1; then
+            brew install xcodegen
+          fi
+
+      - name: Download bundled MLX model
+        run: ./scripts/ci/download-mlx-model.sh
+
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: |
+            ios/Pods
+            ios/monGARS.xcworkspace
+          key: pods-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: |
+            pods-${{ runner.os }}-
+
+      - name: Generate Xcode project
+        working-directory: ios
+        run: xcodegen generate
+
+      - name: Install CocoaPods
+        working-directory: ios
+        run: |
           set -euo pipefail
-          ARCHIVE_PATH="$1"; EXPORT_OPTS="$2"; EXPORT_DIR="$3"
-          mkdir -p "$EXPORT_DIR"
-          xcodebuild -exportArchive -archivePath "$ARCHIVE_PATH" -exportPath "$EXPORT_DIR" -exportOptionsPlist "$EXPORT_OPTS" -allowProvisioningUpdates
-          ls -la "$EXPORT_DIR"
-          BASH
-          chmod +x scripts/export_ipa.sh
+          bundle exec pod install --repo-update
+
+      - name: Restore DerivedData cache
+        uses: actions/cache@v4
+        with:
+          path: build/DerivedData
+          key: derived-${{ runner.os }}-${{ env.XCODE_VERSION }}-${{ hashFiles('ios/project.yml', 'ios/Podfile.lock') }}
+          restore-keys: |
+            derived-${{ runner.os }}-${{ env.XCODE_VERSION }}-
+
+      - name: Prepare signing workspace
+        run: mkdir -p signing
 
       - name: Decode signing files
         run: |
-          echo "$P12_BASE64" | base64 --decode > signing/cert.p12
-          echo "$MOBILEPROVISION_BASE64" | base64 --decode > signing/profile.mobileprovision
+          echo "$P12_BASE64" | base64 -D > signing/cert.p12
+          echo "$MOBILEPROVISION_BASE64" | base64 -D > signing/profile.mobileprovision
 
       - name: Import certificate & provisioning profile
         run: |
-          bash scripts/import_signing.sh \
+          ./scripts/ci/import_signing.sh \
             signing/cert.p12 \
             "$P12_PASSWORD" \
             signing/profile.mobileprovision \
             "$KEYCHAIN_NAME" \
             "$KEYCHAIN_PASSWORD"
 
-      - name: Resolve profile name
-        id: profile
-        run: |
-          PROFILE_PLIST=$(mktemp)
-          /usr/bin/security cms -D -i signing/profile.mobileprovision > "$PROFILE_PLIST"
-          PROFILE_NAME=$(/usr/libexec/PlistBuddy -c 'Print Name' "$PROFILE_PLIST")
-          echo "name=$PROFILE_NAME" >> $GITHUB_OUTPUT
-
       - name: Xcode Archive (manual signing)
         run: |
-          set -euxo pipefail
-          rm -rf "$ARCHIVE_PATH" "$DERIVED_DATA" "$RESULT_BUNDLE" || true
+          set -euo pipefail
+          rm -rf "$ARCHIVE_PATH" "$RESULT_BUNDLE" || true
           BUNDLE_ID="${BUNDLE_ID_PREFIX}.${BUNDLE_ID_SUFFIX}"
           xcodebuild \
+            -workspace "$WORKSPACE" \
             -scheme "$SCHEME" \
             -configuration "$CONFIGURATION" \
             -archivePath "$ARCHIVE_PATH" \
@@ -102,7 +133,8 @@ jobs:
             CODE_SIGN_STYLE=Manual \
             DEVELOPMENT_TEAM="${TEAM_ID}" \
             PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
-            PROVISIONING_PROFILE_SPECIFIER="${{ steps.profile.outputs.name }}" \
+            PROVISIONING_PROFILE_SPECIFIER="$PROFILE_NAME" \
+            CODE_SIGN_IDENTITY="Apple Distribution" \
             OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_NAME"
 
       - name: Create exportOptions.plist
@@ -120,7 +152,7 @@ jobs:
             <key>destination</key><string>export</string>
             <key>provisioningProfiles</key>
             <dict>
-              <key>${BUNDLE_ID_PREFIX}.${BUNDLE_ID_SUFFIX}</key><string>${{ steps.profile.outputs.name }}</string>
+              <key>${BUNDLE_ID_PREFIX}.${BUNDLE_ID_SUFFIX}</key><string>${PROFILE_NAME}</string>
             </dict>
           </dict>
           </plist>
@@ -128,7 +160,7 @@ jobs:
 
       - name: Export IPA
         run: |
-          bash scripts/export_ipa.sh "$ARCHIVE_PATH" exportOptions.plist export
+          ./scripts/ci/export_ipa.sh "$ARCHIVE_PATH" exportOptions.plist export
 
       - name: Upload IPA
         uses: actions/upload-artifact@v4
@@ -139,4 +171,35 @@ jobs:
       - name: Cleanup keychain
         if: always()
         run: |
-          security delete-keychain "$KEYCHAIN_NAME" || true
+          set -euo pipefail
+          rm -rf signing export exportOptions.plist || true
+          if [ -n "${ORIG_KEYCHAINS_B64:-}" ]; then
+            RESTORE_ARGS=()
+            if ORIG_KEYCHAINS_DECODED=$(python3 - <<'PY'
+import base64, os, sys
+data = os.environ.get("ORIG_KEYCHAINS_B64", "")
+try:
+    sys.stdout.write(base64.b64decode(data.encode()).decode())
+except Exception:
+    sys.exit(1)
+PY
+); then
+              while IFS= read -r keychain; do
+                [ -z "$keychain" ] && continue
+                RESTORE_ARGS+=("$keychain")
+              done <<< "$ORIG_KEYCHAINS_DECODED"
+              if [ ${#RESTORE_ARGS[@]} -gt 0 ]; then
+                security list-keychains -d user -s "${RESTORE_ARGS[@]}"
+              fi
+            else
+              echo "::warning title=Keychain restore failed::Unable to decode original keychain search list." >&2
+            fi
+          fi
+          if [ -n "${ORIG_DEFAULT_KEYCHAIN:-}" ]; then
+            security default-keychain -s "$ORIG_DEFAULT_KEYCHAIN" || true
+          else
+            security default-keychain -s login.keychain-db || true
+          fi
+          if ! security delete-keychain "$KEYCHAIN_NAME"; then
+            echo "::warning title=Keychain cleanup failed::Failed to delete $KEYCHAIN_NAME; investigate runner cleanup." >&2
+          fi

--- a/scripts/ci/export_ipa.sh
+++ b/scripts/ci/export_ipa.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# export_ipa.sh — Wrapper around `xcodebuild -exportArchive` for CI.
+#
+# Arguments:
+#   1. Path to the .xcarchive to export
+#   2. Path to the exportOptions.plist file
+#   3. Output directory for the exported IPA
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+Usage: export_ipa.sh <archive-path> <export-options> <export-dir>
+USAGE
+}
+
+log() {
+  printf '[export_ipa] %s\n' "$*"
+}
+
+if [[ $# -ne 3 ]]; then
+  usage
+  exit 1
+fi
+
+ARCHIVE_PATH=$1
+EXPORT_OPTIONS=$2
+EXPORT_DIR=$3
+
+if [[ ! -d "$ARCHIVE_PATH" ]]; then
+  echo "Archive not found: $ARCHIVE_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -f "$EXPORT_OPTIONS" ]]; then
+  echo "exportOptions.plist not found: $EXPORT_OPTIONS" >&2
+  exit 1
+fi
+
+log "Exporting IPA to $EXPORT_DIR"
+mkdir -p "$EXPORT_DIR"
+
+xcodebuild -exportArchive \
+  -archivePath "$ARCHIVE_PATH" \
+  -exportPath "$EXPORT_DIR" \
+  -exportOptionsPlist "$EXPORT_OPTIONS"
+
+log "Export complete"
+ls -la "$EXPORT_DIR"

--- a/scripts/ci/import_signing.sh
+++ b/scripts/ci/import_signing.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# import_signing.sh — Prepare a temporary keychain and install signing assets for CI builds.
+#
+# Arguments:
+#   1. Path to the .p12 certificate file
+#   2. Password for the .p12 certificate
+#   3. Path to the provisioning profile (.mobileprovision)
+#   4. Name of the keychain to create/use
+#   5. Password for the temporary keychain
+#
+# The script outputs PROFILE_UUID, PROFILE_NAME, ORIG_KEYCHAINS_B64, and
+# ORIG_DEFAULT_KEYCHAIN to $GITHUB_ENV so downstream workflow steps can reference
+# them during signing and cleanup.
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+Usage: import_signing.sh <p12-path> <p12-password> <provision-path> <keychain-name> <keychain-password>
+USAGE
+}
+
+log() {
+  printf '[import_signing] %s\n' "$*"
+}
+
+if [[ $# -ne 5 ]]; then
+  usage
+  exit 1
+fi
+
+P12_PATH=$1
+P12_PASSWORD=$2
+MOBILEPROVISION_PATH=$3
+KEYCHAIN_NAME=$4
+KEYCHAIN_PASSWORD=$5
+
+if [[ ! -f "$P12_PATH" ]]; then
+  echo "Certificate not found: $P12_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -f "$MOBILEPROVISION_PATH" ]]; then
+  echo "Provisioning profile not found: $MOBILEPROVISION_PATH" >&2
+  exit 1
+fi
+
+log "Creating temporary keychain $KEYCHAIN_NAME"
+security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
+security set-keychain-settings -lut 21600 "$KEYCHAIN_NAME"
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
+
+log "Capturing existing keychain search list"
+ORIG_KEYCHAIN_ARRAY=()
+while IFS= read -r line; do
+  parsed=$(printf '%s' "$line" | sed 's/^[ \t]*//' | tr -d '"')
+  if [[ -n "$parsed" ]]; then
+    ORIG_KEYCHAIN_ARRAY+=("$parsed")
+  fi
+done < <(security list-keychains -d user)
+ORIG_DEFAULT_KEYCHAIN=$(security default-keychain | tr -d '"')
+ORIG_KEYCHAINS_JOINED=""
+if (( ${#ORIG_KEYCHAIN_ARRAY[@]} > 0 )); then
+  for keychain in "${ORIG_KEYCHAIN_ARRAY[@]}"; do
+    ORIG_KEYCHAINS_JOINED+="$keychain"$'\n'
+  done
+fi
+ORIG_KEYCHAINS_B64=$(printf '%s' "$ORIG_KEYCHAINS_JOINED" | python3 - <<'PY'
+import base64, sys
+payload = sys.stdin.read().encode()
+sys.stdout.write(base64.b64encode(payload).decode())
+PY
+)
+
+{
+  echo "ORIG_KEYCHAINS_B64=$ORIG_KEYCHAINS_B64"
+  echo "ORIG_DEFAULT_KEYCHAIN=$ORIG_DEFAULT_KEYCHAIN"
+} >> "$GITHUB_ENV"
+
+log "Importing signing certificate"
+security import "$P12_PATH" -k "$KEYCHAIN_NAME" -P "$P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME" || true
+
+log "Updating keychain search path"
+security list-keychains -d user -s "$KEYCHAIN_NAME" "${ORIG_KEYCHAIN_ARRAY[@]}"
+security default-keychain -s "$KEYCHAIN_NAME"
+
+log "Installing provisioning profile"
+PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+mkdir -p "$PROFILE_DIR"
+# shellcheck disable=SC2317 # false positive: trap handler defined below is used by EXIT trap
+cleanup_plist() {
+  rm -f "$PLIST_TMP"
+}
+
+PLIST_TMP=$(mktemp)
+trap cleanup_plist EXIT
+
+security cms -D -i "$MOBILEPROVISION_PATH" > "$PLIST_TMP"
+PROFILE_UUID=$(/usr/libexec/PlistBuddy -c 'Print UUID' "$PLIST_TMP")
+PROFILE_NAME=$(/usr/libexec/PlistBuddy -c 'Print Name' "$PLIST_TMP")
+cp "$MOBILEPROVISION_PATH" "$PROFILE_DIR/$PROFILE_UUID.mobileprovision"
+
+{
+  echo "PROFILE_UUID=$PROFILE_UUID"
+  echo "PROFILE_NAME=$PROFILE_NAME"
+} >> "$GITHUB_ENV"
+
+log "Provisioning profile $PROFILE_NAME ($PROFILE_UUID) installed"
+
+exit 0


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that imports signing assets, archives monGARS with manual signing, and exports a signed Ad-Hoc IPA

## Testing
- npm test -- --runInBand
- npm run lint
- CI=true npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68d238ae7ff48333b898bfe359cfd1a8

## Summary by Sourcery

Implement a GitHub Actions workflow that automates importing signing assets, performing an Xcode archive with manual Ad-Hoc signing, exporting the IPA, and uploading it as a build artifact.

New Features:
- Import signing credentials and provisioning profiles into a temporary keychain and set up manual code signing
- Archive the monGARS iOS app with manual signing and export an Ad-Hoc signed IPA
- Upload the generated IPA as a GitHub Actions artifact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI workflow to build and export AdHoc-signed iOS apps on pushes, pull requests, and manual runs, uploading the IPA as an artifact.
  * Added CI scripts to import signing assets, manage keychains, and run Xcode archive/export reliably with cleanup and error handling.
  * Enhances build reliability and enables faster QA distribution via downloadable iOS artifacts.
  * No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->