### PR TITLE
Fix iOS AdHoc workflow keychain import

### DIFF
--- a/.github/workflows/ios-adhoc-export.yml
+++ b/.github/workflows/ios-adhoc-export.yml
@@ -70,17 +70,47 @@ jobs:
         run: |
           python - <<'PY'
           import base64
+          import binascii
           import os
+          import sys
           from pathlib import Path
+
+          REQUIRED_ENV_VARS = {
+              "P12_BASE64": "signing/cert.p12",
+              "MOBILEPROVISION_BASE64": "signing/profile.mobileprovision",
+          }
 
           signing_dir = Path("signing")
           signing_dir.mkdir(parents=True, exist_ok=True)
 
-          with open(signing_dir / "cert.p12", "wb") as cert_file:
-              cert_file.write(base64.b64decode(os.environ["P12_BASE64"]))
+          def decode_secret(env_var: str, output_path: Path) -> None:
+              value = os.environ.get(env_var)
+              if not value:
+                  sys.stderr.write(
+                      f"::error ::Missing signing secret {env_var}. "
+                      "Add it to the repository secrets before rerunning.\n"
+                  )
+                  sys.exit(1)
 
-          with open(signing_dir / "profile.mobileprovision", "wb") as profile_file:
-              profile_file.write(base64.b64decode(os.environ["MOBILEPROVISION_BASE64"]))
+              try:
+                  decoded = base64.b64decode(value)
+              except binascii.Error as exc:
+                  sys.stderr.write(
+                      f"::error ::Secret {env_var} is not valid base64: {exc}\n"
+                  )
+                  sys.exit(1)
+
+              if not decoded:
+                  sys.stderr.write(
+                      f"::error ::Secret {env_var} decoded to 0 bytes. "
+                      "Verify the uploaded file and try again.\n"
+                  )
+                  sys.exit(1)
+
+              output_path.write_bytes(decoded)
+
+          for env_var, relative_path in REQUIRED_ENV_VARS.items():
+              decode_secret(env_var, Path(relative_path))
           PY
 
       - name: Import certificate & provisioning profile

--- a/.github/workflows/ios-adhoc-export.yml
+++ b/.github/workflows/ios-adhoc-export.yml
@@ -240,23 +240,30 @@ jobs:
             exit 1
           fi
 
-          RESOLVED_BUNDLE_ID="$PROFILE_BUNDLE_ID"
+          if [ -n "$REQUESTED_BUNDLE_ID" ] && [ "$REQUESTED_BUNDLE_ID" != "$PROFILE_BUNDLE_ID" ]; then
+            echo "::error ::Provisioning profile bundle identifier $PROFILE_BUNDLE_ID does not match requested bundle identifier $REQUESTED_BUNDLE_ID. Update the configured secrets or upload a matching provisioning profile."
+            exit 1
+          fi
+
           if [ -n "$REQUESTED_BUNDLE_ID" ]; then
-            if [ "$REQUESTED_BUNDLE_ID" = "$PROFILE_BUNDLE_ID" ]; then
-              RESOLVED_BUNDLE_ID="$REQUESTED_BUNDLE_ID"
-            else
-              echo "::warning ::Requested bundle identifier $REQUESTED_BUNDLE_ID does not match provisioning profile bundle $PROFILE_BUNDLE_ID. Using provisioning profile identifier."
-            fi
+            RESOLVED_BUNDLE_ID="$REQUESTED_BUNDLE_ID"
+          else
+            RESOLVED_BUNDLE_ID="$PROFILE_BUNDLE_ID"
           fi
 
           RESOLVED_TEAM_ID="${TEAM_ID:-}"
-          if [ -z "$RESOLVED_TEAM_ID" ]; then
-            RESOLVED_TEAM_ID="$PROFILE_TEAM_ID"
+          if [ -n "$RESOLVED_TEAM_ID" ] && [ -n "$PROFILE_TEAM_ID" ] && [ "$RESOLVED_TEAM_ID" != "$PROFILE_TEAM_ID" ]; then
+            echo "::error ::Provisioning profile team identifier $PROFILE_TEAM_ID does not match TEAM_ID secret $RESOLVED_TEAM_ID. Update the configured secrets or upload a matching provisioning profile."
+            exit 1
           fi
 
           if [ -z "$RESOLVED_TEAM_ID" ]; then
-            echo "::error ::Unable to determine Apple team identifier from secrets or provisioning profile."
-            exit 1
+            if [ -n "$PROFILE_TEAM_ID" ]; then
+              RESOLVED_TEAM_ID="$PROFILE_TEAM_ID"
+            else
+              echo "::error ::Unable to determine Apple team identifier from secrets or provisioning profile."
+              exit 1
+            fi
           fi
 
           echo "bundle_id=$RESOLVED_BUNDLE_ID" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ios-adhoc-export.yml
+++ b/.github/workflows/ios-adhoc-export.yml
@@ -190,19 +190,86 @@ jobs:
             "$KEYCHAIN_NAME" \
             "$KEYCHAIN_PASSWORD"
 
-      - name: Resolve profile name
+      - name: Resolve provisioning profile metadata
         id: profile
         run: |
+          set -euo pipefail
           PROFILE_PLIST=$(mktemp)
           /usr/bin/security cms -D -i signing/profile.mobileprovision > "$PROFILE_PLIST"
           PROFILE_NAME=$(/usr/libexec/PlistBuddy -c 'Print Name' "$PROFILE_PLIST")
-          echo "name=$PROFILE_NAME" >> $GITHUB_OUTPUT
+          APPLICATION_IDENTIFIER=$(/usr/libexec/PlistBuddy -c 'Print Entitlements:application-identifier' "$PROFILE_PLIST")
+          if [[ "$APPLICATION_IDENTIFIER" == *.* ]]; then
+            PROFILE_BUNDLE_ID="${APPLICATION_IDENTIFIER#*.}"
+          else
+            PROFILE_BUNDLE_ID="$APPLICATION_IDENTIFIER"
+          fi
+          PROFILE_TEAM_ID=$(/usr/libexec/PlistBuddy -c 'Print ApplicationIdentifierPrefix:0' "$PROFILE_PLIST" 2>/dev/null || true)
+          if [ -z "$PROFILE_TEAM_ID" ]; then
+            PROFILE_TEAM_ID=$(/usr/libexec/PlistBuddy -c 'Print Entitlements:com.apple.developer.team-identifier' "$PROFILE_PLIST" 2>/dev/null || true)
+          fi
+          if [ -z "$PROFILE_BUNDLE_ID" ]; then
+            echo "::error ::Failed to read bundle identifier from provisioning profile."
+            exit 1
+          fi
+          echo "name=$PROFILE_NAME" >> "$GITHUB_OUTPUT"
+          echo "bundle_id=$PROFILE_BUNDLE_ID" >> "$GITHUB_OUTPUT"
+          if [ -n "$PROFILE_TEAM_ID" ]; then
+            echo "team_id=$PROFILE_TEAM_ID" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Determine signing configuration
+        id: signing
+        run: |
+          set -euo pipefail
+          PROFILE_BUNDLE_ID="${{ steps.profile.outputs.bundle_id }}"
+          PROFILE_TEAM_ID="${{ steps.profile.outputs.team_id }}"
+
+          REQUESTED_BUNDLE_ID=""
+          if [ -n "${BUNDLE_ID_SUFFIX:-}" ]; then
+            if [ -n "${BUNDLE_ID_PREFIX:-}" ]; then
+              REQUESTED_BUNDLE_ID="${BUNDLE_ID_PREFIX}.${BUNDLE_ID_SUFFIX}"
+            else
+              REQUESTED_BUNDLE_ID="${BUNDLE_ID_SUFFIX}"
+            fi
+          elif [ -n "${BUNDLE_ID_PREFIX:-}" ]; then
+            REQUESTED_BUNDLE_ID="${BUNDLE_ID_PREFIX}"
+          fi
+
+          if [ -z "$PROFILE_BUNDLE_ID" ]; then
+            echo "::error ::Provisioning profile did not expose an application identifier."
+            exit 1
+          fi
+
+          RESOLVED_BUNDLE_ID="$PROFILE_BUNDLE_ID"
+          if [ -n "$REQUESTED_BUNDLE_ID" ]; then
+            if [ "$REQUESTED_BUNDLE_ID" = "$PROFILE_BUNDLE_ID" ]; then
+              RESOLVED_BUNDLE_ID="$REQUESTED_BUNDLE_ID"
+            else
+              echo "::warning ::Requested bundle identifier $REQUESTED_BUNDLE_ID does not match provisioning profile bundle $PROFILE_BUNDLE_ID. Using provisioning profile identifier."
+            fi
+          fi
+
+          RESOLVED_TEAM_ID="${TEAM_ID:-}"
+          if [ -z "$RESOLVED_TEAM_ID" ]; then
+            RESOLVED_TEAM_ID="$PROFILE_TEAM_ID"
+          fi
+
+          if [ -z "$RESOLVED_TEAM_ID" ]; then
+            echo "::error ::Unable to determine Apple team identifier from secrets or provisioning profile."
+            exit 1
+          fi
+
+          echo "bundle_id=$RESOLVED_BUNDLE_ID" >> "$GITHUB_OUTPUT"
+          echo "team_id=$RESOLVED_TEAM_ID" >> "$GITHUB_OUTPUT"
+          echo "RESOLVED_BUNDLE_ID=$RESOLVED_BUNDLE_ID" >> "$GITHUB_ENV"
+          echo "RESOLVED_TEAM_ID=$RESOLVED_TEAM_ID" >> "$GITHUB_ENV"
 
       - name: Xcode Archive (manual signing)
         run: |
           set -euxo pipefail
           rm -rf "$ARCHIVE_PATH" "$DERIVED_DATA" "$RESULT_BUNDLE" || true
-          BUNDLE_ID="${BUNDLE_ID_PREFIX}.${BUNDLE_ID_SUFFIX}"
+          : "${RESOLVED_BUNDLE_ID:?Resolved bundle identifier missing}"
+          : "${RESOLVED_TEAM_ID:?Resolved team identifier missing}"
           xcodebuild \
             -workspace "$WORKSPACE" \
             -scheme "$SCHEME" \
@@ -213,8 +280,8 @@ jobs:
             -resultBundlePath "$RESULT_BUNDLE" \
             archive \
             CODE_SIGN_STYLE=Manual \
-            DEVELOPMENT_TEAM="${TEAM_ID}" \
-            PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
+            DEVELOPMENT_TEAM="$RESOLVED_TEAM_ID" \
+            PRODUCT_BUNDLE_IDENTIFIER="$RESOLVED_BUNDLE_ID" \
             PROVISIONING_PROFILE_SPECIFIER="${{ steps.profile.outputs.name }}" \
             OTHER_CODE_SIGN_FLAGS="--keychain ${KEYCHAIN_PATH:-$HOME/Library/Keychains/$KEYCHAIN_NAME}"
 
@@ -225,15 +292,15 @@ jobs:
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
           <dict>
-            <key>method</key><string>ad-hoc</string>
+            <key>method</key><string>release-testing</string>
             <key>signingStyle</key><string>manual</string>
-            <key>teamID</key><string>${TEAM_ID}</string>
+            <key>teamID</key><string>${RESOLVED_TEAM_ID}</string>
             <key>compileBitcode</key><false/>
             <key>stripSwiftSymbols</key><true/>
             <key>destination</key><string>export</string>
             <key>provisioningProfiles</key>
             <dict>
-              <key>${BUNDLE_ID_PREFIX}.${BUNDLE_ID_SUFFIX}</key><string>${{ steps.profile.outputs.name }}</string>
+              <key>${RESOLVED_BUNDLE_ID}</key><string>${{ steps.profile.outputs.name }}</string>
             </dict>
           </dict>
           </plist>

--- a/.github/workflows/ios-adhoc-export.yml
+++ b/.github/workflows/ios-adhoc-export.yml
@@ -227,22 +227,58 @@ jobs:
 
           PREFIX="${BUNDLE_ID_PREFIX:-}"
           SUFFIX="${BUNDLE_ID_SUFFIX:-}"
-          REQUESTED_BUNDLE_ID=""
+          REQUESTED_BUNDLE_ID="${BUNDLE_IDENTIFIER:-}"
 
-          if [ -n "$PREFIX" ] || [ -n "$SUFFIX" ]; then
-            if [ -z "$PREFIX" ]; then
-              echo "::error ::BUNDLE_ID_SUFFIX is set but BUNDLE_ID_PREFIX is empty. Provide both or omit the suffix secret."
-              exit 1
-            fi
+          if [ -n "$PREFIX" ]; then
             CLEAN_PREFIX="${PREFIX%.}"
             if [ -n "$SUFFIX" ]; then
               CLEAN_SUFFIX="${SUFFIX#.}"
+              if [ -z "$CLEAN_SUFFIX" ]; then
+                echo "::error ::BUNDLE_ID_SUFFIX resolved to an empty value after trimming dots."
+                exit 1
+              fi
               REQUESTED_BUNDLE_ID="$CLEAN_PREFIX.$CLEAN_SUFFIX"
             else
               REQUESTED_BUNDLE_ID="$CLEAN_PREFIX"
             fi
-          elif [ -n "${BUNDLE_IDENTIFIER:-}" ]; then
-            REQUESTED_BUNDLE_ID="$BUNDLE_IDENTIFIER"
+          elif [ -n "$SUFFIX" ]; then
+            CLEAN_SUFFIX="${SUFFIX#.}"
+            if [ -z "$CLEAN_SUFFIX" ]; then
+              echo "::error ::BUNDLE_ID_SUFFIX resolved to an empty value after trimming dots."
+              exit 1
+            fi
+
+            if [ -n "$REQUESTED_BUNDLE_ID" ]; then
+              BASE_SOURCE="BUNDLE_IDENTIFIER"
+              BASE="$REQUESTED_BUNDLE_ID"
+            else
+              BASE_SOURCE="provisioning profile"
+              BASE="$PROFILE_BUNDLE_ID"
+            fi
+
+            BASE="${BASE%%\*}"
+            BASE="${BASE%.}"
+
+            if [ -z "$BASE" ]; then
+              echo "::error ::Unable to derive bundle identifier prefix for suffix override. Set BUNDLE_ID_PREFIX or provide a full BUNDLE_IDENTIFIER."
+              exit 1
+            fi
+
+            if [[ "$BASE" == *."$CLEAN_SUFFIX" ]]; then
+              BASE="${BASE%.$CLEAN_SUFFIX}"
+            elif [ "$BASE_SOURCE" = "BUNDLE_IDENTIFIER" ] && [[ "$BASE" == *.*.* ]]; then
+              BASE="${BASE%.*}"
+            fi
+
+            BASE="${BASE%.}"
+
+            if [ -z "$BASE" ]; then
+              echo "::error ::Derived bundle identifier prefix was empty after normalization. Provide BUNDLE_ID_PREFIX or a full BUNDLE_IDENTIFIER."
+              exit 1
+            fi
+
+            REQUESTED_BUNDLE_ID="$BASE.$CLEAN_SUFFIX"
+            echo "::notice ::Derived bundle identifier prefix '$BASE' from $BASE_SOURCE for suffix override."
           fi
 
           if [ -z "$PROFILE_BUNDLE_ID" ]; then

--- a/.github/workflows/ios-adhoc-export.yml
+++ b/.github/workflows/ios-adhoc-export.yml
@@ -1,0 +1,156 @@
+name: iOS AdHoc Signed IPA
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  build-adhoc:
+    runs-on: macos-15
+
+    env:
+      SCHEME: monGARS
+      CONFIGURATION: Release
+      ARCHIVE_PATH: build/monGARS.xcarchive
+      DERIVED_DATA: build/DerivedData
+      RESULT_BUNDLE: build/DerivedData/ResultBundle_build.xcresult
+
+      BUNDLE_ID_PREFIX: anardoni.export
+      BUNDLE_ID_SUFFIX: ${{ secrets.BUNDLE_ID_SUFFIX }}
+      TEAM_ID: ${{ secrets.TEAM_ID }}
+
+      KEYCHAIN_NAME: build-signing.keychain-db
+      KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+
+      P12_BASE64: ${{ secrets.P12_BASE64 }}
+      P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+      MOBILEPROVISION_BASE64: ${{ secrets.MOBILEPROVISION_BASE64 }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare scripts
+        run: |
+          mkdir -p scripts signing
+          cat > scripts/import_signing.sh <<'BASH'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          P12_PATH="$1"; P12_PASSWORD="$2"; MP_PATH="$3"; KC_NAME="$4"; KC_PASS="$5"
+          KC_PATH="$HOME/Library/Keychains/$KC_NAME"
+          security create-keychain -p "$KC_PASS" "$KC_PATH"
+          security set-keychain-settings -lut 21600 "$KC_PATH"
+          security unlock-keychain -p "$KC_PASS" "$KC_PATH"
+          security import "$P12_PATH" -k "$KC_PATH" -P "$P12_PASSWORD" -f pkcs12 -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KC_PASS" "$KC_PATH" || true
+          security list-keychains -d user -s "$KC_PATH"
+          security default-keychain -s "$KC_PATH"
+          PP_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"; mkdir -p "$PP_DIR"
+          PLIST_TMP=$(mktemp); security cms -D -i "$MP_PATH" > "$PLIST_TMP"
+          UUID=$(/usr/libexec/PlistBuddy -c 'Print UUID' "$PLIST_TMP")
+          cp "$MP_PATH" "$PP_DIR/$UUID.mobileprovision"
+          echo "PROFILE_UUID=$UUID" >> "$GITHUB_ENV"
+          echo "KEYCHAIN_PATH=$KC_PATH" >> "$GITHUB_ENV"
+          BASH
+          chmod +x scripts/import_signing.sh
+
+          cat > scripts/export_ipa.sh <<'BASH'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          ARCHIVE_PATH="$1"; EXPORT_OPTS="$2"; EXPORT_DIR="$3"
+          mkdir -p "$EXPORT_DIR"
+          xcodebuild -exportArchive -archivePath "$ARCHIVE_PATH" -exportPath "$EXPORT_DIR" -exportOptionsPlist "$EXPORT_OPTS" -allowProvisioningUpdates
+          ls -la "$EXPORT_DIR"
+          BASH
+          chmod +x scripts/export_ipa.sh
+
+      - name: Decode signing files
+        run: |
+          python - <<'PY'
+          import base64
+          import os
+          from pathlib import Path
+
+          signing_dir = Path("signing")
+          signing_dir.mkdir(parents=True, exist_ok=True)
+
+          with open(signing_dir / "cert.p12", "wb") as cert_file:
+              cert_file.write(base64.b64decode(os.environ["P12_BASE64"]))
+
+          with open(signing_dir / "profile.mobileprovision", "wb") as profile_file:
+              profile_file.write(base64.b64decode(os.environ["MOBILEPROVISION_BASE64"]))
+          PY
+
+      - name: Import certificate & provisioning profile
+        run: |
+          bash scripts/import_signing.sh \
+            signing/cert.p12 \
+            "$P12_PASSWORD" \
+            signing/profile.mobileprovision \
+            "$KEYCHAIN_NAME" \
+            "$KEYCHAIN_PASSWORD"
+
+      - name: Resolve profile name
+        id: profile
+        run: |
+          PROFILE_PLIST=$(mktemp)
+          /usr/bin/security cms -D -i signing/profile.mobileprovision > "$PROFILE_PLIST"
+          PROFILE_NAME=$(/usr/libexec/PlistBuddy -c 'Print Name' "$PROFILE_PLIST")
+          echo "name=$PROFILE_NAME" >> $GITHUB_OUTPUT
+
+      - name: Xcode Archive (manual signing)
+        run: |
+          set -euxo pipefail
+          rm -rf "$ARCHIVE_PATH" "$DERIVED_DATA" "$RESULT_BUNDLE" || true
+          BUNDLE_ID="${BUNDLE_ID_PREFIX}.${BUNDLE_ID_SUFFIX}"
+          xcodebuild \
+            -scheme "$SCHEME" \
+            -configuration "$CONFIGURATION" \
+            -archivePath "$ARCHIVE_PATH" \
+            -destination "generic/platform=iOS" \
+            -derivedDataPath "$DERIVED_DATA" \
+            -resultBundlePath "$RESULT_BUNDLE" \
+            archive \
+            CODE_SIGN_STYLE=Manual \
+            DEVELOPMENT_TEAM="${TEAM_ID}" \
+            PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
+            PROVISIONING_PROFILE_SPECIFIER="${{ steps.profile.outputs.name }}" \
+            OTHER_CODE_SIGN_FLAGS="--keychain ${KEYCHAIN_PATH:-$HOME/Library/Keychains/$KEYCHAIN_NAME}"
+
+      - name: Create exportOptions.plist
+        run: |
+          cat > exportOptions.plist <<PLIST
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key><string>ad-hoc</string>
+            <key>signingStyle</key><string>manual</string>
+            <key>teamID</key><string>${TEAM_ID}</string>
+            <key>compileBitcode</key><false/>
+            <key>stripSwiftSymbols</key><true/>
+            <key>destination</key><string>export</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>${BUNDLE_ID_PREFIX}.${BUNDLE_ID_SUFFIX}</key><string>${{ steps.profile.outputs.name }}</string>
+            </dict>
+          </dict>
+          </plist>
+          PLIST
+
+      - name: Export IPA
+        run: |
+          bash scripts/export_ipa.sh "$ARCHIVE_PATH" exportOptions.plist export
+
+      - name: Upload IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: monGARS-AdHoc-IPA
+          path: export/*.ipa
+
+      - name: Cleanup keychain
+        if: always()
+        run: |
+          security delete-keychain "${KEYCHAIN_PATH:-$KEYCHAIN_NAME}" || true

--- a/.github/workflows/ios-adhoc-export.yml
+++ b/.github/workflows/ios-adhoc-export.yml
@@ -8,23 +8,16 @@ on:
 
 jobs:
   build-adhoc:
-    environment:
-      name: offLLM
     runs-on: macos-15
 
     env:
-      NODE_VERSION: "20"
-      RUBY_VERSION: "3.2"
-      XCODE_VERSION: "16.4"
       SCHEME: monGARS
       CONFIGURATION: Release
       ARCHIVE_PATH: build/monGARS.xcarchive
       DERIVED_DATA: build/DerivedData
       RESULT_BUNDLE: build/DerivedData/ResultBundle_build.xcresult
-      WORKSPACE: ios/monGARS.xcworkspace
 
-      BUNDLE_IDENTIFIER: ${{ secrets.BUNDLE_IDENTIFIER != '' && secrets.BUNDLE_IDENTIFIER || 'anardoni.export.monGARS' }}
-      BUNDLE_ID_PREFIX: ${{ secrets.BUNDLE_ID_PREFIX }}
+      BUNDLE_ID_PREFIX: anardoni.export
       BUNDLE_ID_SUFFIX: ${{ secrets.BUNDLE_ID_SUFFIX }}
       TEAM_ID: ${{ secrets.TEAM_ID }}
 
@@ -39,92 +32,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Select Xcode ${{ env.XCODE_VERSION }}
-        run: |
-          sudo xcode-select -s "/Applications/Xcode_${XCODE_VERSION}.app"
-          xcodebuild -version
-
-      - name: Download bundled MLX model
-        run: ./scripts/ci/download-mlx-model.sh
-
-      - name: Set up Node ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v5
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-          cache-dependency-path: package-lock.json
-
-      - name: Install JS dependencies
-        run: npm ci
-
-      - name: Set up Ruby ${{ env.RUBY_VERSION }}
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-          bundler-cache: true
-          working-directory: ios
-
-      - name: Cache Pods
-        uses: actions/cache@v4
-        with:
-          path: ios/Pods
-          key: pods-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock') }}
-          restore-keys: pods-${{ runner.os }}-
-
-      - name: Install XcodeGen
-        run: |
-          if ! command -v xcodegen >/dev/null 2>&1; then
-            brew install xcodegen
-          fi
-
-      - name: Generate Xcode project
-        working-directory: ios
-        run: xcodegen generate
-
-      - name: Install CocoaPods
-        id: install_pods
-        working-directory: ios
-        run: |
-          set -euo pipefail
-          if bundle exec pod install --repo-update; then
-            exit 0
-          fi
-          echo "bundle exec pod install failed; retrying with system pod"
-          pod install --repo-update
-
-      - name: Verify workspace
-        run: |
-          if [ ! -d "$WORKSPACE" ]; then
-            echo "::error ::Expected workspace $WORKSPACE to exist after pod install."
-            exit 1
-          fi
-
       - name: Prepare scripts
         run: |
-          SCRIPTS_DIR="$RUNNER_TEMP/signing-scripts"
-          mkdir -p "$SCRIPTS_DIR" signing
-          cat > "$SCRIPTS_DIR/import_signing.sh" <<'BASH'
+          mkdir -p scripts signing
+          cat > scripts/import_signing.sh <<'BASH'
           #!/usr/bin/env bash
           set -euo pipefail
           P12_PATH="$1"; P12_PASSWORD="$2"; MP_PATH="$3"; KC_NAME="$4"; KC_PASS="$5"
-          KC_PATH="$HOME/Library/Keychains/$KC_NAME"
-          security create-keychain -p "$KC_PASS" "$KC_PATH"
-          security set-keychain-settings -lut 21600 "$KC_PATH"
-          security unlock-keychain -p "$KC_PASS" "$KC_PATH"
-          security import "$P12_PATH" -k "$KC_PATH" -P "$P12_PASSWORD" -f pkcs12 -T /usr/bin/codesign -T /usr/bin/security
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$KC_PASS" "$KC_PATH" || true
-          security list-keychains -d user -s "$KC_PATH"
-          security default-keychain -s "$KC_PATH"
+          security create-keychain -p "$KC_PASS" "$KC_NAME"
+          security set-keychain-settings -lut 21600 "$KC_NAME"
+          security unlock-keychain -p "$KC_PASS" "$KC_NAME"
+          security import "$P12_PATH" -k "$KC_NAME" -P "$P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KC_PASS" "$KC_NAME" || true
+          security list-keychains -d user -s "$KC_NAME"
+          security default-keychain -s "$KC_NAME"
           PP_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"; mkdir -p "$PP_DIR"
           PLIST_TMP=$(mktemp); security cms -D -i "$MP_PATH" > "$PLIST_TMP"
           UUID=$(/usr/libexec/PlistBuddy -c 'Print UUID' "$PLIST_TMP")
           cp "$MP_PATH" "$PP_DIR/$UUID.mobileprovision"
           echo "PROFILE_UUID=$UUID" >> "$GITHUB_ENV"
-          echo "KEYCHAIN_PATH=$KC_PATH" >> "$GITHUB_ENV"
           BASH
-          chmod +x "$SCRIPTS_DIR/import_signing.sh"
+          chmod +x scripts/import_signing.sh
 
-          cat > "$SCRIPTS_DIR/export_ipa.sh" <<'BASH'
+          cat > scripts/export_ipa.sh <<'BASH'
           #!/usr/bin/env bash
           set -euo pipefail
           ARCHIVE_PATH="$1"; EXPORT_OPTS="$2"; EXPORT_DIR="$3"
@@ -132,211 +62,36 @@ jobs:
           xcodebuild -exportArchive -archivePath "$ARCHIVE_PATH" -exportPath "$EXPORT_DIR" -exportOptionsPlist "$EXPORT_OPTS" -allowProvisioningUpdates
           ls -la "$EXPORT_DIR"
           BASH
-          chmod +x "$SCRIPTS_DIR/export_ipa.sh"
-          echo "SIGNING_SCRIPTS_DIR=$SCRIPTS_DIR" >> "$GITHUB_ENV"
+          chmod +x scripts/export_ipa.sh
 
       - name: Decode signing files
         run: |
-          python - <<'PY'
-          import base64
-          import binascii
-          import os
-          import sys
-          from pathlib import Path
-
-          REQUIRED_ENV_VARS = {
-              "P12_BASE64": "signing/cert.p12",
-              "MOBILEPROVISION_BASE64": "signing/profile.mobileprovision",
-          }
-
-          signing_dir = Path("signing")
-          signing_dir.mkdir(parents=True, exist_ok=True)
-
-          def decode_secret(env_var: str, output_path: Path) -> None:
-              value = os.environ.get(env_var)
-              if not value:
-                  sys.stderr.write(
-                      f"::error ::Missing signing secret {env_var}. "
-                      "Add it to the repository or environment secrets before rerunning.\n"
-                  )
-                  sys.exit(1)
-
-              try:
-                  decoded = base64.b64decode(value)
-              except binascii.Error as exc:
-                  sys.stderr.write(
-                      f"::error ::Secret {env_var} is not valid base64: {exc}\n"
-                  )
-                  sys.exit(1)
-
-              if not decoded:
-                  sys.stderr.write(
-                      f"::error ::Secret {env_var} decoded to 0 bytes. "
-                      "Verify the uploaded file and try again.\n"
-                  )
-                  sys.exit(1)
-
-              output_path.write_bytes(decoded)
-
-          for env_var, relative_path in REQUIRED_ENV_VARS.items():
-              decode_secret(env_var, Path(relative_path))
-          PY
+          echo "$P12_BASE64" | base64 --decode > signing/cert.p12
+          echo "$MOBILEPROVISION_BASE64" | base64 --decode > signing/profile.mobileprovision
 
       - name: Import certificate & provisioning profile
         run: |
-          bash "$SIGNING_SCRIPTS_DIR/import_signing.sh" \
+          bash scripts/import_signing.sh \
             signing/cert.p12 \
             "$P12_PASSWORD" \
             signing/profile.mobileprovision \
             "$KEYCHAIN_NAME" \
             "$KEYCHAIN_PASSWORD"
 
-      - name: Resolve provisioning profile metadata
+      - name: Resolve profile name
         id: profile
         run: |
-          set -euo pipefail
           PROFILE_PLIST=$(mktemp)
           /usr/bin/security cms -D -i signing/profile.mobileprovision > "$PROFILE_PLIST"
           PROFILE_NAME=$(/usr/libexec/PlistBuddy -c 'Print Name' "$PROFILE_PLIST")
-          APPLICATION_IDENTIFIER=$(/usr/libexec/PlistBuddy -c 'Print Entitlements:application-identifier' "$PROFILE_PLIST")
-          if [[ "$APPLICATION_IDENTIFIER" == *.* ]]; then
-            PROFILE_BUNDLE_ID="${APPLICATION_IDENTIFIER#*.}"
-          else
-            PROFILE_BUNDLE_ID="$APPLICATION_IDENTIFIER"
-          fi
-          PROFILE_TEAM_ID=$(/usr/libexec/PlistBuddy -c 'Print ApplicationIdentifierPrefix:0' "$PROFILE_PLIST" 2>/dev/null || true)
-          if [ -z "$PROFILE_TEAM_ID" ]; then
-            PROFILE_TEAM_ID=$(/usr/libexec/PlistBuddy -c 'Print Entitlements:com.apple.developer.team-identifier' "$PROFILE_PLIST" 2>/dev/null || true)
-          fi
-          if [ -z "$PROFILE_BUNDLE_ID" ]; then
-            echo "::error ::Failed to read bundle identifier from provisioning profile."
-            exit 1
-          fi
-          echo "name=$PROFILE_NAME" >> "$GITHUB_OUTPUT"
-          echo "bundle_id=$PROFILE_BUNDLE_ID" >> "$GITHUB_OUTPUT"
-          if [ -n "$PROFILE_TEAM_ID" ]; then
-            echo "team_id=$PROFILE_TEAM_ID" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Determine signing configuration
-        id: signing
-        run: |
-          set -euo pipefail
-          PROFILE_BUNDLE_ID="${{ steps.profile.outputs.bundle_id }}"
-          PROFILE_TEAM_ID="${{ steps.profile.outputs.team_id }}"
-
-          PREFIX="${BUNDLE_ID_PREFIX:-}"
-          SUFFIX="${BUNDLE_ID_SUFFIX:-}"
-          REQUESTED_BUNDLE_ID="${BUNDLE_IDENTIFIER:-}"
-
-          if [ -n "$PREFIX" ]; then
-            CLEAN_PREFIX="${PREFIX%.}"
-            if [ -n "$SUFFIX" ]; then
-              CLEAN_SUFFIX="${SUFFIX#.}"
-              if [ -z "$CLEAN_SUFFIX" ]; then
-                echo "::error ::BUNDLE_ID_SUFFIX resolved to an empty value after trimming dots."
-                exit 1
-              fi
-              REQUESTED_BUNDLE_ID="$CLEAN_PREFIX.$CLEAN_SUFFIX"
-            else
-              REQUESTED_BUNDLE_ID="$CLEAN_PREFIX"
-            fi
-          elif [ -n "$SUFFIX" ]; then
-            CLEAN_SUFFIX="${SUFFIX#.}"
-            if [ -z "$CLEAN_SUFFIX" ]; then
-              echo "::error ::BUNDLE_ID_SUFFIX resolved to an empty value after trimming dots."
-              exit 1
-            fi
-
-            if [ -n "$REQUESTED_BUNDLE_ID" ]; then
-              BASE_SOURCE="BUNDLE_IDENTIFIER"
-              BASE="$REQUESTED_BUNDLE_ID"
-            else
-              BASE_SOURCE="provisioning profile"
-              BASE="$PROFILE_BUNDLE_ID"
-            fi
-
-            BASE="${BASE%%\*}"
-            BASE="${BASE%.}"
-
-            if [ -z "$BASE" ]; then
-              echo "::error ::Unable to derive bundle identifier prefix for suffix override. Set BUNDLE_ID_PREFIX or provide a full BUNDLE_IDENTIFIER."
-              exit 1
-            fi
-
-            if [[ "$BASE" == *."$CLEAN_SUFFIX" ]]; then
-              BASE="${BASE%.$CLEAN_SUFFIX}"
-            elif [ "$BASE_SOURCE" = "BUNDLE_IDENTIFIER" ] && [[ "$BASE" == *.*.* ]]; then
-              BASE="${BASE%.*}"
-            fi
-
-            BASE="${BASE%.}"
-
-            if [ -z "$BASE" ]; then
-              echo "::error ::Derived bundle identifier prefix was empty after normalization. Provide BUNDLE_ID_PREFIX or a full BUNDLE_IDENTIFIER."
-              exit 1
-            fi
-
-            REQUESTED_BUNDLE_ID="$BASE.$CLEAN_SUFFIX"
-            echo "::notice ::Derived bundle identifier prefix '$BASE' from $BASE_SOURCE for suffix override."
-          fi
-
-          if [ -z "$PROFILE_BUNDLE_ID" ]; then
-            echo "::error ::Provisioning profile did not expose an application identifier."
-            exit 1
-          fi
-
-          if [ -n "$REQUESTED_BUNDLE_ID" ] && [ -n "$PROFILE_BUNDLE_ID" ]; then
-            MATCHED="false"
-            if [ "$REQUESTED_BUNDLE_ID" = "$PROFILE_BUNDLE_ID" ]; then
-              MATCHED="true"
-            elif [[ "$PROFILE_BUNDLE_ID" == *"*" ]]; then
-              PROFILE_PREFIX="${PROFILE_BUNDLE_ID%%\*}"
-              if [[ "$REQUESTED_BUNDLE_ID" == "$PROFILE_PREFIX"* ]]; then
-                MATCHED="true"
-              fi
-            fi
-
-            if [ "$MATCHED" != "true" ]; then
-              echo "::error ::Provisioning profile bundle identifier $PROFILE_BUNDLE_ID does not match requested bundle identifier $REQUESTED_BUNDLE_ID. Update the configured secrets or upload a matching provisioning profile."
-              exit 1
-            fi
-          fi
-
-          if [ -n "$REQUESTED_BUNDLE_ID" ]; then
-            RESOLVED_BUNDLE_ID="$REQUESTED_BUNDLE_ID"
-          else
-            RESOLVED_BUNDLE_ID="$PROFILE_BUNDLE_ID"
-          fi
-
-          RESOLVED_TEAM_ID="${TEAM_ID:-}"
-          if [ -n "$RESOLVED_TEAM_ID" ] && [ -n "$PROFILE_TEAM_ID" ] && [ "$RESOLVED_TEAM_ID" != "$PROFILE_TEAM_ID" ]; then
-            echo "::error ::Provisioning profile team identifier $PROFILE_TEAM_ID does not match TEAM_ID secret $RESOLVED_TEAM_ID. Update the configured secrets or upload a matching provisioning profile."
-            exit 1
-          fi
-
-          if [ -z "$RESOLVED_TEAM_ID" ]; then
-            if [ -n "$PROFILE_TEAM_ID" ]; then
-              RESOLVED_TEAM_ID="$PROFILE_TEAM_ID"
-            else
-              echo "::error ::Unable to determine Apple team identifier from secrets or provisioning profile."
-              exit 1
-            fi
-          fi
-
-          echo "bundle_id=$RESOLVED_BUNDLE_ID" >> "$GITHUB_OUTPUT"
-          echo "team_id=$RESOLVED_TEAM_ID" >> "$GITHUB_OUTPUT"
-          echo "RESOLVED_BUNDLE_ID=$RESOLVED_BUNDLE_ID" >> "$GITHUB_ENV"
-          echo "RESOLVED_TEAM_ID=$RESOLVED_TEAM_ID" >> "$GITHUB_ENV"
+          echo "name=$PROFILE_NAME" >> $GITHUB_OUTPUT
 
       - name: Xcode Archive (manual signing)
         run: |
           set -euxo pipefail
           rm -rf "$ARCHIVE_PATH" "$DERIVED_DATA" "$RESULT_BUNDLE" || true
-          : "${RESOLVED_BUNDLE_ID:?Resolved bundle identifier missing}"
-          : "${RESOLVED_TEAM_ID:?Resolved team identifier missing}"
+          BUNDLE_ID="${BUNDLE_ID_PREFIX}.${BUNDLE_ID_SUFFIX}"
           xcodebuild \
-            -workspace "$WORKSPACE" \
             -scheme "$SCHEME" \
             -configuration "$CONFIGURATION" \
             -archivePath "$ARCHIVE_PATH" \
@@ -345,10 +100,10 @@ jobs:
             -resultBundlePath "$RESULT_BUNDLE" \
             archive \
             CODE_SIGN_STYLE=Manual \
-            DEVELOPMENT_TEAM="$RESOLVED_TEAM_ID" \
-            PRODUCT_BUNDLE_IDENTIFIER="$RESOLVED_BUNDLE_ID" \
+            DEVELOPMENT_TEAM="${TEAM_ID}" \
+            PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
             PROVISIONING_PROFILE_SPECIFIER="${{ steps.profile.outputs.name }}" \
-            OTHER_CODE_SIGN_FLAGS="--keychain ${KEYCHAIN_PATH:-$HOME/Library/Keychains/$KEYCHAIN_NAME}"
+            OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_NAME"
 
       - name: Create exportOptions.plist
         run: |
@@ -357,15 +112,15 @@ jobs:
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
           <dict>
-            <key>method</key><string>release-testing</string>
+            <key>method</key><string>ad-hoc</string>
             <key>signingStyle</key><string>manual</string>
-            <key>teamID</key><string>${RESOLVED_TEAM_ID}</string>
+            <key>teamID</key><string>${TEAM_ID}</string>
             <key>compileBitcode</key><false/>
             <key>stripSwiftSymbols</key><true/>
             <key>destination</key><string>export</string>
             <key>provisioningProfiles</key>
             <dict>
-              <key>${RESOLVED_BUNDLE_ID}</key><string>${{ steps.profile.outputs.name }}</string>
+              <key>${BUNDLE_ID_PREFIX}.${BUNDLE_ID_SUFFIX}</key><string>${{ steps.profile.outputs.name }}</string>
             </dict>
           </dict>
           </plist>
@@ -373,7 +128,7 @@ jobs:
 
       - name: Export IPA
         run: |
-          bash "$SIGNING_SCRIPTS_DIR/export_ipa.sh" "$ARCHIVE_PATH" exportOptions.plist export
+          bash scripts/export_ipa.sh "$ARCHIVE_PATH" exportOptions.plist export
 
       - name: Upload IPA
         uses: actions/upload-artifact@v4
@@ -384,4 +139,4 @@ jobs:
       - name: Cleanup keychain
         if: always()
         run: |
-          security delete-keychain "${KEYCHAIN_PATH:-$HOME/Library/Keychains/$KEYCHAIN_NAME}" || true
+          security delete-keychain "$KEYCHAIN_NAME" || true

--- a/.github/workflows/ios-adhoc-export.yml
+++ b/.github/workflows/ios-adhoc-export.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-adhoc:
     runs-on: macos-15
+    environment: offLLM
 
     env:
       SCHEME: monGARS
@@ -72,8 +73,44 @@ jobs:
 
       - name: Decode signing files
         run: |
-          printf '%s' "$P12_BASE64" | base64 --decode > signing/cert.p12
-          printf '%s' "$MOBILEPROVISION_BASE64" | base64 --decode > signing/profile.mobileprovision
+          python - <<'PY'
+          import base64
+          import binascii
+          import os
+          import sys
+          from pathlib import Path
+
+          secrets_to_paths = {
+              "P12_BASE64": Path("signing/cert.p12"),
+              "MOBILEPROVISION_BASE64": Path("signing/profile.mobileprovision"),
+          }
+
+          for env_var, output_path in secrets_to_paths.items():
+              value = os.environ.get(env_var)
+              if not value:
+                  sys.stderr.write(
+                      f"::error ::Missing signing secret {env_var}. "
+                      "Add it to the repository or environment secrets before rerunning.\n"
+                  )
+                  sys.exit(1)
+
+              try:
+                  decoded = base64.b64decode(value)
+              except binascii.Error as exc:
+                  sys.stderr.write(
+                      f"::error ::Secret {env_var} is not valid base64: {exc}\n"
+                  )
+                  sys.exit(1)
+
+              if not decoded:
+                  sys.stderr.write(
+                      f"::error ::Secret {env_var} decoded to 0 bytes. "
+                      "Verify the uploaded file and try again.\n"
+                  )
+                  sys.exit(1)
+
+              output_path.write_bytes(decoded)
+          PY
 
       - name: Import certificate & provisioning profile
         run: |

--- a/.github/workflows/ios-adhoc-export.yml
+++ b/.github/workflows/ios-adhoc-export.yml
@@ -13,11 +13,15 @@ jobs:
     runs-on: macos-15
 
     env:
+      NODE_VERSION: "20"
+      RUBY_VERSION: "3.2"
+      XCODE_VERSION: "16.4"
       SCHEME: monGARS
       CONFIGURATION: Release
       ARCHIVE_PATH: build/monGARS.xcarchive
       DERIVED_DATA: build/DerivedData
       RESULT_BUNDLE: build/DerivedData/ResultBundle_build.xcresult
+      WORKSPACE: ios/monGARS.xcworkspace
 
       BUNDLE_ID_PREFIX: anardoni.export
       BUNDLE_ID_SUFFIX: ${{ secrets.BUNDLE_ID_SUFFIX }}
@@ -34,10 +38,71 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Select Xcode ${{ env.XCODE_VERSION }}
+        run: |
+          sudo xcode-select -s "/Applications/Xcode_${XCODE_VERSION}.app"
+          xcodebuild -version
+
+      - name: Download bundled MLX model
+        run: ./scripts/ci/download-mlx-model.sh
+
+      - name: Set up Node ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Set up Ruby ${{ env.RUBY_VERSION }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+          working-directory: ios
+
+      - name: Cache Pods
+        uses: actions/cache@v4
+        with:
+          path: ios/Pods
+          key: pods-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: pods-${{ runner.os }}-
+
+      - name: Install XcodeGen
+        run: |
+          if ! command -v xcodegen >/dev/null 2>&1; then
+            brew install xcodegen
+          fi
+
+      - name: Generate Xcode project
+        working-directory: ios
+        run: xcodegen generate
+
+      - name: Install CocoaPods
+        id: install_pods
+        working-directory: ios
+        run: |
+          set -euo pipefail
+          if bundle exec pod install --repo-update; then
+            exit 0
+          fi
+          echo "bundle exec pod install failed; retrying with system pod"
+          pod install --repo-update
+
+      - name: Verify workspace
+        run: |
+          if [ ! -d "$WORKSPACE" ]; then
+            echo "::error ::Expected workspace $WORKSPACE to exist after pod install."
+            exit 1
+          fi
+
       - name: Prepare scripts
         run: |
-          mkdir -p scripts signing
-          cat > scripts/import_signing.sh <<'BASH'
+          SCRIPTS_DIR="$RUNNER_TEMP/signing-scripts"
+          mkdir -p "$SCRIPTS_DIR" signing
+          cat > "$SCRIPTS_DIR/import_signing.sh" <<'BASH'
           #!/usr/bin/env bash
           set -euo pipefail
           P12_PATH="$1"; P12_PASSWORD="$2"; MP_PATH="$3"; KC_NAME="$4"; KC_PASS="$5"
@@ -56,9 +121,9 @@ jobs:
           echo "PROFILE_UUID=$UUID" >> "$GITHUB_ENV"
           echo "KEYCHAIN_PATH=$KC_PATH" >> "$GITHUB_ENV"
           BASH
-          chmod +x scripts/import_signing.sh
+          chmod +x "$SCRIPTS_DIR/import_signing.sh"
 
-          cat > scripts/export_ipa.sh <<'BASH'
+          cat > "$SCRIPTS_DIR/export_ipa.sh" <<'BASH'
           #!/usr/bin/env bash
           set -euo pipefail
           ARCHIVE_PATH="$1"; EXPORT_OPTS="$2"; EXPORT_DIR="$3"
@@ -66,7 +131,8 @@ jobs:
           xcodebuild -exportArchive -archivePath "$ARCHIVE_PATH" -exportPath "$EXPORT_DIR" -exportOptionsPlist "$EXPORT_OPTS" -allowProvisioningUpdates
           ls -la "$EXPORT_DIR"
           BASH
-          chmod +x scripts/export_ipa.sh
+          chmod +x "$SCRIPTS_DIR/export_ipa.sh"
+          echo "SIGNING_SCRIPTS_DIR=$SCRIPTS_DIR" >> "$GITHUB_ENV"
 
       - name: Decode signing files
         run: |
@@ -117,7 +183,7 @@ jobs:
 
       - name: Import certificate & provisioning profile
         run: |
-          bash scripts/import_signing.sh \
+          bash "$SIGNING_SCRIPTS_DIR/import_signing.sh" \
             signing/cert.p12 \
             "$P12_PASSWORD" \
             signing/profile.mobileprovision \
@@ -138,6 +204,7 @@ jobs:
           rm -rf "$ARCHIVE_PATH" "$DERIVED_DATA" "$RESULT_BUNDLE" || true
           BUNDLE_ID="${BUNDLE_ID_PREFIX}.${BUNDLE_ID_SUFFIX}"
           xcodebuild \
+            -workspace "$WORKSPACE" \
             -scheme "$SCHEME" \
             -configuration "$CONFIGURATION" \
             -archivePath "$ARCHIVE_PATH" \
@@ -174,7 +241,7 @@ jobs:
 
       - name: Export IPA
         run: |
-          bash scripts/export_ipa.sh "$ARCHIVE_PATH" exportOptions.plist export
+          bash "$SIGNING_SCRIPTS_DIR/export_ipa.sh" "$ARCHIVE_PATH" exportOptions.plist export
 
       - name: Upload IPA
         uses: actions/upload-artifact@v4
@@ -185,4 +252,4 @@ jobs:
       - name: Cleanup keychain
         if: always()
         run: |
-          security delete-keychain "${KEYCHAIN_PATH:-$KEYCHAIN_NAME}" || true
+          security delete-keychain "${KEYCHAIN_PATH:-$HOME/Library/Keychains/$KEYCHAIN_NAME}" || true

--- a/.github/workflows/ios-adhoc-export.yml
+++ b/.github/workflows/ios-adhoc-export.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build-adhoc:
+    environment:
+      name: offLLM
     runs-on: macos-15
 
     env:
@@ -88,7 +90,7 @@ jobs:
               if not value:
                   sys.stderr.write(
                       f"::error ::Missing signing secret {env_var}. "
-                      "Add it to the repository secrets before rerunning.\n"
+                      "Add it to the repository or environment secrets before rerunning.\n"
                   )
                   sys.exit(1)
 

--- a/.github/workflows/ios-adhoc-export.yml
+++ b/.github/workflows/ios-adhoc-export.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build-adhoc:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: macos-15
     environment: offLLM
 
@@ -23,55 +24,15 @@ jobs:
       TEAM_ID: ${{ secrets.TEAM_ID }}
 
       KEYCHAIN_NAME: build-signing.keychain-db
-      KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-
-      P12_BASE64: ${{ secrets.P12_BASE64 }}
-      P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-      MOBILEPROVISION_BASE64: ${{ secrets.MOBILEPROVISION_BASE64 }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Prepare scripts
-        run: |
-          mkdir -p scripts signing
-          cat > scripts/import_signing.sh <<'BASH'
-          #!/usr/bin/env bash
-          set -euo pipefail
-          P12_PATH="$1"; P12_PASSWORD="$2"; MP_PATH="$3"; KC_NAME="$4"; KC_PASS="$5"
-          if [[ "$KC_NAME" == /* ]]; then
-            KC_PATH="$KC_NAME"
-          else
-            KC_PATH="$HOME/Library/Keychains/$KC_NAME"
-          fi
-          security create-keychain -p "$KC_PASS" "$KC_PATH"
-          security set-keychain-settings -lut 21600 "$KC_PATH"
-          security unlock-keychain -p "$KC_PASS" "$KC_PATH"
-          security import "$P12_PATH" -k "$KC_PATH" -P "$P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$KC_PASS" "$KC_PATH" || true
-          security list-keychains -d user -s "$KC_PATH"
-          security default-keychain -s "$KC_PATH"
-          PP_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"; mkdir -p "$PP_DIR"
-          PLIST_TMP=$(mktemp); security cms -D -i "$MP_PATH" > "$PLIST_TMP"
-          UUID=$(/usr/libexec/PlistBuddy -c 'Print UUID' "$PLIST_TMP")
-          cp "$MP_PATH" "$PP_DIR/$UUID.mobileprovision"
-          echo "PROFILE_UUID=$UUID" >> "$GITHUB_ENV"
-          echo "KEYCHAIN_PATH=$KC_PATH" >> "$GITHUB_ENV"
-          BASH
-          chmod +x scripts/import_signing.sh
-
-          cat > scripts/export_ipa.sh <<'BASH'
-          #!/usr/bin/env bash
-          set -euo pipefail
-          ARCHIVE_PATH="$1"; EXPORT_OPTS="$2"; EXPORT_DIR="$3"
-          mkdir -p "$EXPORT_DIR"
-          xcodebuild -exportArchive -archivePath "$ARCHIVE_PATH" -exportPath "$EXPORT_DIR" -exportOptionsPlist "$EXPORT_OPTS" -allowProvisioningUpdates
-          ls -la "$EXPORT_DIR"
-          BASH
-          chmod +x scripts/export_ipa.sh
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       - name: Decode signing files
+        env:
+          P12_BASE64: ${{ secrets.P12_BASE64 }}
+          MOBILEPROVISION_BASE64: ${{ secrets.MOBILEPROVISION_BASE64 }}
         run: |
           python - <<'PY'
           import base64
@@ -95,7 +56,7 @@ jobs:
                   sys.exit(1)
 
               try:
-                  decoded = base64.b64decode(value)
+                  decoded = base64.b64decode(value, validate=True)
               except binascii.Error as exc:
                   sys.stderr.write(
                       f"::error ::Secret {env_var} is not valid base64: {exc}\n"
@@ -109,32 +70,38 @@ jobs:
                   )
                   sys.exit(1)
 
+              output_path.parent.mkdir(parents=True, exist_ok=True)
               output_path.write_bytes(decoded)
+              try:
+                  output_path.chmod(0o600)
+              except Exception:
+                  pass
           PY
 
       - name: Import certificate & provisioning profile
+        env:
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
-          bash scripts/import_signing.sh \
+          bash scripts/ci/import_signing.sh \
             signing/cert.p12 \
             "$P12_PASSWORD" \
             signing/profile.mobileprovision \
             "$KEYCHAIN_NAME" \
             "$KEYCHAIN_PASSWORD"
 
-      - name: Resolve profile name
-        id: profile
+      - name: Sanitize signing files
         run: |
-          PROFILE_PLIST=$(mktemp)
-          /usr/bin/security cms -D -i signing/profile.mobileprovision > "$PROFILE_PLIST"
-          PROFILE_NAME=$(/usr/libexec/PlistBuddy -c 'Print Name' "$PROFILE_PLIST")
-          echo "name=$PROFILE_NAME" >> $GITHUB_OUTPUT
+          rm -rf signing || true
 
       - name: Xcode Archive (manual signing)
         run: |
           set -euxo pipefail
           rm -rf "$ARCHIVE_PATH" "$DERIVED_DATA" "$RESULT_BUNDLE" || true
+          : "${BUNDLE_ID_SUFFIX:?BUNDLE_ID_SUFFIX is required and must not be empty}"
           BUNDLE_ID="${BUNDLE_ID_PREFIX}.${BUNDLE_ID_SUFFIX}"
           KEYCHAIN_PATH="${KEYCHAIN_PATH:?KEYCHAIN_PATH not set by signing import step}"
+          echo "RESOLVED_BUNDLE_ID=$BUNDLE_ID" >> "$GITHUB_ENV"
           xcodebuild \
             -scheme "$SCHEME" \
             -configuration "$CONFIGURATION" \
@@ -146,11 +113,12 @@ jobs:
             CODE_SIGN_STYLE=Manual \
             DEVELOPMENT_TEAM="${TEAM_ID}" \
             PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
-            PROVISIONING_PROFILE_SPECIFIER="${{ steps.profile.outputs.name }}" \
+            PROVISIONING_PROFILE_SPECIFIER="${PROFILE_NAME:?PROFILE_NAME not exported by signing import step}" \
             OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_PATH"
 
       - name: Create exportOptions.plist
         run: |
+          BUNDLE_ID="${RESOLVED_BUNDLE_ID:-${BUNDLE_ID_PREFIX}.${BUNDLE_ID_SUFFIX}}"
           cat > exportOptions.plist <<PLIST
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -159,12 +127,11 @@ jobs:
             <key>method</key><string>ad-hoc</string>
             <key>signingStyle</key><string>manual</string>
             <key>teamID</key><string>${TEAM_ID}</string>
-            <key>compileBitcode</key><false/>
             <key>stripSwiftSymbols</key><true/>
             <key>destination</key><string>export</string>
             <key>provisioningProfiles</key>
             <dict>
-              <key>${BUNDLE_ID_PREFIX}.${BUNDLE_ID_SUFFIX}</key><string>${{ steps.profile.outputs.name }}</string>
+              <key>${BUNDLE_ID}</key><string>${PROFILE_NAME}</string>
             </dict>
           </dict>
           </plist>
@@ -172,10 +139,10 @@ jobs:
 
       - name: Export IPA
         run: |
-          bash scripts/export_ipa.sh "$ARCHIVE_PATH" exportOptions.plist export
+          bash scripts/ci/export_ipa.sh "$ARCHIVE_PATH" exportOptions.plist export
 
       - name: Upload IPA
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: monGARS-AdHoc-IPA
           path: export/*.ipa
@@ -183,4 +150,13 @@ jobs:
       - name: Cleanup keychain
         if: always()
         run: |
-          security delete-keychain "${KEYCHAIN_PATH:-$KEYCHAIN_NAME}" || true
+          KC_PATH="${KEYCHAIN_PATH:-$HOME/Library/Keychains/$KEYCHAIN_NAME}"
+          security delete-keychain "$KC_PATH" || true
+          LOGIN_KC="$HOME/Library/Keychains/login.keychain-db"
+          [ -f "$LOGIN_KC" ] || LOGIN_KC="$HOME/Library/Keychains/login.keychain"
+          security default-keychain -s "$LOGIN_KC" || true
+          security list-keychains -d user -s "$LOGIN_KC" || true
+          rm -rf signing || true
+          if [ -n "${PROFILE_UUID:-}" ]; then
+            rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/${PROFILE_UUID}.mobileprovision" || true
+          fi

--- a/.github/workflows/ios-adhoc-export.yml
+++ b/.github/workflows/ios-adhoc-export.yml
@@ -166,12 +166,36 @@ jobs:
       - name: Cleanup keychain
         if: always()
         run: |
-          KC_PATH="${KEYCHAIN_PATH:-$HOME/Library/Keychains/$KEYCHAIN_NAME}"
-          security delete-keychain "$KC_PATH" || true
           LOGIN_KC="$HOME/Library/Keychains/login.keychain-db"
           [ -f "$LOGIN_KC" ] || LOGIN_KC="$HOME/Library/Keychains/login.keychain"
-          security default-keychain -s "$LOGIN_KC" || true
-          security list-keychains -d user -s "$LOGIN_KC" || true
+          SYSTEM_KC="/Library/Keychains/System.keychain"
+          KC_PATH="${KEYCHAIN_PATH:-$HOME/Library/Keychains/$KEYCHAIN_NAME}"
+
+          if [ -n "${ORIGINAL_DEFAULT_KEYCHAIN:-}" ]; then
+            security default-keychain -s "$ORIGINAL_DEFAULT_KEYCHAIN" || true
+          else
+            security default-keychain -s "$LOGIN_KC" || true
+          fi
+
+          if [ -n "${ORIGINAL_KEYCHAIN_LIST:-}" ]; then
+            OLDIFS=$IFS
+            IFS=$'\n'
+            RESTORE_LIST=()
+            while IFS= read -r line; do
+              [ -z "$line" ] && continue
+              RESTORE_LIST+=("$line")
+            done <<< "$ORIGINAL_KEYCHAIN_LIST"
+            IFS=$OLDIFS
+            if [ "${#RESTORE_LIST[@]}" -gt 0 ]; then
+              security list-keychains -d user -s "${RESTORE_LIST[@]}" || true
+            fi
+          else
+            FALLBACK_LIST=("$LOGIN_KC")
+            [ -f "$SYSTEM_KC" ] && FALLBACK_LIST+=("$SYSTEM_KC")
+            security list-keychains -d user -s "${FALLBACK_LIST[@]}" || true
+          fi
+
+          security delete-keychain "$KC_PATH" || true
           rm -rf signing || true
           if [ -n "${PROFILE_UUID:-}" ]; then
             rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/${PROFILE_UUID}.mobileprovision" || true

--- a/.github/workflows/ios-adhoc-export.yml
+++ b/.github/workflows/ios-adhoc-export.yml
@@ -23,8 +23,7 @@ jobs:
       RESULT_BUNDLE: build/DerivedData/ResultBundle_build.xcresult
       WORKSPACE: ios/monGARS.xcworkspace
 
-      BUNDLE_ID_PREFIX: anardoni.export
-      BUNDLE_ID_SUFFIX: ${{ secrets.BUNDLE_ID_SUFFIX }}
+      BUNDLE_IDENTIFIER: anardoni.export.monGARS
       TEAM_ID: ${{ secrets.TEAM_ID }}
 
       KEYCHAIN_NAME: build-signing.keychain-db
@@ -224,16 +223,7 @@ jobs:
           PROFILE_BUNDLE_ID="${{ steps.profile.outputs.bundle_id }}"
           PROFILE_TEAM_ID="${{ steps.profile.outputs.team_id }}"
 
-          REQUESTED_BUNDLE_ID=""
-          if [ -n "${BUNDLE_ID_SUFFIX:-}" ]; then
-            if [ -n "${BUNDLE_ID_PREFIX:-}" ]; then
-              REQUESTED_BUNDLE_ID="${BUNDLE_ID_PREFIX}.${BUNDLE_ID_SUFFIX}"
-            else
-              REQUESTED_BUNDLE_ID="${BUNDLE_ID_SUFFIX}"
-            fi
-          elif [ -n "${BUNDLE_ID_PREFIX:-}" ]; then
-            REQUESTED_BUNDLE_ID="${BUNDLE_ID_PREFIX}"
-          fi
+          REQUESTED_BUNDLE_ID="${BUNDLE_IDENTIFIER:-}"
 
           if [ -z "$PROFILE_BUNDLE_ID" ]; then
             echo "::error ::Provisioning profile did not expose an application identifier."

--- a/.github/workflows/ios-adhoc-export.yml
+++ b/.github/workflows/ios-adhoc-export.yml
@@ -23,7 +23,9 @@ jobs:
       RESULT_BUNDLE: build/DerivedData/ResultBundle_build.xcresult
       WORKSPACE: ios/monGARS.xcworkspace
 
-      BUNDLE_IDENTIFIER: anardoni.export.monGARS
+      BUNDLE_IDENTIFIER: ${{ secrets.BUNDLE_IDENTIFIER != '' && secrets.BUNDLE_IDENTIFIER || 'anardoni.export.monGARS' }}
+      BUNDLE_ID_PREFIX: ${{ secrets.BUNDLE_ID_PREFIX }}
+      BUNDLE_ID_SUFFIX: ${{ secrets.BUNDLE_ID_SUFFIX }}
       TEAM_ID: ${{ secrets.TEAM_ID }}
 
       KEYCHAIN_NAME: build-signing.keychain-db
@@ -223,16 +225,46 @@ jobs:
           PROFILE_BUNDLE_ID="${{ steps.profile.outputs.bundle_id }}"
           PROFILE_TEAM_ID="${{ steps.profile.outputs.team_id }}"
 
-          REQUESTED_BUNDLE_ID="${BUNDLE_IDENTIFIER:-}"
+          PREFIX="${BUNDLE_ID_PREFIX:-}"
+          SUFFIX="${BUNDLE_ID_SUFFIX:-}"
+          REQUESTED_BUNDLE_ID=""
+
+          if [ -n "$PREFIX" ] || [ -n "$SUFFIX" ]; then
+            if [ -z "$PREFIX" ]; then
+              echo "::error ::BUNDLE_ID_SUFFIX is set but BUNDLE_ID_PREFIX is empty. Provide both or omit the suffix secret."
+              exit 1
+            fi
+            CLEAN_PREFIX="${PREFIX%.}"
+            if [ -n "$SUFFIX" ]; then
+              CLEAN_SUFFIX="${SUFFIX#.}"
+              REQUESTED_BUNDLE_ID="$CLEAN_PREFIX.$CLEAN_SUFFIX"
+            else
+              REQUESTED_BUNDLE_ID="$CLEAN_PREFIX"
+            fi
+          elif [ -n "${BUNDLE_IDENTIFIER:-}" ]; then
+            REQUESTED_BUNDLE_ID="$BUNDLE_IDENTIFIER"
+          fi
 
           if [ -z "$PROFILE_BUNDLE_ID" ]; then
             echo "::error ::Provisioning profile did not expose an application identifier."
             exit 1
           fi
 
-          if [ -n "$REQUESTED_BUNDLE_ID" ] && [ "$REQUESTED_BUNDLE_ID" != "$PROFILE_BUNDLE_ID" ]; then
-            echo "::error ::Provisioning profile bundle identifier $PROFILE_BUNDLE_ID does not match requested bundle identifier $REQUESTED_BUNDLE_ID. Update the configured secrets or upload a matching provisioning profile."
-            exit 1
+          if [ -n "$REQUESTED_BUNDLE_ID" ] && [ -n "$PROFILE_BUNDLE_ID" ]; then
+            MATCHED="false"
+            if [ "$REQUESTED_BUNDLE_ID" = "$PROFILE_BUNDLE_ID" ]; then
+              MATCHED="true"
+            elif [[ "$PROFILE_BUNDLE_ID" == *"*" ]]; then
+              PROFILE_PREFIX="${PROFILE_BUNDLE_ID%%\*}"
+              if [[ "$REQUESTED_BUNDLE_ID" == "$PROFILE_PREFIX"* ]]; then
+                MATCHED="true"
+              fi
+            fi
+
+            if [ "$MATCHED" != "true" ]; then
+              echo "::error ::Provisioning profile bundle identifier $PROFILE_BUNDLE_ID does not match requested bundle identifier $REQUESTED_BUNDLE_ID. Update the configured secrets or upload a matching provisioning profile."
+              exit 1
+            fi
           fi
 
           if [ -n "$REQUESTED_BUNDLE_ID" ]; then

--- a/.github/workflows/ios-adhoc-export.yml
+++ b/.github/workflows/ios-adhoc-export.yml
@@ -147,6 +147,22 @@ jobs:
           name: monGARS-AdHoc-IPA
           path: export/*.ipa
 
+      - name: Upload Xcode result bundle
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: monGARS-xcresult
+          path: ${{ env.RESULT_BUNDLE }}
+          if-no-files-found: warn
+
+      - name: Upload exportOptions.plist
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: exportOptions
+          path: exportOptions.plist
+          if-no-files-found: warn
+
       - name: Cleanup keychain
         if: always()
         run: |

--- a/.github/workflows/ios-adhoc-export.yml
+++ b/.github/workflows/ios-adhoc-export.yml
@@ -39,18 +39,24 @@ jobs:
           #!/usr/bin/env bash
           set -euo pipefail
           P12_PATH="$1"; P12_PASSWORD="$2"; MP_PATH="$3"; KC_NAME="$4"; KC_PASS="$5"
-          security create-keychain -p "$KC_PASS" "$KC_NAME"
-          security set-keychain-settings -lut 21600 "$KC_NAME"
-          security unlock-keychain -p "$KC_PASS" "$KC_NAME"
-          security import "$P12_PATH" -k "$KC_NAME" -P "$P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$KC_PASS" "$KC_NAME" || true
-          security list-keychains -d user -s "$KC_NAME"
-          security default-keychain -s "$KC_NAME"
+          if [[ "$KC_NAME" == /* ]]; then
+            KC_PATH="$KC_NAME"
+          else
+            KC_PATH="$HOME/Library/Keychains/$KC_NAME"
+          fi
+          security create-keychain -p "$KC_PASS" "$KC_PATH"
+          security set-keychain-settings -lut 21600 "$KC_PATH"
+          security unlock-keychain -p "$KC_PASS" "$KC_PATH"
+          security import "$P12_PATH" -k "$KC_PATH" -P "$P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KC_PASS" "$KC_PATH" || true
+          security list-keychains -d user -s "$KC_PATH"
+          security default-keychain -s "$KC_PATH"
           PP_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"; mkdir -p "$PP_DIR"
           PLIST_TMP=$(mktemp); security cms -D -i "$MP_PATH" > "$PLIST_TMP"
           UUID=$(/usr/libexec/PlistBuddy -c 'Print UUID' "$PLIST_TMP")
           cp "$MP_PATH" "$PP_DIR/$UUID.mobileprovision"
           echo "PROFILE_UUID=$UUID" >> "$GITHUB_ENV"
+          echo "KEYCHAIN_PATH=$KC_PATH" >> "$GITHUB_ENV"
           BASH
           chmod +x scripts/import_signing.sh
 
@@ -66,8 +72,8 @@ jobs:
 
       - name: Decode signing files
         run: |
-          echo "$P12_BASE64" | base64 --decode > signing/cert.p12
-          echo "$MOBILEPROVISION_BASE64" | base64 --decode > signing/profile.mobileprovision
+          printf '%s' "$P12_BASE64" | base64 --decode > signing/cert.p12
+          printf '%s' "$MOBILEPROVISION_BASE64" | base64 --decode > signing/profile.mobileprovision
 
       - name: Import certificate & provisioning profile
         run: |
@@ -91,6 +97,7 @@ jobs:
           set -euxo pipefail
           rm -rf "$ARCHIVE_PATH" "$DERIVED_DATA" "$RESULT_BUNDLE" || true
           BUNDLE_ID="${BUNDLE_ID_PREFIX}.${BUNDLE_ID_SUFFIX}"
+          KEYCHAIN_PATH="${KEYCHAIN_PATH:?KEYCHAIN_PATH not set by signing import step}"
           xcodebuild \
             -scheme "$SCHEME" \
             -configuration "$CONFIGURATION" \
@@ -103,7 +110,7 @@ jobs:
             DEVELOPMENT_TEAM="${TEAM_ID}" \
             PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
             PROVISIONING_PROFILE_SPECIFIER="${{ steps.profile.outputs.name }}" \
-            OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_NAME"
+            OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_PATH"
 
       - name: Create exportOptions.plist
         run: |
@@ -139,4 +146,4 @@ jobs:
       - name: Cleanup keychain
         if: always()
         run: |
-          security delete-keychain "$KEYCHAIN_NAME" || true
+          security delete-keychain "${KEYCHAIN_PATH:-$KEYCHAIN_NAME}" || true

--- a/scripts/ci/export_ipa.sh
+++ b/scripts/ci/export_ipa.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Export an Xcode archive to an IPA with the provided export options.
+# Usage: export_ipa.sh <archive-path> <export-options-plist> <export-directory>
+
+set -euo pipefail
+set -x
+
+ARCHIVE_PATH="$1"
+EXPORT_OPTS="$2"
+EXPORT_DIR="$3"
+
+mkdir -p "$EXPORT_DIR"
+
+xcodebuild -exportArchive \
+  -archivePath "$ARCHIVE_PATH" \
+  -exportPath "$EXPORT_DIR" \
+  -exportOptionsPlist "$EXPORT_OPTS"
+
+ls -la "$EXPORT_DIR"
+
+set +x

--- a/scripts/ci/export_ipa.sh
+++ b/scripts/ci/export_ipa.sh
@@ -3,11 +3,26 @@
 # Usage: export_ipa.sh <archive-path> <export-options-plist> <export-directory>
 
 set -euo pipefail
-set -x
+if [[ $# -ne 3 ]]; then
+  echo "::error ::Usage: $0 <archive-path> <export-options-plist> <export-directory>" >&2
+  exit 2
+fi
 
 ARCHIVE_PATH="$1"
 EXPORT_OPTS="$2"
 EXPORT_DIR="$3"
+
+if [[ ! -d "$ARCHIVE_PATH" ]]; then
+  echo "::error ::Archive not found (expected directory): $ARCHIVE_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -f "$EXPORT_OPTS" ]]; then
+  echo "::error ::exportOptions.plist not found: $EXPORT_OPTS" >&2
+  exit 1
+fi
+
+set -x
 
 mkdir -p "$EXPORT_DIR"
 

--- a/scripts/ci/import_signing.sh
+++ b/scripts/ci/import_signing.sh
@@ -56,8 +56,12 @@ log() {
 }
 
 cleanup_tmp_files() {
-  [[ -n "$KEYCHAIN_LIST_TMP" && -f "$KEYCHAIN_LIST_TMP" ]] && rm -f "$KEYCHAIN_LIST_TMP"
-  [[ -n "$PLIST_TMP" && -f "$PLIST_TMP" ]] && rm -f "$PLIST_TMP"
+  if [[ -n "$KEYCHAIN_LIST_TMP" && -f "$KEYCHAIN_LIST_TMP" ]]; then
+    rm -f "$KEYCHAIN_LIST_TMP"
+  fi
+  if [[ -n "$PLIST_TMP" && -f "$PLIST_TMP" ]]; then
+    rm -f "$PLIST_TMP"
+  fi
 }
 
 KEYCHAIN_LIST_TMP=""

--- a/scripts/ci/import_signing.sh
+++ b/scripts/ci/import_signing.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Import signing assets into a temporary keychain for CI workflows.
+#
+# Usage: import_signing.sh <p12-path> <p12-password> <mobileprovision-path> <keychain-name-or-path> <keychain-password>
+# - Supports keychain arguments that are names, absolute paths, relative paths, or home-relative paths.
+# - Emits PROFILE_UUID and KEYCHAIN_PATH for downstream GitHub Actions steps.
+# - Enables verbose logging via `set -x` while masking sensitive arguments.
+
+set -euo pipefail
+
+if [[ $# -ne 5 ]]; then
+  echo "::error ::Expected 5 arguments, received $#" >&2
+  exit 1
+fi
+
+P12_PATH="$1"
+P12_PASSWORD="$2"
+MP_PATH="$3"
+KC_ARG="$4"
+KC_PASS="$5"
+
+resolve_keychain_path() {
+  local arg="$1"
+  case "$arg" in
+    /*)
+      printf '%s' "$arg"
+      ;;
+    ~*|*/*)
+      python3 -c 'import os, sys; print(os.path.abspath(os.path.expanduser(sys.argv[1])))' "$arg"
+      ;;
+    *)
+      printf '%s' "$HOME/Library/Keychains/$arg"
+      ;;
+  esac
+}
+
+KC_PATH="$(resolve_keychain_path "$KC_ARG")"
+mkdir -p "$(dirname "$KC_PATH")"
+
+log() {
+  printf '::notice ::%s\n' "$1"
+}
+
+log "Importing signing assets into keychain: $KC_PATH"
+
+set -x
+
+security delete-keychain "$KC_PATH" >/dev/null 2>&1 || true
+
+set +x
+security create-keychain -p "$KC_PASS" "$KC_PATH"
+set -x
+
+set +x
+security set-keychain-settings -lut 21600 "$KC_PATH"
+set -x
+
+set +x
+security unlock-keychain -p "$KC_PASS" "$KC_PATH"
+set -x
+
+set +x
+security import "$P12_PATH" -k "$KC_PATH" -P "$P12_PASSWORD" -f pkcs12 -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/xcodebuild
+set -x
+
+set +x
+security set-key-partition-list -S apple-tool:,apple: -s -k "$KC_PASS" "$KC_PATH" >/dev/null 2>&1 || true
+set -x
+
+mapfile -t EXISTING_KEYCHAINS < <(security list-keychains -d user | sed -e 's/^[[:space:]]*"//' -e 's/"$//')
+FILTERED_KEYCHAINS=()
+for keychain in "${EXISTING_KEYCHAINS[@]}"; do
+  [[ -z "$keychain" ]] && continue
+  [[ "$keychain" == "$KC_PATH" ]] && continue
+  FILTERED_KEYCHAINS+=("$keychain")
+done
+
+if [[ ${#FILTERED_KEYCHAINS[@]} -gt 0 ]]; then
+  security list-keychains -d user -s "$KC_PATH" "${FILTERED_KEYCHAINS[@]}"
+else
+  security list-keychains -d user -s "$KC_PATH"
+fi
+
+security default-keychain -s "$KC_PATH"
+
+PP_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+mkdir -p "$PP_DIR"
+PLIST_TMP="$(mktemp)"
+
+set +x
+security cms -D -i "$MP_PATH" > "$PLIST_TMP"
+set -x
+
+UUID=$(/usr/libexec/PlistBuddy -c 'Print UUID' "$PLIST_TMP")
+PROFILE_NAME=$(/usr/libexec/PlistBuddy -c 'Print Name' "$PLIST_TMP")
+if [[ -z "$UUID" || -z "$PROFILE_NAME" ]]; then
+  set +x
+  echo "::error ::Failed to resolve provisioning profile metadata" >&2
+  exit 1
+fi
+cp "$MP_PATH" "$PP_DIR/$UUID.mobileprovision"
+rm -f "$PLIST_TMP"
+
+set +x
+echo "PROFILE_UUID=$UUID" >> "$GITHUB_ENV"
+echo "PROFILE_NAME=$PROFILE_NAME" >> "$GITHUB_ENV"
+echo "KEYCHAIN_PATH=$KC_PATH" >> "$GITHUB_ENV"
+set -x
+
+log "Installed provisioning profile $PROFILE_NAME ($UUID)"
+
+# Restore xtrace to default off for downstream scripts.
+set +x


### PR DESCRIPTION
## Summary
- ensure the signing import script works with full keychain paths and exposes the keychain to later steps
- decode the signing assets with an embedded Python helper for portable base64 handling
- reuse the resolved keychain path when archiving and during cleanup to avoid invalid parameters

## Testing
- CI=1 npm test
- npm run lint
- CI=1 npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68d238ae7ff48333b898bfe359cfd1a8

## Summary by Sourcery

Add and refine iOS AdHoc export GitHub Actions workflow to properly handle keychain import, decode signing assets, and export the IPA.

Enhancements:
- Ensure the signing import script works with full keychain paths and expose KEYCHAIN_PATH to later steps
- Decode base64–encoded P12 and provisioning profile using an embedded Python helper for portable handling
- Reuse the resolved keychain path in xcodebuild and cleanup steps to avoid invalid parameters

CI:
- Introduce ios-adhoc-export.yml workflow to automate checkout, signing import, archive, export, upload, and cleanup steps on macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated iOS AdHoc CI workflow to build, sign, export, and upload AdHoc IPA artifacts for testing.
  * Workflow triggers include manual dispatch, pushes to main/master, and pull requests; artifacts (IPA and build results) are uploaded for testers.
  * Includes CI helpers to import signing materials, export IPAs, upload artifacts, and securely clean up credentials.
  * No user-facing changes to the app experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->