### PR TITLE
Harden caching and rate limiting semantics

### DIFF
--- a/__tests__/cacheAndRate.test.js
+++ b/__tests__/cacheAndRate.test.js
@@ -1,0 +1,121 @@
+const ORIGINAL_TIMEOUT = 5000;
+
+describe("cacheAndRate utilities", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.useFakeTimers({ doNotFake: ["nextTick"] });
+    jest.setTimeout(250);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.setTimeout(ORIGINAL_TIMEOUT);
+    jest.restoreAllMocks();
+  });
+
+  const loadModule = () => require("../src/services/utils/cacheAndRate");
+
+  it("deduplicates concurrent cache calls and respects TTL", async () => {
+    jest.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+    const { simpleCache, resetCacheAndRateState } = loadModule();
+
+    const fn = jest
+      .fn()
+      .mockResolvedValueOnce("first")
+      .mockResolvedValueOnce("second");
+
+    const first = simpleCache("key", fn, 1000);
+    const second = simpleCache("key", fn, 1000);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      "first",
+      "first",
+    ]);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(500);
+    jest.setSystemTime(new Date("2024-01-01T00:00:00.500Z"));
+
+    await expect(simpleCache("key", fn, 1000)).resolves.toBe("first");
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(600);
+    jest.setSystemTime(new Date("2024-01-01T00:00:01.100Z"));
+
+    await expect(simpleCache("key", fn, 1000)).resolves.toBe("second");
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    resetCacheAndRateState();
+  });
+
+  it("does not cache errors", async () => {
+    jest.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+    const { simpleCache, resetCacheAndRateState } = loadModule();
+
+    const error = new Error("boom");
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce("recovered");
+
+    await expect(simpleCache("key", fn, 1000)).rejects.toBe(error);
+    await expect(simpleCache("key", fn, 1000)).resolves.toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    resetCacheAndRateState();
+  });
+
+  it("propagates errors from delayed rate-limited executions and continues queueing", async () => {
+    jest.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+    const { rateLimiter, resetCacheAndRateState } = loadModule();
+
+    const successFn = jest.fn().mockResolvedValue("ok");
+    const error = new Error("boom");
+    const failingFn = jest.fn().mockRejectedValue(error);
+
+    await rateLimiter("provider", successFn, 50);
+
+    const pendingPromise = rateLimiter("provider", failingFn, 50);
+    const expectation = expect(pendingPromise).rejects.toMatchObject({
+      message: "boom",
+    });
+
+    await jest.advanceTimersByTimeAsync(50);
+    await expectation;
+
+    const afterError = rateLimiter("provider", successFn, 50);
+    await jest.advanceTimersByTimeAsync(50);
+    await expect(afterError).resolves.toBe("ok");
+
+    expect(failingFn).toHaveBeenCalledTimes(1);
+    expect(successFn).toHaveBeenCalledTimes(2);
+
+    resetCacheAndRateState();
+  });
+
+  it("serialises bursts of rate limited calls", async () => {
+    jest.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+    const { rateLimiter, resetCacheAndRateState } = loadModule();
+
+    const invocationTimes = [];
+    const fn = jest.fn().mockImplementation(() => {
+      invocationTimes.push(Date.now());
+      return Promise.resolve(invocationTimes.length);
+    });
+
+    const p1 = rateLimiter("provider", fn, 100);
+    const p2 = rateLimiter("provider", fn, 100);
+    const p3 = rateLimiter("provider", fn, 100);
+
+    await jest.advanceTimersByTimeAsync(300);
+
+    await expect(Promise.all([p1, p2, p3])).resolves.toEqual([1, 2, 3]);
+    const deltas = invocationTimes.map((time, index) =>
+      index === 0 ? 0 : time - invocationTimes[0],
+    );
+    expect(deltas).toEqual([0, 100, 200]);
+    expect(fn).toHaveBeenCalledTimes(3);
+
+    resetCacheAndRateState();
+  });
+});

--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -39,7 +39,7 @@
 
 - Long-term memory persists through `VectorMemory`, which enforces encryption-at-rest, schema migrations, and storage limits before writing any payloads to disk, keeping sensitive recall data under quota and uniformly structured.【F:src/memory/VectorMemory.ts†L1-L136】
 - Encryption is handled with AES-256-GCM inside `EncryptionService`, guaranteeing authenticated ciphertext for every memory record the persistence layer stores or retrieves.【F:src/services/encryption.ts†L1-L30】
-- External-provider calls respect API governance through `getApiKeys`/`validate`, while `simpleCache` and `rateLimiter` throttle requests so trust policies (key presence, request pacing) are enforced even when tools are invoked in tight loops.【F:src/services/utils/apiKeys.js†L1-L23】【F:src/services/utils/cacheAndRate.js†L1-L27】
+- External-provider calls respect API governance through `getApiKeys`/`validate`, while `simpleCache` deduplicates concurrent fetches and `rateLimiter` serialises bursts so trust policies (key presence, request pacing) are enforced even when tools are invoked in tight loops.【F:src/services/utils/apiKeys.js†L1-L23】【F:src/services/utils/cacheAndRate.js†L9-L92】
 
 ## Bridging and Native Turbo Modules
 

--- a/src/services/utils/cacheAndRate.js
+++ b/src/services/utils/cacheAndRate.js
@@ -1,30 +1,103 @@
 const cache = new Map();
-const lastRequestTimes = new Map();
+
+const rateLimiterState = new Map();
+
+const waitFor = (ms) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+export function resetCacheAndRateState() {
+  cache.clear();
+  rateLimiterState.clear();
+}
 
 export async function simpleCache(key, fn, ttl = 5 * 60 * 1000) {
-  if (cache.has(key)) {
-    const entry = cache.get(key);
-    if (Date.now() - entry.timestamp < ttl) {
-      return entry.value;
-    }
+  if (typeof fn !== "function") {
+    throw new TypeError("simpleCache requires a function to execute");
   }
-  const value = await fn();
-  cache.set(key, { value, timestamp: Date.now() });
-  return value;
+
+  const now = Date.now();
+  const existing = cache.get(key);
+
+  if (existing) {
+    if (existing.promise) {
+      return existing.promise;
+    }
+
+    if (existing.expiresAt > now) {
+      return existing.value;
+    }
+
+    cache.delete(key);
+  }
+
+  const promise = Promise.resolve()
+    .then(() => fn())
+    .then((value) => {
+      cache.set(key, {
+        value,
+        expiresAt: Date.now() + ttl,
+      });
+      return value;
+    })
+    .catch((error) => {
+      cache.delete(key);
+      throw error;
+    });
+
+  cache.set(key, {
+    promise,
+    expiresAt: now + ttl,
+  });
+
+  return promise;
 }
 
 export function rateLimiter(provider, fn, delay = 1000) {
-  const now = Date.now();
-  const last = lastRequestTimes.get(provider) || 0;
-  const remaining = delay - (now - last);
-  if (remaining > 0) {
-    return new Promise((resolve) => {
-      setTimeout(async () => {
-        lastRequestTimes.set(provider, Date.now());
-        resolve(await fn());
-      }, remaining);
-    });
+  if (typeof fn !== "function") {
+    return Promise.reject(
+      new TypeError("rateLimiter requires a function to execute"),
+    );
   }
-  lastRequestTimes.set(provider, now);
-  return fn();
+
+  const safeDelay = Math.max(0, delay);
+
+  let state = rateLimiterState.get(provider);
+  if (!state) {
+    state = {
+      queue: Promise.resolve(),
+      lastInvocationTime: 0,
+      hasRun: false,
+    };
+    rateLimiterState.set(provider, state);
+  }
+
+  const scheduled = state.queue
+    .catch(() => undefined)
+    .then(async () => {
+      const now = Date.now();
+
+      if (state.hasRun) {
+        const elapsed = now - state.lastInvocationTime;
+        const waitTime = safeDelay - elapsed;
+        if (waitTime > 0) {
+          await waitFor(waitTime);
+        }
+      }
+
+      state.lastInvocationTime = Date.now();
+      state.hasRun = true;
+
+      return fn();
+    });
+
+  state.queue = scheduled.then(
+    (value) => value,
+    (error) => {
+      throw error;
+    },
+  );
+
+  return scheduled;
 }


### PR DESCRIPTION
## Summary
- ensure `rateLimiter` rejects when delayed executions fail instead of leaving callers hanging
- add Jest coverage for the rate limiter to confirm delayed rejections propagate correctly
- queue rate-limited invocations per provider so bursts respect spacing, validate inputs, and expose a reset helper
- make `simpleCache` dedupe concurrent fetches, avoid persisting failures, and document the updated behaviour

## Testing
- npm test -- --watch=false
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68d61a352d088333b959ca775364fe02