### PR TITLE
Harden cache TTL validation and deepen audit coverage

### DIFF
--- a/__tests__/cacheAndRate.test.js
+++ b/__tests__/cacheAndRate.test.js
@@ -48,6 +48,23 @@ describe("cacheAndRate utilities", () => {
     resetCacheAndRateState();
   });
 
+  it("validates TTL inputs before caching", async () => {
+    const { simpleCache, resetCacheAndRateState } = loadModule();
+
+    const fn = jest.fn().mockResolvedValue("ok");
+
+    await expect(simpleCache("key", fn, Number.NaN)).rejects.toThrow(
+      "simpleCache requires a finite TTL in milliseconds",
+    );
+    await expect(simpleCache("key", fn, -1)).rejects.toThrow(
+      "simpleCache TTL must be non-negative",
+    );
+
+    expect(fn).not.toHaveBeenCalled();
+
+    resetCacheAndRateState();
+  });
+
   it("does not cache errors", async () => {
     jest.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
     const { simpleCache, resetCacheAndRateState } = loadModule();
@@ -61,6 +78,24 @@ describe("cacheAndRate utilities", () => {
     await expect(simpleCache("key", fn, 1000)).rejects.toBe(error);
     await expect(simpleCache("key", fn, 1000)).resolves.toBe("recovered");
     expect(fn).toHaveBeenCalledTimes(2);
+
+    resetCacheAndRateState();
+  });
+
+  it("rejects invalid delay values in the rate limiter", async () => {
+    const { rateLimiter, resetCacheAndRateState } = loadModule();
+
+    const fn = jest.fn().mockResolvedValue("ok");
+
+    await expect(rateLimiter("provider", fn, Number.NaN)).rejects.toThrow(
+      "rateLimiter requires a finite delay in milliseconds",
+    );
+
+    await expect(rateLimiter("provider", fn, -1)).rejects.toThrow(
+      "rateLimiter delay must be non-negative",
+    );
+
+    expect(fn).not.toHaveBeenCalled();
 
     resetCacheAndRateState();
   });

--- a/docs/codebase-audit.md
+++ b/docs/codebase-audit.md
@@ -1,0 +1,44 @@
+# Codebase audit
+
+## Overview
+
+This audit combined automated checks (Jest, ESLint, Prettier) with targeted review of high-risk modules such as caching utilities and the advanced tool registry. The goal was to surface latent defects, noisy logging, and maintainability risks that could destabilise agent orchestration.
+
+## Key findings
+
+### Cache and rate limiting utilities
+
+- `simpleCache` now avoids capturing unused rejection arguments while still retrying failed lookups so each caller gets a fresh error instance or resolved value without polluting the shared cache entry.【F:src/services/utils/cacheAndRate.js†L15-L60】
+- TTL inputs are validated before caching, preventing `NaN`, `Infinity`, or negative windows from freezing entries in the map; Jest coverage asserts both the guardrails and the unchanged happy-path semantics in the cache-and-rate Jest suite.【F:src/services/utils/cacheAndRate.js†L20-L58】【390c08†L18-L124】
+- `rateLimiter` guards against invalid delays and automatically resets the provider queue after an error, which prevents deadlocks but depends on consumers handling rejected promises to avoid rapid-fire retries.【F:src/services/utils/cacheAndRate.js†L63-L113】
+
+### File system tool diagnostics
+
+- The file system tool correctly sanitises paths via `resolveSafePath` and rejects directory traversal, emitting structured telemetry alongside a logged error; the Jest suite intentionally exercises this failure path, which is why repeated console noise appears in test output.【F:src/architecture/toolSystem.js†L291-L416】
+
+### Plugin activation logs
+
+- LLM plugin hooks broadcast activation messages (`Sparse attention plugin initialized`, `Switching to Q8_0 quantization`), confirming that instrumentation remains wired through the plugin manager and service logger; retain these logs for observability but consider demoting to debug in production builds if they become verbose.【F:src/architecture/pluginSetup.js†L1-L30】【F:src/architecture/pluginManager.js†L1-L60】【F:src/services/llmService.js†L296-L327】
+
+### Memory retrieval and context planning
+
+- `MemoryManager` threads `VectorIndexer`, `Retriever`, and `HistoryService` together so interactions are indexed, retrieved, and persisted with the same embedding service that powers runtime recall; detaching any one service would orphan conversation history or sparse attention fallbacks.【F:src/core/memory/MemoryManager.js†L1-L35】
+- `ContextEngineer` raises relevance thresholds, prunes via hierarchical sparse attention, and ranks by device-aware quality scoring, ensuring memory recall respects token budgets on low-memory devices while still prioritising fresh or knowledge-base content.【F:src/services/contextEngineer.js†L16-L176】
+
+### Prompt routing and tool execution
+
+- `PromptBuilder` normalises tool metadata before injecting it into the system prompt so downstream parsing keeps deterministic ordering and excludes malformed entries.【F:src/core/prompt/PromptBuilder.js†L1-L71】
+- `ToolHandler` validates required parameters, surfaces parser errors for malformed tool calls, and routes telemetry to the workflow tracer/logger so missing arguments or execution failures are observable without halting orchestration.【F:src/core/tools/ToolHandler.js†L1-L198】
+
+## Recommendations
+
+- Maintain the updated caching behaviour to keep ESLint passing and ensure `npm run lint` remains part of pre-commit checks, because the repo enforces strict unused-parameter rules.【F:src/services/utils/cacheAndRate.js†L15-L60】
+- Enforce numeric TTL and delay inputs in downstream integrations; the new guards fail fast and tests capture the contract so caller bugs do not silently pin stale cache entries or saturate provider queues.【F:src/services/utils/cacheAndRate.js†L20-L113】【390c08†L51-L178】
+- When investigating file-system issues, reference the structured error payload returned by the tool rather than the raw console output to avoid mistaking defensive logging for regressions.【F:src/architecture/toolSystem.js†L291-L416】
+- If runtime logging becomes noisy, add log-level gating around plugin lifecycle events so release builds can mute informational output without sacrificing diagnostics during development.【F:src/architecture/pluginManager.js†L1-L60】【F:src/services/llmService.js†L296-L327】
+
+## Test status
+
+- Jest: 19 suites, 71 tests passing.【72ad4b†L20-L24】
+- ESLint: No issues after cache utility update.【c1fc40†L1-L5】
+- Prettier: Formatting verified for the entire project.【b7386a†L1-L6】


### PR DESCRIPTION
## Summary
- normalize TTL inputs in `simpleCache` so non-finite and negative values fail fast while keeping cache expiry calculations consistent
- cover the new TTL and delay guards with Jest so cache and rate limiter contracts stay enforced
- extend the codebase audit with retrieval, context, and tooling insights plus refreshed automated check status

## Testing
- npm test -- --runInBand
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68d6e550c07883339c746e2e35a6ca8b