### PR TITLE
Add February 2025 codebase audit report

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,6 +14,8 @@ ios/MyOfflineLLMApp/Resources/Models
 .github/workflows/ios-unsigned-device.yml
 # ignore disabled workflow files
 .github/workflows/*.yml.disabled
+# Prettier lacks a Java parser; skip Android sources so format:check can run
+android/**/*.java
 README.md
 CONTRIBUTING.md
 # keep architecture doc unformatted so inline diagrams remain stable

--- a/docs/codebase-audit-20250215.md
+++ b/docs/codebase-audit-20250215.md
@@ -1,0 +1,21 @@
+# Codebase audit – 2025-02-15
+
+## Automated checks
+
+- Jest passes all 19 suites (72 tests) when run serially, confirming baseline coverage for orchestrator, tooling, memory, and plugin paths.【1a7cb2†L1-L29】
+- ESLint completes without rule violations but warns that TypeScript 5.9.2 is newer than the supported <5.6.0 range for `@typescript-eslint` tooling, risking future incompatibilities.【b90d3f†L1-L13】【F:package.json†L61-L81】
+- Prettier required excluding Java sources because the bundled configuration lacks a Java parser; ignoring `android/**/*.java` restores `format:check` stability without affecting JS/TS style enforcement.【71764e†L1-L13】【caddaf†L1-L5】
+
+## Runtime and orchestration review
+
+- `AgentOrchestrator.run` composes prompts deterministically, logging each phase via `WorkflowTracer` so context assembly, tool execution, and persistence remain observable.【F:src/core/AgentOrchestrator.js†L24-L118】
+- Memory writes enqueue both vector indexing and bounded conversation history updates, keeping replay context capped at 20 entries to avoid prompt bloat.【F:src/core/memory/MemoryManager.js†L9-L32】【F:src/core/memory/services/HistoryService.js†L1-L16】
+- Tool execution uses `applyParameterDefaults`, strict validation, and rich telemetry; file-system helpers enforce path resolution and directory safety across React Native and Node hosts.【F:src/architecture/toolSystem.js†L1-L120】【F:src/architecture/toolSystem.js†L302-L414】【F:src/utils/fsUtils.js†L271-L320】
+- LLM loading activates sparse-attention and adaptive-quantization plugins immediately after native model initialization, keeping performance hooks consistent between platforms.【F:src/services/llmService.js†L1-L120】【F:src/services/llmService.js†L90-L118】
+
+## Potential risks & follow-ups
+
+- ESLint’s TypeScript-parser warning indicates the project should either downgrade TypeScript below 5.6 or upgrade `@typescript-eslint` once support lands to keep linting reliable on future releases.【b90d3f†L1-L13】【F:package.json†L61-L81】
+- The iOS bridge path in `LLMService.generate` ignores `maxTokens`, `temperature`, and plugin-provided options because it calls the native module with only the prompt; investigate native API parity to avoid feature drift across platforms.【F:src/services/llmService.js†L120-L166】
+- File-system tool tests surface console errors when invalid paths are supplied, confirming guardrails but also indicating callers must handle verbose logging in production; consider downgrading to structured warnings once analytics mature.【977250†L1-L44】【F:src/architecture/toolSystem.js†L302-L414】
+- Android brightness control ships via a custom TurboModule; document sideload permission expectations so future React Native upgrades preserve this non-system setting behavior.【F:android/app/src/main/java/com/mongars/BrightnessTurboModule.java†L1-L58】


### PR DESCRIPTION
## Summary
- document the current runtime, tooling, and risk assessment in a 2025-02-15 audit report under docs/
- adjust Prettier configuration to ignore Android Java sources so format:check succeeds without a Java parser

## Testing
- npm test -- --runInBand
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68d7006b545083338dcfcc9eb36e6677

## Summary by Sourcery

Add a February 2025 codebase audit report and adjust formatting configuration to ignore Android Java sources for stable format checks.

New Features:
- Add a comprehensive codebase audit report under docs/codebase-audit-20250215.md detailing automated checks, runtime orchestration, and identified risks.

Enhancements:
- Update Prettier configuration to ignore Android Java files so format:check passes without a Java parser.

Documentation:
- Document Jest, ESLint, and Prettier audit results and tooling status.
- Outline runtime orchestration, memory management, tool execution, and LLM loading processes.
- List potential risks and follow-up tasks related to TypeScript version compatibility, native API parity, logging verbosity, and Android TurboModule behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Added a comprehensive codebase audit document summarizing automated test results, linting/formatting considerations, runtime/orchestration behavior, and cross-platform risks with recommended follow-ups.

* Chores
  * Updated Prettier ignore rules to exclude Android Java files from formatting checks, reducing noise and speeding up CI without impacting app functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->