### PR TITLE
Add signing secret precheck to iOS build workflow

### DIFF
--- a/.github/actions/signing-secrets-check/action.yml
+++ b/.github/actions/signing-secrets-check/action.yml
@@ -1,0 +1,41 @@
+name: signing-secrets-check
+description: Validate that all required signing secrets are populated before running signing workflows.
+inputs:
+  required-secrets:
+    description: |-
+      Newline-delimited list of environment variable names that must be populated for signing to proceed.
+    required: true
+outputs:
+  ready:
+    description: Indicates whether all required secrets were found.
+    value: ${{ steps.evaluate.outputs.ready }}
+runs:
+  using: composite
+  steps:
+    - id: evaluate
+      shell: bash
+      env:
+        REQUIRED_SECRETS: ${{ inputs.required-secrets }}
+      run: |
+        set -euo pipefail
+        python3 - <<'PY'
+        import os
+        import sys
+
+        required = [line.strip() for line in os.environ["REQUIRED_SECRETS"].splitlines() if line.strip()]
+        missing = [name for name in required if not os.environ.get(name)]
+
+        output_path = os.environ["GITHUB_OUTPUT"]
+        with open(output_path, "a", encoding="utf-8") as fh:
+            fh.write(f"ready={'false' if missing else 'true'}\n")
+
+        if missing:
+            joined = ", ".join(missing)
+            sys.stdout.write(
+                f"::warning ::Skipping signed build because the following secrets are not configured: {joined}\n"
+            )
+        else:
+            sys.stdout.write(
+                "::notice ::All signing secrets detected; continuing with signed build.\n"
+            )
+        PY

--- a/.github/workflows/ios-signed-monGARS.yml
+++ b/.github/workflows/ios-signed-monGARS.yml
@@ -6,8 +6,43 @@ on:
     branches: [main]
 
 jobs:
+  signing_precheck:
+    runs-on: ubuntu-latest
+    outputs:
+      ready: ${{ steps.evaluate.outputs.ready }}
+    steps:
+      - name: Evaluate signing secrets
+        id: evaluate
+        env:
+          P12_BASE64: ${{ secrets.P12_BASE64 }}
+          MOBILEPROVISION_BASE64: ${{ secrets.MOBILEPROVISION_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          missing=()
+
+          [[ -z "${P12_BASE64}" ]] && missing+=("P12_BASE64")
+          [[ -z "${MOBILEPROVISION_BASE64}" ]] && missing+=("MOBILEPROVISION_BASE64")
+          [[ -z "${P12_PASSWORD}" ]] && missing+=("P12_PASSWORD")
+          [[ -z "${KEYCHAIN_PASSWORD}" ]] && missing+=("KEYCHAIN_PASSWORD")
+          [[ -z "${APPLE_TEAM_ID}" ]] && missing+=("APPLE_TEAM_ID")
+
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            IFS=", "
+            joined="${missing[*]}"
+            unset IFS
+            printf 'ready=false\n' >>"$GITHUB_OUTPUT"
+            printf '::warning ::Skipping signed build because the following secrets are not configured: %s\n' "$joined"
+          else
+            printf 'ready=true\n' >>"$GITHUB_OUTPUT"
+            printf '::notice ::All signing secrets detected; continuing with signed build.\n'
+          fi
+
   build:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    needs: signing_precheck
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && needs.signing_precheck.outputs.ready == 'true' }}
     runs-on: macos-15
     timeout-minutes: 60
 

--- a/.github/workflows/ios-signed-monGARS.yml
+++ b/.github/workflows/ios-signed-monGARS.yml
@@ -2,43 +2,40 @@ name: Build iOS App (monGARS)
 
 on:
   workflow_dispatch:
+    inputs:
+      require_signing:
+        description: Skip secret validation and signed build when set to "false".
+        required: false
+        default: "true"
   push:
     branches: [main]
 
+env:
+  SIGNING_SECRET_NAMES: |
+    P12_BASE64
+    MOBILEPROVISION_BASE64
+    P12_PASSWORD
+    KEYCHAIN_PASSWORD
+    APPLE_TEAM_ID
+
 jobs:
   signing_precheck:
+    if: github.event_name != 'workflow_dispatch' || inputs.require_signing == 'true'
     runs-on: ubuntu-latest
     outputs:
       ready: ${{ steps.evaluate.outputs.ready }}
     steps:
       - name: Evaluate signing secrets
         id: evaluate
+        uses: ./.github/actions/signing-secrets-check
+        with:
+          required-secrets: ${{ env.SIGNING_SECRET_NAMES }}
         env:
           P12_BASE64: ${{ secrets.P12_BASE64 }}
           MOBILEPROVISION_BASE64: ${{ secrets.MOBILEPROVISION_BASE64 }}
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: |
-          set -euo pipefail
-          missing=()
-
-          [[ -z "${P12_BASE64}" ]] && missing+=("P12_BASE64")
-          [[ -z "${MOBILEPROVISION_BASE64}" ]] && missing+=("MOBILEPROVISION_BASE64")
-          [[ -z "${P12_PASSWORD}" ]] && missing+=("P12_PASSWORD")
-          [[ -z "${KEYCHAIN_PASSWORD}" ]] && missing+=("KEYCHAIN_PASSWORD")
-          [[ -z "${APPLE_TEAM_ID}" ]] && missing+=("APPLE_TEAM_ID")
-
-          if [[ ${#missing[@]} -gt 0 ]]; then
-            IFS=", "
-            joined="${missing[*]}"
-            unset IFS
-            printf 'ready=false\n' >>"$GITHUB_OUTPUT"
-            printf '::warning ::Skipping signed build because the following secrets are not configured: %s\n' "$joined"
-          else
-            printf 'ready=true\n' >>"$GITHUB_OUTPUT"
-            printf '::notice ::All signing secrets detected; continuing with signed build.\n'
-          fi
 
   build:
     needs: signing_precheck


### PR DESCRIPTION
## Summary
- add a preflight job that checks for required signing secrets and surfaces missing secret names as a workflow warning
- gate the signed iOS build job on the precheck output so the job skips cleanly when secrets are absent

## Testing
- CI=1 npm test
- npm run lint
- npx prettier --check . --log-level=warn

------
https://chatgpt.com/codex/tasks/task_e_68da32117a0c83339edb49f5ab03e410

## Summary by Sourcery

Introduce a preflight check for iOS signing secrets in the GitHub Actions workflow and skip the signed build if any secrets are not configured.

CI:
- Add signing_precheck job to verify required iOS signing secrets before the signed build.
- Gate the signed build job on the precheck output to cleanly skip when secrets are missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a precheck that validates required signing secrets before running signed builds.
  - Builds are now gated to proceed only when all signing prerequisites are met.
  - Introduced an option to skip signing validation when triggering the workflow.
  - Provides clear notices when all secrets are present and warnings listing any missing secrets.

- Chores
  - Enhanced CI reliability with stricter validation and controlled build flow based on signing readiness.
  - Improved transparency in pipeline outcomes through explicit readiness signals and messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->