### PR TITLE
Normalize monGARS signing readiness output

### DIFF
--- a/.github/workflows/ios-signed-monGARS.yml
+++ b/.github/workflows/ios-signed-monGARS.yml
@@ -24,8 +24,8 @@ jobs:
     permissions:
       contents: read
     outputs:
-      ready: ${{ steps.precheck_result.outputs.ready }}
-      message: ${{ steps.precheck_result.outputs.message }}
+      ready: ${{ toJSON(steps.precheck_result.outputs.ready == 'true') }}
+      message: ${{ steps.precheck_result.outputs.message || 'Signed build readiness unavailable.' }}
     steps:
       - name: Determine signing requirement
         id: require_signing
@@ -119,7 +119,7 @@ jobs:
 
   build:
     needs: signing_precheck
-    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && needs.signing_precheck.result == 'success' && needs.signing_precheck.outputs.ready == 'true' }}
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && needs.signing_precheck.result == 'success' && fromJSON(needs.signing_precheck.outputs.ready) }}
     runs-on: macos-15
     timeout-minutes: 60
 


### PR DESCRIPTION
## Summary
- emit the signing precheck job readiness output as canonical JSON booleans for downstream consumers
- gate the macOS build job directly on the sanitized readiness output so the build no longer skips when secrets are present

## Testing
- CI=1 npm test
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68da9b7895bc833384a331c8a0dd4dd1

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/offLLM/235)
<!-- GitContextEnd -->

## Summary by Sourcery

Normalize the signing readiness output in the iOS workflow to emit JSON booleans, provide a default message fallback, and gate the macOS build job on the parsed boolean flag.

Enhancements:
- Emit canonical JSON booleans for the signing precheck readiness output
- Provide a fallback message when the readiness output is unavailable
- Update the macOS build job condition to parse and use the boolean readiness flag directly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected readiness evaluation in the iOS build workflow to use a boolean check, preventing erroneous build triggers or skips.
* **Chores**
  * Improved signing precheck output handling with a safe default message for clearer CI logs and more predictable conditional steps.
  * General CI reliability improvements for the iOS pipeline. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->