### PR TITLE
Improve signing precheck reporting

### DIFF
--- a/.github/actions/signing-secrets-check/action.yml
+++ b/.github/actions/signing-secrets-check/action.yml
@@ -9,6 +9,9 @@ outputs:
   ready:
     description: Indicates whether all required secrets were found.
     value: ${{ steps.evaluate.outputs.ready }}
+  missing:
+    description: Comma-separated list of any secrets that were not populated.
+    value: ${{ steps.evaluate.outputs.missing }}
 runs:
   using: composite
   steps:
@@ -26,13 +29,18 @@ runs:
         missing = [name for name in required if not os.environ.get(name)]
 
         output_path = os.environ["GITHUB_OUTPUT"]
+        joined = ",".join(missing)
+
         with open(output_path, "a", encoding="utf-8") as fh:
             fh.write(f"ready={'false' if missing else 'true'}\n")
+            fh.write(f"missing={joined}\n")
 
         if missing:
-            joined = ", ".join(missing)
             sys.stdout.write(
-                f"::warning ::Skipping signed build because the following secrets are not configured: {joined}\n"
+                (
+                    "::notice ::Signed build skipped; configure the following secrets to enable it: "
+                    f"{', '.join(missing)}\n"
+                )
             )
         else:
             sys.stdout.write(

--- a/.github/actions/signing-secrets-check/action.yml
+++ b/.github/actions/signing-secrets-check/action.yml
@@ -29,19 +29,18 @@ runs:
         missing = [name for name in required if not os.environ.get(name)]
 
         output_path = os.environ["GITHUB_OUTPUT"]
-        joined = ",".join(missing)
+        joined = ", ".join(missing)
 
         with open(output_path, "a", encoding="utf-8") as fh:
             fh.write(f"ready={'false' if missing else 'true'}\n")
             fh.write(f"missing={joined}\n")
 
         if missing:
-            sys.stdout.write(
-                (
-                    "::notice ::Signed build skipped; configure the following secrets to enable it: "
-                    f"{', '.join(missing)}\n"
-                )
+            message = (
+                "Signed build skipped; configure the following secrets to enable it: "
+                f"{joined}."
             )
+            sys.stdout.write(f"::notice ::{message}\n")
         else:
             sys.stdout.write(
                 "::notice ::All signing secrets detected; continuing with signed build.\n"

--- a/.github/workflows/ios-signed-monGARS.yml
+++ b/.github/workflows/ios-signed-monGARS.yml
@@ -82,6 +82,7 @@ jobs:
         env:
           REQUIRE_SIGNING: ${{ steps.require_signing.outputs.require_signing }}
           READY: ${{ steps.evaluate.outputs.ready }}
+          MISSING: ${{ steps.evaluate.outputs.missing }}
         run: |
           set -euo pipefail
 
@@ -96,10 +97,16 @@ jobs:
             ready_value="false"
           fi
 
+          missing_value="${MISSING:-}"
+
           if [[ "$ready_value" == "true" ]]; then
             echo "message=All signing secrets detected; proceeding with signed build." >>"$GITHUB_OUTPUT"
           else
-            echo "message=Missing signing secrets; skipping signed build." >>"$GITHUB_OUTPUT"
+            summary="Missing signing secrets; skipping signed build."
+            if [[ -n "${missing_value// }" ]]; then
+              summary+=" Missing: ${missing_value}."
+            fi
+            echo "message=${summary}" >>"$GITHUB_OUTPUT"
           fi
 
           echo "ready=$ready_value" >>"$GITHUB_OUTPUT"
@@ -109,12 +116,18 @@ jobs:
         env:
           READY: ${{ steps.precheck_result.outputs.ready }}
           SUMMARY_MESSAGE: ${{ steps.precheck_result.outputs.message }}
+          MISSING: ${{ steps.evaluate.outputs.missing }}
         run: |
           {
             echo "## Signing precheck"
             echo ""
             echo "- Ready: \`$READY\`"
             echo "- Details: $SUMMARY_MESSAGE"
+            missing_list="${MISSING:-}"
+            if [[ -n "${missing_list// }" ]]; then
+              missing_list="$(printf '%s' "$missing_list" | tr ',' ', ')"
+              echo "- Missing secrets: $missing_list"
+            fi
           } >>"$GITHUB_STEP_SUMMARY"
 
   build:

--- a/.github/workflows/ios-signed-monGARS.yml
+++ b/.github/workflows/ios-signed-monGARS.yml
@@ -86,37 +86,48 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ "$REQUIRE_SIGNING" != "true" ]]; then
-            echo "ready=false" >>"$GITHUB_OUTPUT"
-            echo "message=Signed build skipped via workflow input." >>"$GITHUB_OUTPUT"
-            exit 0
-          fi
+          python3 - <<'PY'
+          import os
 
-          ready_value="$READY"
-          if [[ -z "$ready_value" ]]; then
-            ready_value="false"
-          fi
+          require_signing = os.environ.get("REQUIRE_SIGNING", "").lower() == "true"
+          ready_raw = os.environ.get("READY", "")
+          missing_raw = os.environ.get("MISSING", "")
+          output_path = os.environ["GITHUB_OUTPUT"]
 
-          missing_value="${MISSING:-}"
+          def normalize_missing(raw: str) -> str:
+              parts = [item.strip() for item in raw.split(",") if item.strip()]
+              return ", ".join(parts)
 
-          if [[ "$ready_value" == "true" ]]; then
-            echo "message=All signing secrets detected; proceeding with signed build." >>"$GITHUB_OUTPUT"
-          else
-            summary="Missing signing secrets; skipping signed build."
-            if [[ -n "${missing_value// }" ]]; then
-              summary+=" Missing: ${missing_value}."
-            fi
-            echo "message=${summary}" >>"$GITHUB_OUTPUT"
-          fi
+          if not require_signing:
+              ready_value = "false"
+              message = "Signed build skipped via workflow input."
+              formatted_missing = ""
+          else:
+              ready_value = "true" if ready_raw == "true" else "false"
+              formatted_missing = normalize_missing(missing_raw)
 
-          echo "ready=$ready_value" >>"$GITHUB_OUTPUT"
+              if ready_value == "true":
+                  message = "All signing secrets detected; continuing with signed build."
+              elif formatted_missing:
+                  message = (
+                      "Signed build skipped; configure the following secrets to enable it: "
+                      f"{formatted_missing}."
+                  )
+              else:
+                  message = "Signed build skipped; required signing secrets are missing."
+
+          with open(output_path, "a", encoding="utf-8") as handle:
+              handle.write(f"ready={ready_value}\n")
+              handle.write(f"message={message}\n")
+              handle.write(f"missing_formatted={formatted_missing}\n")
+          PY
 
       - name: Summarize signing gate
         if: ${{ always() }}
         env:
           READY: ${{ steps.precheck_result.outputs.ready }}
           SUMMARY_MESSAGE: ${{ steps.precheck_result.outputs.message }}
-          MISSING: ${{ steps.evaluate.outputs.missing }}
+          MISSING: ${{ steps.precheck_result.outputs.missing_formatted }}
         run: |
           {
             echo "## Signing precheck"
@@ -125,7 +136,6 @@ jobs:
             echo "- Details: $SUMMARY_MESSAGE"
             missing_list="${MISSING:-}"
             if [[ -n "${missing_list// }" ]]; then
-              missing_list="$(printf '%s' "$missing_list" | tr ',' ', ')"
               echo "- Missing secrets: $missing_list"
             fi
           } >>"$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- extend the signing-secrets-check composite action to emit the missing secret list and report expected skips as notices
- surface missing secret names in the ios signed build workflow summary so engineers can see which values are absent

## Testing
- CI=1 npm test -- --runInBand
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68daa09c76ac8333bc4ef6fb3b3a5d57

## Summary by Sourcery

Provide detailed reporting of missing signing secrets by extending the signing-secrets-check action and updating the iOS signed build workflow to expose absent secret names.

Enhancements:
- Add a 'missing' output to the signing-secrets-check composite action to list any absent secrets.
- Emit a notice with the names of missing secrets when the composite action skips a signed build.
- Update the iOS signed build workflow to include the missing secret names in both the skip message and GitHub step summary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposes a “missing secrets” output from the signing-secrets check, listing any unset secrets.
  * Propagates and displays missing secrets throughout the iOS signing workflow.
  * Enhances precheck summaries to include a formatted list of missing secrets when applicable.

* **Chores**
  * Changes missing-secrets messaging from warning to notice for clearer, less noisy reporting.
  * Maintains existing readiness behavior (ready only when no secrets are missing).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->