### PR TITLE
Streamline iOS signing precheck evaluation

### DIFF
--- a/.github/actions/signing-secrets-check/action.yml
+++ b/.github/actions/signing-secrets-check/action.yml
@@ -5,10 +5,31 @@ inputs:
     description: |-
       Newline-delimited list of environment variable names that must be populated for signing to proceed.
     required: true
+  require-signing-input:
+    description: |-
+      Raw require_signing value supplied via workflow_dispatch. Empty values default to "true".
+    required: false
+    default: ""
+  event-name:
+    description: GitHub event name triggering the workflow (e.g., push, workflow_dispatch).
+    required: false
+    default: ""
 outputs:
   ready:
     description: Indicates whether all required secrets were found.
     value: ${{ steps.evaluate.outputs.ready }}
+  missing:
+    description: Comma-separated list of any secrets that were not populated.
+    value: ${{ steps.evaluate.outputs.missing }}
+  message:
+    description: Human-readable summary of the signing readiness state.
+    value: ${{ steps.evaluate.outputs.message }}
+  missing_formatted:
+    description: Comma-space separated list of missing secrets for reuse in summaries.
+    value: ${{ steps.evaluate.outputs.missing_formatted }}
+  require_signing:
+    description: Normalized boolean string indicating whether signing was requested.
+    value: ${{ steps.evaluate.outputs.require_signing }}
 runs:
   using: composite
   steps:
@@ -16,26 +37,79 @@ runs:
       shell: bash
       env:
         REQUIRED_SECRETS: ${{ inputs.required-secrets }}
+        REQUIRE_SIGNING_INPUT: ${{ inputs.require-signing-input }}
+        EVENT_NAME: ${{ inputs.event-name }}
       run: |
         set -euo pipefail
         python3 - <<'PY'
         import os
         import sys
 
-        required = [line.strip() for line in os.environ["REQUIRED_SECRETS"].splitlines() if line.strip()]
-        missing = [name for name in required if not os.environ.get(name)]
+        TRUE_VALUES = {"true", "1", "yes", "on"}
+        FALSE_VALUES = {"false", "0", "no", "off"}
+
+        required_raw = os.environ.get("REQUIRED_SECRETS", "")
+        required = [line.strip() for line in required_raw.splitlines() if line.strip()]
+
+        raw_input = os.environ.get("REQUIRE_SIGNING_INPUT", "")
+        event_name = os.environ.get("EVENT_NAME", "")
+
+        if event_name != "workflow_dispatch" or not raw_input.strip():
+            normalized_request = "true"
+        else:
+            normalized_request = raw_input.strip().lower()
+
+        if normalized_request in TRUE_VALUES:
+            require_signing = True
+        elif normalized_request in FALSE_VALUES:
+            require_signing = False
+        else:
+            sys.stdout.write(
+                f"::warning ::Unknown require_signing value '{raw_input}'; defaulting to true.\n"
+            )
+            require_signing = True
+
+        missing = [name for name in required if not os.environ.get(name)] if require_signing else []
+        joined_missing = ", ".join(missing)
+
+        if not require_signing:
+            ready_value = "false"
+            message = "Signed build skipped via workflow input."
+            notice = message
+            joined_missing = ""
+        elif missing:
+            ready_value = "false"
+            message = (
+                "Signed build skipped; configure the following secrets to enable it: "
+                f"{joined_missing}."
+            )
+            notice = message
+        else:
+            ready_value = "true"
+            message = "All signing secrets detected; continuing with signed build."
+            notice = message
+
+        sys.stdout.write(f"::notice ::{notice}\n")
 
         output_path = os.environ["GITHUB_OUTPUT"]
         with open(output_path, "a", encoding="utf-8") as fh:
-            fh.write(f"ready={'false' if missing else 'true'}\n")
+            fh.write(f"ready={ready_value}\n")
+            fh.write(f"missing={joined_missing}\n")
+            fh.write(f"message={message}\n")
+            fh.write(f"missing_formatted={joined_missing}\n")
+            fh.write(f"require_signing={'true' if require_signing else 'false'}\n")
 
-        if missing:
-            joined = ", ".join(missing)
-            sys.stdout.write(
-                f"::warning ::Skipping signed build because the following secrets are not configured: {joined}\n"
-            )
-        else:
-            sys.stdout.write(
-                "::notice ::All signing secrets detected; continuing with signed build.\n"
-            )
+        summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary_path:
+            lines = [
+                "## Signing precheck",
+                "",
+                f"- Ready: `{ready_value}`",
+                f"- Details: {message}",
+            ]
+            if joined_missing:
+                lines.append(f"- Missing secrets: {joined_missing}")
+
+            with open(summary_path, "a", encoding="utf-8") as summary:
+                summary.write("\n".join(lines) + "\n")
         PY

--- a/.github/workflows/ios-signed-monGARS.yml
+++ b/.github/workflows/ios-signed-monGARS.yml
@@ -24,98 +24,22 @@ jobs:
     permissions:
       contents: read
     outputs:
-      ready: ${{ toJSON(steps.precheck_result.outputs.ready == 'true') }}
-      message: ${{ steps.precheck_result.outputs.message || 'Signed build readiness unavailable.' }}
+      ready: ${{ toJSON(steps.precheck.outputs.ready == 'true') }}
+      message: ${{ steps.precheck.outputs.message || 'Signed build readiness unavailable.' }}
     steps:
-      - name: Determine signing requirement
-        id: require_signing
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          INPUT_REQUIRE_SIGNING: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.require_signing || '' }}
-        run: |
-          set -euo pipefail
-
-          raw_input="$INPUT_REQUIRE_SIGNING"
-          if [[ "$EVENT_NAME" != "workflow_dispatch" || -z "$raw_input" ]]; then
-            raw_input="true"
-          fi
-
-          normalized="$(printf '%s' "$raw_input" | tr '[:upper:]' '[:lower:]')"
-          case "$normalized" in
-            true|1|yes|on)
-              normalized="true"
-              ;;
-            false|0|no|off)
-              normalized="false"
-              ;;
-            *)
-              echo "::warning ::Unknown require_signing value '$raw_input'; defaulting to true."
-              normalized="true"
-              ;;
-          esac
-
-          echo "require_signing=$normalized" >>"$GITHUB_OUTPUT"
-
-      - name: Checkout repository
-        if: ${{ steps.require_signing.outputs.require_signing == 'true' }}
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Evaluate signing secrets
-        if: ${{ steps.require_signing.outputs.require_signing == 'true' }}
-        id: evaluate
+      - name: Run signing precheck
+        id: precheck
         uses: ./.github/actions/signing-secrets-check
         with:
           required-secrets: ${{ env.SIGNING_SECRET_NAMES }}
+          event-name: ${{ github.event_name }}
+          require-signing-input: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.require_signing || '' }}
         env:
           P12_BASE64: ${{ secrets.P12_BASE64 }}
           MOBILEPROVISION_BASE64: ${{ secrets.MOBILEPROVISION_BASE64 }}
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-
-      - name: Finalize signing precheck result
-        id: precheck_result
-        shell: bash
-        env:
-          REQUIRE_SIGNING: ${{ steps.require_signing.outputs.require_signing }}
-          READY: ${{ steps.evaluate.outputs.ready }}
-        run: |
-          set -euo pipefail
-
-          if [[ "$REQUIRE_SIGNING" != "true" ]]; then
-            echo "ready=false" >>"$GITHUB_OUTPUT"
-            echo "message=Signed build skipped via workflow input." >>"$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          ready_value="$READY"
-          if [[ -z "$ready_value" ]]; then
-            ready_value="false"
-          fi
-
-          if [[ "$ready_value" == "true" ]]; then
-            echo "message=All signing secrets detected; proceeding with signed build." >>"$GITHUB_OUTPUT"
-          else
-            echo "message=Missing signing secrets; skipping signed build." >>"$GITHUB_OUTPUT"
-          fi
-
-          echo "ready=$ready_value" >>"$GITHUB_OUTPUT"
-
-      - name: Summarize signing gate
-        if: ${{ always() }}
-        env:
-          READY: ${{ steps.precheck_result.outputs.ready }}
-          SUMMARY_MESSAGE: ${{ steps.precheck_result.outputs.message }}
-        run: |
-          {
-            echo "## Signing precheck"
-            echo ""
-            echo "- Ready: \`$READY\`"
-            echo "- Details: $SUMMARY_MESSAGE"
-          } >>"$GITHUB_STEP_SUMMARY"
 
   build:
     needs: signing_precheck


### PR DESCRIPTION
## Summary
- expand the signing secrets composite action to normalize the require_signing input, emit ready/message outputs, and write a consistent summary
- collapse the iOS signing precheck job to a single step that reuses the composite action outputs for downstream gating

## Testing
- CI=1 npm test -- --runInBand
- npm run lint
- npm run format:check | tail -n 20

------
https://chatgpt.com/codex/tasks/task_e_68daa09c76ac8333bc4ef6fb3b3a5d57

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/offLLM/237)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional controls to set signing requirements based on event/context.
  - Exposed richer outputs: readiness, missing secrets (raw and formatted), status message, and whether signing is required.
  - Added optional signing precheck summary in job logs.

- Refactor
  - Replaced multi-step signing gate with a single precheck step using a dedicated action.
  - Simplified workflow logic and messaging for signing readiness.

- Chores
  - Updated workflows to consume the new precheck outputs for build gating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->