### PR TITLE
Streamline signing readiness gate

### DIFF
--- a/.github/actions/signing-secrets-check/action.yml
+++ b/.github/actions/signing-secrets-check/action.yml
@@ -5,10 +5,18 @@ inputs:
     description: |-
       Newline-delimited list of environment variable names that must be populated for signing to proceed.
     required: true
+  require-signing:
+    description: |-
+      Raw workflow input indicating whether signing should run. Accepts truthy/falsey strings (true/false/yes/no/1/0).
+    required: false
+    default: ""
 outputs:
   ready:
-    description: Indicates whether all required secrets were found.
+    description: Indicates whether all required secrets were found and signing should continue.
     value: ${{ steps.evaluate.outputs.ready }}
+  message:
+    description: Human-readable summary of the signing readiness decision.
+    value: ${{ steps.evaluate.outputs.message }}
   missing:
     description: Comma-separated list of any secrets that were not populated.
     value: ${{ steps.evaluate.outputs.missing }}
@@ -19,30 +27,91 @@ runs:
       shell: bash
       env:
         REQUIRED_SECRETS: ${{ inputs.required-secrets }}
+        REQUIRE_SIGNING_INPUT: ${{ inputs.require-signing }}
       run: |
         set -euo pipefail
         python3 - <<'PY'
         import os
         import sys
+        from typing import List, Tuple
 
-        required = [line.strip() for line in os.environ["REQUIRED_SECRETS"].splitlines() if line.strip()]
+        TRUTHY = {"true", "1", "yes", "on"}
+        FALSY = {"false", "0", "no", "off"}
+
+        def normalize_secret_names(raw: str) -> List[str]:
+            seen = set()
+            ordered: List[str] = []
+            for line in raw.splitlines():
+                candidate = line.strip()
+                if not candidate:
+                    continue
+                key = candidate
+                if key not in seen:
+                    seen.add(key)
+                    ordered.append(candidate)
+            return ordered
+
+        def normalize_require_signing(raw: str) -> Tuple[bool, str | None]:
+            if raw is None:
+                return True, None
+            candidate = raw.strip().lower()
+            if not candidate:
+                return True, None
+            if candidate in TRUTHY:
+                return True, None
+            if candidate in FALSY:
+                return False, None
+            return True, f"Unknown require_signing value '{raw}'; defaulting to true."
+
+        required = normalize_secret_names(os.environ.get("REQUIRED_SECRETS", ""))
+        require_signing_raw = os.environ.get("REQUIRE_SIGNING_INPUT")
+        require_signing, warning = normalize_require_signing(require_signing_raw)
+        if warning:
+            sys.stdout.write(f"::warning ::{warning}\n")
+
         missing = [name for name in required if not os.environ.get(name)]
+        missing_joined = ", ".join(missing)
 
-        output_path = os.environ["GITHUB_OUTPUT"]
-        joined = ", ".join(missing)
-
-        with open(output_path, "a", encoding="utf-8") as fh:
-            fh.write(f"ready={'false' if missing else 'true'}\n")
-            fh.write(f"missing={joined}\n")
-
-        if missing:
+        if not require_signing:
+            ready = False
+            message = "Signed build skipped via workflow input."
+        elif not required:
+            ready = True
+            message = "No signing secrets were requested; continuing with signed build."
+        elif missing:
+            ready = False
             message = (
                 "Signed build skipped; configure the following secrets to enable it: "
-                f"{joined}."
+                f"{missing_joined}."
             )
-            sys.stdout.write(f"::notice ::{message}\n")
         else:
-            sys.stdout.write(
-                "::notice ::All signing secrets detected; continuing with signed build.\n"
-            )
+            ready = True
+            message = "All signing secrets detected; continuing with signed build."
+
+        ready_str = "true" if ready else "false"
+
+        output_path = os.environ["GITHUB_OUTPUT"]
+        with open(output_path, "a", encoding="utf-8") as fh:
+            fh.write(f"ready={ready_str}\n")
+            fh.write(f"message={message}\n")
+            fh.write(f"missing={missing_joined}\n")
+
+        sys.stdout.write(f"::notice ::{message}\n")
+
+        summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary_path:
+            lines = [
+                "## Signing secrets check",
+                "",
+                f"- Require signing: `{require_signing}`",
+                f"- Ready: `{ready_str}`",
+                f"- Details: {message}",
+            ]
+            if missing_joined:
+                lines.append(f"- Missing secrets: {missing_joined}")
+            else:
+                lines.append("- Missing secrets: none")
+            lines.append("")
+            with open(summary_path, "a", encoding="utf-8") as summary_file:
+                summary_file.write("\n".join(lines))
         PY

--- a/.github/workflows/ios-signed-monGARS.yml
+++ b/.github/workflows/ios-signed-monGARS.yml
@@ -28,6 +28,9 @@ jobs:
       message: ${{ steps.signing_gate.outputs.message }}
       missing: ${{ steps.signing_gate.outputs.missing }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Evaluate signing readiness
         id: signing_gate
         uses: ./.github/actions/signing-secrets-check

--- a/.github/workflows/ios-signed-monGARS.yml
+++ b/.github/workflows/ios-signed-monGARS.yml
@@ -24,121 +24,22 @@ jobs:
     permissions:
       contents: read
     outputs:
-      ready: ${{ toJSON(steps.precheck_result.outputs.ready == 'true') }}
-      message: ${{ steps.precheck_result.outputs.message || 'Signed build readiness unavailable.' }}
+      ready: ${{ steps.signing_gate.outputs.ready }}
+      message: ${{ steps.signing_gate.outputs.message }}
+      missing: ${{ steps.signing_gate.outputs.missing }}
     steps:
-      - name: Determine signing requirement
-        id: require_signing
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          INPUT_REQUIRE_SIGNING: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.require_signing || '' }}
-        run: |
-          set -euo pipefail
-
-          raw_input="$INPUT_REQUIRE_SIGNING"
-          if [[ "$EVENT_NAME" != "workflow_dispatch" || -z "$raw_input" ]]; then
-            raw_input="true"
-          fi
-
-          normalized="$(printf '%s' "$raw_input" | tr '[:upper:]' '[:lower:]')"
-          case "$normalized" in
-            true|1|yes|on)
-              normalized="true"
-              ;;
-            false|0|no|off)
-              normalized="false"
-              ;;
-            *)
-              echo "::warning ::Unknown require_signing value '$raw_input'; defaulting to true."
-              normalized="true"
-              ;;
-          esac
-
-          echo "require_signing=$normalized" >>"$GITHUB_OUTPUT"
-
-      - name: Checkout repository
-        if: ${{ steps.require_signing.outputs.require_signing == 'true' }}
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Evaluate signing secrets
-        if: ${{ steps.require_signing.outputs.require_signing == 'true' }}
-        id: evaluate
+      - name: Evaluate signing readiness
+        id: signing_gate
         uses: ./.github/actions/signing-secrets-check
         with:
           required-secrets: ${{ env.SIGNING_SECRET_NAMES }}
+          require-signing: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.require_signing || 'true' }}
         env:
           P12_BASE64: ${{ secrets.P12_BASE64 }}
           MOBILEPROVISION_BASE64: ${{ secrets.MOBILEPROVISION_BASE64 }}
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-
-      - name: Finalize signing precheck result
-        id: precheck_result
-        shell: bash
-        env:
-          REQUIRE_SIGNING: ${{ steps.require_signing.outputs.require_signing }}
-          READY: ${{ steps.evaluate.outputs.ready }}
-          MISSING: ${{ steps.evaluate.outputs.missing }}
-        run: |
-          set -euo pipefail
-
-          python3 - <<'PY'
-          import os
-
-          require_signing = os.environ.get("REQUIRE_SIGNING", "").lower() == "true"
-          ready_raw = os.environ.get("READY", "")
-          missing_raw = os.environ.get("MISSING", "")
-          output_path = os.environ["GITHUB_OUTPUT"]
-
-          def normalize_missing(raw: str) -> str:
-              parts = [item.strip() for item in raw.split(",") if item.strip()]
-              return ", ".join(parts)
-
-          if not require_signing:
-              ready_value = "false"
-              message = "Signed build skipped via workflow input."
-              formatted_missing = ""
-          else:
-              ready_value = "true" if ready_raw == "true" else "false"
-              formatted_missing = normalize_missing(missing_raw)
-
-              if ready_value == "true":
-                  message = "All signing secrets detected; continuing with signed build."
-              elif formatted_missing:
-                  message = (
-                      "Signed build skipped; configure the following secrets to enable it: "
-                      f"{formatted_missing}."
-                  )
-              else:
-                  message = "Signed build skipped; required signing secrets are missing."
-
-          with open(output_path, "a", encoding="utf-8") as handle:
-              handle.write(f"ready={ready_value}\n")
-              handle.write(f"message={message}\n")
-              handle.write(f"missing_formatted={formatted_missing}\n")
-          PY
-
-      - name: Summarize signing gate
-        if: ${{ always() }}
-        env:
-          READY: ${{ steps.precheck_result.outputs.ready }}
-          SUMMARY_MESSAGE: ${{ steps.precheck_result.outputs.message }}
-          MISSING: ${{ steps.precheck_result.outputs.missing_formatted }}
-        run: |
-          {
-            echo "## Signing precheck"
-            echo ""
-            echo "- Ready: \`$READY\`"
-            echo "- Details: $SUMMARY_MESSAGE"
-            missing_list="${MISSING:-}"
-            if [[ -n "${missing_list// }" ]]; then
-              echo "- Missing secrets: $missing_list"
-            fi
-          } >>"$GITHUB_STEP_SUMMARY"
 
   build:
     needs: signing_precheck


### PR DESCRIPTION
## Summary
- normalize the signing secrets check composite to handle workflow inputs, emit ready/message/missing outputs, and write a consistent summary
- simplify the iOS signing precheck job to a single composite step that surfaces the new outputs for downstream gating

## Testing
- npm test
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68dab55afe9883339994502c4cbac2ec

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/offLLM/238)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an option to explicitly require signing in the workflow.
  - Provided a clear, human-readable readiness message and GitHub Step Summary.
  - Exposed missing secrets details to downstream jobs for better visibility.

- Refactor
  - Simplified the iOS signing precheck into a single step using a reusable action.
  - Standardized readiness logic with robust truthy/falsy handling and deduplicated required secrets.
  - Streamlined output propagation (ready, message, missing) to downstream steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->