### PR TITLE
Add monGARS signed iOS build workflow

### DIFF
--- a/.github/workflows/ios-signed-monGARS.yml
+++ b/.github/workflows/ios-signed-monGARS.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Setup Bun
         if: hashFiles('bun.lockb') != ''
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7
 
       - name: Install JS deps
         run: |


### PR DESCRIPTION
## Summary
- replace the monGARS workflow with a macOS 15 job that always builds and signs the app instead of skipping when secrets are missing
- run XcodeGen, CocoaPods, and the repo signing scripts before archiving with the expected bundle identifier overrides
- export and upload the signed IPA together with the ExportOptions and xcresult artifacts

## Testing
- CI=1 npm test
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68dac13fdab48333a62bd65735093a1b

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/offLLM/239)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Introduced a new iOS Signed build workflow supporting Ad Hoc, Development, and App Store export methods (default: ad-hoc).
  - Produces downloadable artifacts: signed IPA (monGARS-signed-ipa), export config, and build result bundle.
  - Expanded triggers to both main and master branches.
  - Streamlined build: explicit Xcode selection, secret verification, JS dependency handling, project generation, and Pod install on macOS 15 with a fixed timeout.
  - Simplified signing/keychain handling and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->