### PR TITLE
Skip signed iOS build when signing secrets are missing

### DIFF
--- a/.github/workflows/ios-signed-monGARS.yml
+++ b/.github/workflows/ios-signed-monGARS.yml
@@ -20,7 +20,16 @@ env:
   XCODE_PROJECT_NAME: monGARS.xcodeproj
 
 jobs:
+  missing-signing-secrets:
+    runs-on: ubuntu-latest
+    if: ${{ secrets.P12_BASE64 == '' || secrets.MOBILEPROVISION_BASE64 == '' || secrets.TEAM_ID == '' }}
+    steps:
+      - name: Skip signed build
+        run: |
+          echo "::warning ::Skipping signed iOS build because one or more signing secrets (P12_BASE64, MOBILEPROVISION_BASE64, TEAM_ID) are not configured."
+
   build-signed-ipa:
+    if: ${{ secrets.P12_BASE64 != '' && secrets.MOBILEPROVISION_BASE64 != '' && secrets.TEAM_ID != '' }}
     runs-on: macos-15
     timeout-minutes: 60
 


### PR DESCRIPTION
## Summary
- add a guard job that emits a warning and exits early when signing secrets are not configured
- conditionally run the signed iOS archive job only when all signing secrets are present

## Testing
- CI=1 npm test
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68daca49b1788333aaae524fe225aca2