### PR TITLE
Fix ExportOptions heredoc indentation

### DIFF
--- a/.github/workflows/ios-signed-monGARS.yml
+++ b/.github/workflows/ios-signed-monGARS.yml
@@ -164,16 +164,16 @@ jobs:
           if [ -f export-options.plist ]; then
             cp export-options.plist ExportOptions.plist
           else
-            cat > ExportOptions.plist <<'PLIST'
-            <?xml version="1.0" encoding="UTF-8"?>
-            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-            <plist version="1.0"><dict>
-            <key>method</key><string>ad-hoc</string>
-            <key>signingStyle</key><string>manual</string>
-            <key>stripSwiftSymbols</key><true/>
-            <key>compileBitcode</key><false/>
-            </dict></plist>
-            PLIST
+            printf '%s\n' \
+              '<?xml version="1.0" encoding="UTF-8"?>' \
+              '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">' \
+              '<plist version="1.0"><dict>' \
+              '<key>method</key><string>ad-hoc</string>' \
+              '<key>signingStyle</key><string>manual</string>' \
+              '<key>stripSwiftSymbols</key><true/>' \
+              '<key>compileBitcode</key><false/>' \
+              '</dict></plist>' \
+              > ExportOptions.plist
           fi
           # Set method
           /usr/libexec/PlistBuddy -c "Set :method ${METHOD}" ExportOptions.plist || true


### PR DESCRIPTION
## Summary
- replace the ExportOptions.plist heredoc in the signed iOS workflow with a printf so the step no longer depends on unindented delimiters
- unblock the ExportOptions.plist generation step during CI by avoiding shell syntax errors when the workflow runs

## Testing
- CI=1 npm test
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68dad3906a1c8333bb8ff4d6fbed9da0

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/offLLM/243)
<!-- GitContextEnd -->