### PR TITLE
Fix IPA export provisioning profile injection

### DIFF
--- a/scripts/ci/export_ipa.sh
+++ b/scripts/ci/export_ipa.sh
@@ -32,6 +32,53 @@ cleanup() {
 
 trap cleanup EXIT
 
+ensure_export_opts_copy() {
+  if [[ -z "$TMP_EXPORT_OPTS" ]]; then
+    TMP_EXPORT_OPTS="$(mktemp -t exportOptions.XXXXXX.plist)"
+    cp "$EXPORT_OPTS" "$TMP_EXPORT_OPTS"
+    EXPORT_OPTS="$TMP_EXPORT_OPTS"
+  fi
+}
+
+escape_for_plistbuddy() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//"/\\\"}"
+  printf '%s' "$value"
+}
+
+resolve_bundle_identifier_from_archive() {
+  local archive="$1"
+
+  if [[ ! -x /usr/libexec/PlistBuddy ]]; then
+    return 1
+  fi
+
+  local archive_plist
+  archive_plist="${archive}/Info.plist"
+  if [[ -f "$archive_plist" ]]; then
+    local bundle_id
+    bundle_id=$(/usr/libexec/PlistBuddy -c 'Print :ApplicationProperties:CFBundleIdentifier' "$archive_plist" 2>/dev/null || true)
+    if [[ -n "${bundle_id// }" ]]; then
+      printf '%s' "$bundle_id"
+      return 0
+    fi
+  fi
+
+  local info_plist
+  info_plist="$(find "${archive}/Products/Applications" -maxdepth 2 -name 'Info.plist' 2>/dev/null | head -n 1 || true)"
+  if [[ -n "${info_plist// }" && -f "$info_plist" ]]; then
+    local bundle_id
+    bundle_id=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$info_plist" 2>/dev/null || true)
+    if [[ -n "${bundle_id// }" ]]; then
+      printf '%s' "$bundle_id"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
 resolve_team_id_from_profile() {
   local uuid="${PROFILE_UUID:-}"
   if [[ -z "${uuid// }" ]]; then
@@ -79,19 +126,38 @@ if [[ -z "${TEAM_ID// }" ]]; then
 fi
 
 if [[ -n "${TEAM_ID// }" && -x /usr/libexec/PlistBuddy ]]; then
-  TMP_EXPORT_OPTS="$(mktemp -t exportOptions.XXXXXX.plist)"
-  cp "$EXPORT_OPTS" "$TMP_EXPORT_OPTS"
-  if /usr/libexec/PlistBuddy -c 'Print teamID' "$TMP_EXPORT_OPTS" >/dev/null 2>&1; then
-    /usr/libexec/PlistBuddy -c "Set teamID $TEAM_ID" "$TMP_EXPORT_OPTS" >/dev/null 2>&1 || true
+  ensure_export_opts_copy
+  if /usr/libexec/PlistBuddy -c 'Print teamID' "$EXPORT_OPTS" >/dev/null 2>&1; then
+    /usr/libexec/PlistBuddy -c "Set teamID $TEAM_ID" "$EXPORT_OPTS" >/dev/null 2>&1 || true
   else
-    /usr/libexec/PlistBuddy -c "Add teamID string $TEAM_ID" "$TMP_EXPORT_OPTS" >/dev/null 2>&1 || \
-      /usr/libexec/PlistBuddy -c "Set teamID $TEAM_ID" "$TMP_EXPORT_OPTS" >/dev/null 2>&1 || true
+    /usr/libexec/PlistBuddy -c "Add teamID string $TEAM_ID" "$EXPORT_OPTS" >/dev/null 2>&1 || \
+      /usr/libexec/PlistBuddy -c "Set teamID $TEAM_ID" "$EXPORT_OPTS" >/dev/null 2>&1 || true
   fi
-  EXPORT_OPTS="$TMP_EXPORT_OPTS"
 elif [[ -z "${TEAM_ID// }" ]]; then
   echo "::warning ::No team identifier resolved for export; xcodebuild may fail with 'No Team Found in Archive'" >&2
 elif [[ ! -x /usr/libexec/PlistBuddy ]]; then
   echo "::warning ::/usr/libexec/PlistBuddy not available; unable to inject teamID into export options" >&2
+fi
+
+BUNDLE_IDENTIFIER="${PRODUCT_BUNDLE_IDENTIFIER:-}" 
+if [[ -z "${BUNDLE_IDENTIFIER// }" ]]; then
+  BUNDLE_IDENTIFIER="$(resolve_bundle_identifier_from_archive "$ARCHIVE_PATH" || true)"
+fi
+
+PROFILE_NAME="${PROFILE_NAME:-}"
+if [[ -n "${PROFILE_NAME// }" && -n "${BUNDLE_IDENTIFIER// }" ]]; then
+  if [[ -x /usr/libexec/PlistBuddy ]]; then
+    ensure_export_opts_copy
+    /usr/libexec/PlistBuddy -c 'Add :provisioningProfiles dict' "$EXPORT_OPTS" >/dev/null 2>&1 || true
+    escaped_profile="$(escape_for_plistbuddy "$PROFILE_NAME")"
+    if ! /usr/libexec/PlistBuddy -c "Set :provisioningProfiles:${BUNDLE_IDENTIFIER} \"${escaped_profile}\"" "$EXPORT_OPTS" >/dev/null 2>&1; then
+      /usr/libexec/PlistBuddy -c "Add :provisioningProfiles:${BUNDLE_IDENTIFIER} string \"${escaped_profile}\"" "$EXPORT_OPTS" >/dev/null 2>&1 || true
+    fi
+  else
+    echo "::warning ::/usr/libexec/PlistBuddy not available; unable to record provisioning profile ${PROFILE_NAME}" >&2
+  fi
+elif [[ -n "${PROFILE_NAME// }" ]]; then
+  echo "::warning ::Provisioning profile ${PROFILE_NAME} provided but bundle identifier could not be determined" >&2
 fi
 
 set -x


### PR DESCRIPTION
## Summary
- ensure export_ipa.sh always edits a writable copy of exportOptions.plist when mutating team metadata
- derive the archived app bundle identifier and map the installed provisioning profile into the export options so xcodebuild can locate it

## Testing
- CI=1 npm test
- npm run lint
- CI=1 npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68dae019f00c833389b58182aac80c57

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/offLLM/245)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improves reliability of iOS IPA exports with better handling of team ID, fallback bundle identifier detection, and correct provisioning profile mapping.
  * Adds clearer warnings when required metadata or tools are missing, reducing silent failures.

* **Chores**
  * Enhances CI export process with safer export options handling and more robust interactions, decreasing build-time issues and improving transparency during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->