### PR TITLE
Fix iOS signing validation workflow context usage

### DIFF
--- a/.github/workflows/ios-signing-validate.yml
+++ b/.github/workflows/ios-signing-validate.yml
@@ -26,7 +26,6 @@ jobs:
     env:
       WORKING_DIR: ios
       KEYCHAIN_NAME: build-${{ github.run_id }}.keychain-db
-      KEYCHAIN_PATH: ${{ runner.temp }}/build-${{ github.run_id }}.keychain-db
     steps:
       - name: Checkout (shallow)
         uses: actions/checkout@v4
@@ -71,13 +70,17 @@ jobs:
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
           set -euo pipefail
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
+          KEYCHAIN_PATH="$RUNNER_TEMP/$KEYCHAIN_NAME"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security set-keychain-settings "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
           # Save originals so we can restore on cleanup
           echo "ORIGINAL_DEFAULT_KEYCHAIN=$(security default-keychain | sed 's/.*"\(.*\)".*/\1/')" >> $GITHUB_ENV
           echo "ORIGINAL_KEYCHAIN_LIST=$(security list-keychains -d user | sed 's/.*"\(.*\)".*/\1/')" >> $GITHUB_ENV
+
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
 
           # Put temp keychain first
           security list-keychains -d user -s "$KEYCHAIN_PATH" $ORIGINAL_KEYCHAIN_LIST

--- a/.github/workflows/ios-signing-validate.yml
+++ b/.github/workflows/ios-signing-validate.yml
@@ -49,7 +49,7 @@ jobs:
             fi
           done
           if [[ $missing -ne 0 ]]; then
-            exit 1
+            exit $missing
           fi
         shell: bash
 
@@ -70,7 +70,7 @@ jobs:
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
           set -euo pipefail
-          KEYCHAIN_PATH="$RUNNER_TEMP/$KEYCHAIN_NAME"
+          KEYCHAIN_PATH="$RUNNER_TEMP/${KEYCHAIN_NAME}"
 
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security set-keychain-settings "$KEYCHAIN_PATH"

--- a/.github/workflows/ios-signing-validate.yml
+++ b/.github/workflows/ios-signing-validate.yml
@@ -1,4 +1,3 @@
-
 name: iOS Signing & Secrets Validation
 
 on:
@@ -21,14 +20,13 @@ on:
         required: false
         default: "development"
 
-env:
-  WORKING_DIR: ios
-  KEYCHAIN_NAME: build-${{ github.run_id }}.keychain-db
-  KEYCHAIN_PATH: ${{ runner.temp }}/${{ env.KEYCHAIN_NAME }}
-
 jobs:
   validate-signing:
     runs-on: macos-15
+    env:
+      WORKING_DIR: ios
+      KEYCHAIN_NAME: build-${{ github.run_id }}.keychain-db
+      KEYCHAIN_PATH: ${{ runner.temp }}/build-${{ github.run_id }}.keychain-db
     steps:
       - name: Checkout (shallow)
         uses: actions/checkout@v4
@@ -36,12 +34,18 @@ jobs:
           fetch-depth: 1
 
       - name: Verify required secrets exist
+        env:
+          P12_BASE64: ${{ secrets.P12_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          MOBILEPROVISION_BASE64: ${{ secrets.MOBILEPROVISION_BASE64 }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
           set -euo pipefail
           missing=0
-          for s in P12_BASE64 P12_PASSWORD MOBILEPROVISION_BASE64 KEYCHAIN_PASSWORD; do
-            if [[ -z "${{ secrets[ s ] }}" ]]; then
-              echo "::error ::Missing secret: $s"
+          for secret_name in P12_BASE64 P12_PASSWORD MOBILEPROVISION_BASE64 KEYCHAIN_PASSWORD; do
+            value="${!secret_name:-}"
+            if [[ -z "$value" ]]; then
+              echo "::error ::Missing secret: $secret_name"
               missing=1
             fi
           done
@@ -103,7 +107,7 @@ jobs:
           PROFILE_NAME=$(/usr/libexec/PlistBuddy -c 'Print :Name' "$TMP_PLIST")
           PROFILE_UUID=$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$TMP_PLIST")
           APP_ID_FULL=$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' "$TMP_PLIST")
-          PROFILE_TEAM="${{ APP_ID_FULL%%.* }}"
+          PROFILE_TEAM="${APP_ID_FULL%%.*}"
 
           echo "Profile Name     : $PROFILE_NAME"
           echo "Profile UUID     : $PROFILE_UUID"


### PR DESCRIPTION
## Summary
- move keychain environment definitions to the job scope so runner.temp resolves correctly
- verify required secrets via exported environment variables rather than unsupported dynamic secrets lookups
- fix provisioning profile parsing by relying on native bash parameter expansion during validation

## Testing
- npm test
- npm run lint
- npm run format:check -- --log-level warn

------
https://chatgpt.com/codex/tasks/task_e_68db0cf739948333868f0f7c6bdb8abb

## Summary by Sourcery

Fix iOS signing validation workflow by correcting environment scope, secret validation, and profile parsing

Bug Fixes:
- Use bash parameter expansion for secret existence checks
- Fix provisioning profile parsing by extracting the team ID with native bash expansion

CI:
- Move keychain environment definitions into the job scope for proper path resolution
- Export required secrets via environment variables in the validation step instead of dynamic lookups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected team identifier parsing and keychain path handling in iOS signing validation, reducing setup errors and false negatives.
  * Enforced explicit failure when required secrets are missing, with clearer error messages and diagnostics.

* **Chores**
  * Scoped environment variables to the signing validation job to improve isolation and reliability.
  * Streamlined secret validation logic for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->