### PR TITLE
Fix UTF-8 byte accounting in fileSystem tool

### DIFF
--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -22,6 +22,7 @@
 
 - The runtime `toolRegistry` auto-registers every native tool exported for the current platform (iOS or Android) so the agent can execute native capabilities like calendar events, location, messaging, and more without manual wiring.【F:src/core/tools/ToolRegistry.js†L1-L39】
 - For more advanced scenarios, `src/architecture/toolSystem.js` exposes a richer `ToolRegistry` with categories, validation, usage analytics, and a `MCPClient` that can call remote Model Context Protocol servers, plus sample calculator, web search, and filesystem tools to use as templates.【F:src/architecture/toolSystem.js†L1-L392】
+- The built-in file-system tool sanitises requested paths and reports UTF-8 byte counts for reads and writes so telemetry reflects the real disk footprint even when strings include multi-byte characters.【F:src/architecture/toolSystem.js†L299-L420】【F:__tests__/toolSystem.test.js†L122-L184】
 
 ## Services Exposed as Tools or Skills
 


### PR DESCRIPTION
## Summary
- compute UTF-8 byte lengths when reading and writing via the fileSystem tool so telemetry reports real byte counts
- extend toolSystem tests to cover multi-byte read/write scenarios and confirm accurate byte accounting
- document the stricter byte tracking in the architecture guide for visibility

## Testing
- `npm test`
- `npm run lint`
- `npx prettier --write .`
- `npm run format:check >/tmp/format.log`
- `tail -n 20 /tmp/format.log`


------
https://chatgpt.com/codex/tasks/task_e_68e848bcc8288333826645966f674e22

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/offLLM/262)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File read/write responses now include UTF-8-aware bytes metadata (bytesRead/bytesWritten) when available.
* **Bug Fixes**
  * Improves accuracy of reported byte counts for files containing multi-byte (Unicode) characters.
* **Documentation**
  * Clarified that the file system tool sanitizes paths and reports UTF-8 byte counts for reads and writes.
* **Tests**
  * Updated tests to validate correct UTF-8 byte accounting for reading and writing Unicode content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->