### PR TITLE
Harden iOS signed IPA workflow

### DIFF
--- a/.github/workflows/ios-build-signed-ipa.yml
+++ b/.github/workflows/ios-build-signed-ipa.yml
@@ -116,6 +116,10 @@ jobs:
           mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
           echo "$PROFILE_B64" | base64 --decode > "$HOME/Library/MobileDevice/Provisioning Profiles/app.mobileprovision"
           PROFILE_UUID=$(/usr/libexec/PlistBuddy -c "Print:UUID" /dev/stdin <<< $(security cms -D -i "$HOME/Library/MobileDevice/Provisioning Profiles/app.mobileprovision"))
+          if [[ -z "$PROFILE_UUID" || ! "$PROFILE_UUID" =~ ^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$ ]]; then
+            echo "::error::Invalid provisioning profile UUID extracted; verify the IOS_PROVISIONING_PROFILE_BASE64 secret." >&2
+            exit 1
+          fi
           mv "$HOME/Library/MobileDevice/Provisioning Profiles/app.mobileprovision" "$HOME/Library/MobileDevice/Provisioning Profiles/$PROFILE_UUID.mobileprovision"
           echo "Installed profile UUID: $PROFILE_UUID"
           echo "PROFILE_UUID=$PROFILE_UUID" >> $GITHUB_ENV
@@ -218,9 +222,9 @@ jobs:
             exit "$status"
           fi
           ls -lah "$EXPORT_DIR"
-          IPA_PATH="$(/usr/bin/find "$EXPORT_DIR" -name "*.ipa" -maxdepth 1 -print -quit)"
+          IPA_PATH="$(/usr/bin/find "$EXPORT_DIR" -name "*.ipa" -print -quit)"
           if [ -z "$IPA_PATH" ]; then
-            echo "::error::Failed to locate the exported IPA in $EXPORT_DIR" >&2
+            echo "::error::Failed to locate the exported IPA in $EXPORT_DIR (recursive search)" >&2
             exit 1
           fi
           echo "IPA_PATH=$IPA_PATH" >> $GITHUB_ENV
@@ -231,8 +235,15 @@ jobs:
           set -euo pipefail
           DSYM_DIR="$GITHUB_WORKSPACE/build/${APP_NAME}/dSYMs"
           mkdir -p "$DSYM_DIR"
-          find "$ARCHIVE_PATH" -name "*.dSYM" -exec cp -R {} "$DSYM_DIR" \; || true
-          du -sh "$DSYM_DIR" || true
+          if ! find "$ARCHIVE_PATH" -name "*.dSYM" -exec cp -R {} "$DSYM_DIR" \; ; then
+            echo "::warning::Failed to collect dSYM files from $ARCHIVE_PATH"
+          fi
+
+          if [ -z "$(ls -A "$DSYM_DIR")" ]; then
+            echo "::warning::No dSYM files were collected in $DSYM_DIR"
+          else
+            du -sh "$DSYM_DIR"
+          fi
 
       - name: 📄 Upload build logs
         if: always()

--- a/.github/workflows/ios-build-signed-ipa.yml
+++ b/.github/workflows/ios-build-signed-ipa.yml
@@ -1,0 +1,268 @@
+name: iOS • Build Signed IPA
+
+on:
+  workflow_dispatch:
+    inputs:
+      configuration:
+        description: Xcode build configuration
+        type: choice
+        default: Release
+        options: [Release, Debug]
+
+env:
+  # ==== EDIT THESE TO MATCH YOUR PROJECT ====
+  APP_NAME: offLLM
+  SCHEME: monGARS # <--- change if your scheme is different
+  BUNDLE_ID: com.offllm.mongars
+  WORKSPACE: ios/offLLM.xcworkspace # or ios/offLLM.xcodeproj
+  CONFIGURATION: ${{ inputs.configuration || 'Release' }}
+  TEAM_ID: 52T7P32J34
+
+  # Export method for App Store–signed IPA
+  EXPORT_METHOD: app-store
+
+jobs:
+  build-ipa:
+    runs-on: macos-15 # Xcode 16.x / iOS 18.x SDK images
+    permissions:
+      contents: read
+
+    steps:
+      - name: ✅ Validate required signing secrets
+        env:
+          IOS_P12_BASE64: ${{ secrets.IOS_P12_BASE64 }}
+          IOS_P12_PASSWORD: ${{ secrets.IOS_P12_PASSWORD }}
+          IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for var in IOS_P12_BASE64 IOS_P12_PASSWORD IOS_PROVISIONING_PROFILE_BASE64; do
+            if [ -z "${!var:-}" ]; then
+              echo "::error::Missing required secret: ${var}." >&2
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::Populate the required signing secrets in the repository settings before running this workflow." >&2
+            exit 1
+          fi
+
+      - name: 🧰 Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: 🧱 Select newest available Xcode (prefer 16.x)
+        shell: bash
+        run: |
+          set -euo pipefail
+          ls -1 /Applications | grep -i "^Xcode" || true
+          if [ -d "/Applications/Xcode_16.2.app" ]; then
+            sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+          elif [ -d "/Applications/Xcode_16.1.app" ]; then
+            sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer
+          elif [ -d "/Applications/Xcode_16.0.app" ]; then
+            sudo xcode-select -s /Applications/Xcode_16.0.app/Contents/Developer
+          else
+            sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+          fi
+          xcodebuild -version
+          xcodebuild -showsdks | sed 's/^/SDK • /'
+
+      - name: 🍫 Ensure CocoaPods
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v pod >/dev/null 2>&1; then
+            sudo gem install cocoapods --no-document
+          fi
+          pod --version
+
+      - name: 📦 Pod install (if Podfile exists)
+        working-directory: ios
+        run: |
+          set -euo pipefail
+          if [ -f "Podfile" ]; then
+            pod repo update || true
+            pod install --verbose
+          else
+            echo "No Podfile; skipping pods."
+          fi
+
+      - name: 🔐 Create temporary keychain & import cert
+        env:
+          P12_BASE64: ${{ secrets.IOS_P12_BASE64 }}
+          P12_PASSWORD: ${{ secrets.IOS_P12_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/build.keychain-db"
+          KEYPASS="$(openssl rand -hex 12)"
+          security create-keychain -p "$KEYPASS" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYPASS" "$KEYCHAIN"
+          echo "$P12_BASE64" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "$P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYPASS" "$KEYCHAIN"
+          security find-identity -v -p codesigning "$KEYCHAIN"
+          echo "KEYCHAIN_PATH=$KEYCHAIN" >> $GITHUB_ENV
+          rm -f "$RUNNER_TEMP/cert.p12"
+
+      - name: 🪪 Install provisioning profile
+        env:
+          PROFILE_B64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+          echo "$PROFILE_B64" | base64 --decode > "$HOME/Library/MobileDevice/Provisioning Profiles/app.mobileprovision"
+          PROFILE_UUID=$(/usr/libexec/PlistBuddy -c "Print:UUID" /dev/stdin <<< $(security cms -D -i "$HOME/Library/MobileDevice/Provisioning Profiles/app.mobileprovision"))
+          mv "$HOME/Library/MobileDevice/Provisioning Profiles/app.mobileprovision" "$HOME/Library/MobileDevice/Provisioning Profiles/$PROFILE_UUID.mobileprovision"
+          echo "Installed profile UUID: $PROFILE_UUID"
+          echo "PROFILE_UUID=$PROFILE_UUID" >> $GITHUB_ENV
+
+      - name: 🧾 Write ExportOptions.plist
+        run: |
+          set -euo pipefail
+          cat > ExportOptions.plist <<EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key><string>${EXPORT_METHOD}</string>
+            <key>teamID</key><string>${TEAM_ID}</string>
+            <key>compileBitcode</key><false/>
+            <key>destination</key><string>export</string>
+            <key>signingStyle</key><string>manual</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>${BUNDLE_ID}</key><string>${PROFILE_UUID}</string>
+            </dict>
+            <key>stripSwiftSymbols</key><true/>
+            <key>uploadSymbols</key><true/>
+            <key>manageAppVersionAndBuildNumber</key><false/>
+          </dict>
+          </plist>
+          EOF
+          cat ExportOptions.plist
+
+      - name: 🏗️ Archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          LOG_DIR="$GITHUB_WORKSPACE/build/logs"
+          mkdir -p "$LOG_DIR"
+          ARCHIVE_LOG="$LOG_DIR/xcodebuild-archive.log"
+          ARCHIVE_PATH="$RUNNER_TEMP/${APP_NAME}.xcarchive"
+          if [[ "$WORKSPACE" == *.xcworkspace ]]; then
+            set +e
+            xcodebuild archive \
+              -workspace "$WORKSPACE" \
+              -scheme "$SCHEME" \
+              -configuration "$CONFIGURATION" \
+              -destination "generic/platform=iOS" \
+              -archivePath "$ARCHIVE_PATH" \
+              PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
+              DEVELOPMENT_TEAM="$TEAM_ID" \
+              CODE_SIGN_STYLE=Manual \
+              CODE_SIGNING_ALLOWED=YES \
+              CODE_SIGNING_REQUIRED=YES \
+              | tee "$ARCHIVE_LOG" \
+              | xcpretty --color auto
+            status=${PIPESTATUS[0]}
+            set -euo pipefail
+            if [ "$status" -ne 0 ]; then
+              exit "$status"
+            fi
+          else
+            set +e
+            xcodebuild archive \
+              -project "$WORKSPACE" \
+              -scheme "$SCHEME" \
+              -configuration "$CONFIGURATION" \
+              -destination "generic/platform=iOS" \
+              -archivePath "$ARCHIVE_PATH" \
+              PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
+              DEVELOPMENT_TEAM="$TEAM_ID" \
+              CODE_SIGN_STYLE=Manual \
+              CODE_SIGNING_ALLOWED=YES \
+              CODE_SIGNING_REQUIRED=YES \
+              | tee "$ARCHIVE_LOG" \
+              | xcpretty --color auto
+            status=${PIPESTATUS[0]}
+            set -euo pipefail
+            if [ "$status" -ne 0 ]; then
+              exit "$status"
+            fi
+          fi
+          echo "ARCHIVE_PATH=$ARCHIVE_PATH" >> $GITHUB_ENV
+
+      - name: 📦 Export signed IPA
+        shell: bash
+        run: |
+          set -euo pipefail
+          LOG_DIR="$GITHUB_WORKSPACE/build/logs"
+          mkdir -p "$LOG_DIR"
+          EXPORT_LOG="$LOG_DIR/xcodebuild-export.log"
+          EXPORT_DIR="$GITHUB_WORKSPACE/build/${APP_NAME}"
+          mkdir -p "$EXPORT_DIR"
+          set +e
+          xcodebuild -exportArchive \
+            -archivePath "$ARCHIVE_PATH" \
+            -exportPath "$EXPORT_DIR" \
+            -exportOptionsPlist ExportOptions.plist \
+            | tee "$EXPORT_LOG" \
+            | xcpretty --color auto
+          status=${PIPESTATUS[0]}
+          set -euo pipefail
+          if [ "$status" -ne 0 ]; then
+            exit "$status"
+          fi
+          ls -lah "$EXPORT_DIR"
+          IPA_PATH="$(/usr/bin/find "$EXPORT_DIR" -name "*.ipa" -maxdepth 1 -print -quit)"
+          if [ -z "$IPA_PATH" ]; then
+            echo "::error::Failed to locate the exported IPA in $EXPORT_DIR" >&2
+            exit 1
+          fi
+          echo "IPA_PATH=$IPA_PATH" >> $GITHUB_ENV
+          test -f "$IPA_PATH"
+
+      - name: 🧠 Collect dSYMs (optional)
+        run: |
+          set -euo pipefail
+          DSYM_DIR="$GITHUB_WORKSPACE/build/${APP_NAME}/dSYMs"
+          mkdir -p "$DSYM_DIR"
+          find "$ARCHIVE_PATH" -name "*.dSYM" -exec cp -R {} "$DSYM_DIR" \; || true
+          du -sh "$DSYM_DIR" || true
+
+      - name: 📄 Upload build logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-build-logs
+          path: build/logs
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: ⬆️ Upload IPA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-signed-ipa
+          path: |
+            ${{ env.IPA_PATH }}
+            ${{ github.workspace }}/build/${{ env.APP_NAME }}/dSYMs
+          retention-days: 7
+
+      - name: 🧹 Cleanup signing assets
+        if: always()
+        env:
+          KEYCHAIN_PATH: ${{ env.KEYCHAIN_PATH }}
+          PROFILE_UUID: ${{ env.PROFILE_UUID }}
+        run: |
+          set -euo pipefail
+          if [ -n "${KEYCHAIN_PATH:-}" ] && [ -f "$KEYCHAIN_PATH" ]; then
+            security delete-keychain "$KEYCHAIN_PATH" || true
+          fi
+          if [ -n "${PROFILE_UUID:-}" ]; then
+            rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/${PROFILE_UUID}.mobileprovision" || true
+          fi
+          rm -f ExportOptions.plist || true

--- a/.github/workflows/ios-signing-validate.yml
+++ b/.github/workflows/ios-signing-validate.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   validate-signing:
     runs-on: macos-15
-    environment: offLLM   # 👈 attaches the job to your GitHub Environment
+    environment: offLLM # 👈 attaches the job to your GitHub Environment
     env:
       WORKING_DIR: ios
       KEYCHAIN_NAME: build-${{ github.run_id }}.keychain-db


### PR DESCRIPTION
## Summary
- add an upfront signing secret validation gate and enforce safer shell options across the workflow
- ensure CocoaPods availability, capture xcodebuild logs, and persist archive/export output for debugging
- add IPA discovery guards plus cleanup of temporary keychain, provisioning profile, and export artifacts

## Testing
- npm test
- npm run lint
- CI=1 npm run format:check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691168313d208333ac99cd692b2761dc)

## Summary by Sourcery

Harden the iOS signed IPA build workflow by adding upfront secret validation, enforcing safe shell options, capturing build logs, ensuring CocoaPods availability, and cleaning up temporary assets.

Enhancements:
- Add upfront check for required signing secrets to fail early if missing
- Enforce safe shell options (set -euo pipefail) across all workflow steps
- Ensure CocoaPods is installed and run pod install when a Podfile is present
- Capture xcodebuild archive and export logs in build/logs and upload them as artifacts
- Generate ExportOptions.plist dynamically based on environment variables
- Guard IPA discovery by verifying the exported .ipa path and erroring if not found
- Add cleanup step to delete temporary keychain and provisioning profile files after each run

CI:
- Introduce a new GitHub Actions workflow to build and sign iOS IPA on macos-15
- Attach validate-signing job to the GitHub environment and enforce safer shell options

Chores:
- Trim trailing whitespace in the existing ios-signing-validate workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated iOS build-and-sign workflow to produce signed IPA artifacts (with optional dSYMs) and upload build logs/artifacts for distribution.
  * Cleans up signing assets after completion.
  * Minor formatting tweak to the iOS signing workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->